### PR TITLE
test: migrate SortedOracles tests

### DIFF
--- a/contracts/BiPoolManager.sol
+++ b/contracts/BiPoolManager.sol
@@ -1,0 +1,475 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+import { IExchangeProvider } from "./interfaces/IExchangeProvider.sol";
+import { IBiPoolManager } from "./interfaces/IBiPoolManager.sol";
+import { IReserve } from "./interfaces/IReserve.sol";
+import { IPricingModule } from "./interfaces/IPricingModule.sol";
+import { ISortedOracles } from "./interfaces/ISortedOracles.sol";
+
+import { StableToken } from "./StableToken.sol";
+
+import { Initializable } from "./common/Initializable.sol";
+import { FixidityLib } from "./common/FixidityLib.sol";
+
+// TODO: Remove when migrating to mento-core. Newer versions of OZ-contracts have this interface
+interface IERC20Metadata {
+  function symbol() external view returns (string memory);
+}
+
+/**
+ * @title BiPoolExchangeManager
+ * @notice An exchange manager that manages asset exchanges consisting of two assets
+ */
+contract BiPoolManager is IExchangeProvider, IBiPoolManager, Initializable, Ownable {
+  using FixidityLib for FixidityLib.Fraction;
+  using SafeMath for uint256;
+
+  /* ==================== State Variables ==================== */
+
+  // Address of the broker contract.
+  address public broker;
+
+  // Maps a exchange id to the corresponding PoolExchange struct.
+  // exchangeId is in the format "asset0Symbol:asset1Symbol:pricingModuleName"
+  mapping(bytes32 => PoolExchange) public exchanges;
+  bytes32[] public exchangeIds;
+
+  // Address of the Mento reserve contract
+  IReserve public reserve;
+
+  // Address of the Mento reserve contract
+  ISortedOracles public sortedOracles;
+
+  /* ==================== Constructor ==================== */
+
+  /**
+   * @notice Sets initialized == true on implementation contracts.
+   * @param test Set to true to skip implementation initialization.
+   */
+  constructor(bool test) public Initializable(test) {}
+
+  /**
+   * @notice Allows the contract to be upgradable via the proxy.
+   * @param _broker The address of the broker contract.
+   * @param _reserve The address of the reserve contract.
+   */
+  function initialize(
+    address _broker,
+    IReserve _reserve,
+    ISortedOracles _sortedOracles
+  ) external initializer {
+    _transferOwnership(msg.sender);
+    setBroker(_broker);
+    setReserve(_reserve);
+    setSortedOracles(_sortedOracles);
+  }
+
+  /* ==================== Modifiers ==================== */
+
+  modifier onlyBroker() {
+    require(msg.sender == broker, "Caller is not the Broker");
+    _;
+  }
+
+  /* ==================== View Functions ==================== */
+
+  /**
+   * @notice Get a PoolExchange from storage.
+   * @param exchangeId the exchange id
+   */
+  function getPoolExchange(bytes32 exchangeId) public view returns (PoolExchange memory exchange) {
+    exchange = exchanges[exchangeId];
+    require(exchange.asset0 != address(0), "An exchange with the specified id does not exist");
+  }
+
+  /**
+   * @notice Get all exchange IDs.
+   * @return exchangeIds List of the exchangeIds.
+   */
+  function getExchangeIds() external view returns (bytes32[] memory) {
+    return exchangeIds;
+  }
+
+  /**
+   * @notice Get all exchanges (used by interfaces)
+   * @dev We don't expect the number of exchanges to grow to
+   * astronomical values so this is safe gas-wise as is.
+   */
+  function getExchanges() public view returns (Exchange[] memory _exchanges) {
+    _exchanges = new Exchange[](exchangeIds.length);
+    for (uint256 i = 0; i < exchangeIds.length; i++) {
+      _exchanges[i].exchangeId = exchangeIds[i];
+      _exchanges[i].assets = new address[](2);
+      _exchanges[i].assets[0] = exchanges[exchangeIds[i]].asset0;
+      _exchanges[i].assets[1] = exchanges[exchangeIds[i]].asset1;
+    }
+  }
+
+  /**
+   * @notice Calculate amountOut of tokenOut received for a given amountIn of tokenIn
+   * @param exchangeId The id of the exchange i.e PoolExchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountIn The amount of tokenIn to be sold
+   * @return amountOut The amount of tokenOut to be bought
+   */
+  function getAmountOut(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external view returns (uint256 amountOut) {
+    PoolExchange memory exchange = getPoolExchange(exchangeId);
+    (amountOut, ) = _getAmountOut(exchange, tokenIn, tokenOut, amountIn);
+  }
+
+  /**
+   * @notice Calculate amountIn of tokenIn for a given amountIn of tokenIn
+   * @param exchangeId The id of the exchange i.e PoolExchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountOut The amount of tokenOut to be bought
+   * @return amountIn The amount of tokenIn to be sold
+   */
+  function getAmountIn(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external view returns (uint256 amountIn) {
+    PoolExchange memory exchange = getPoolExchange(exchangeId);
+    (amountIn, ) = _getAmountIn(exchange, tokenIn, tokenOut, amountOut);
+  }
+
+  /* ==================== Mutative Functions ==================== */
+
+  /**
+   * @notice Sets the address of the broker contract.
+   * @param _broker The new address of the broker contract.
+   */
+  function setBroker(address _broker) public onlyOwner {
+    require(_broker != address(0), "Broker address must be set");
+    broker = _broker;
+    emit BrokerUpdated(_broker);
+  }
+
+  /**
+   * @notice Sets the address of the reserve contract.
+   * @param _reserve The new address of the reserve contract.
+   */
+  function setReserve(IReserve _reserve) public onlyOwner {
+    require(address(_reserve) != address(0), "Reserve address must be set");
+    reserve = _reserve;
+    emit ReserveUpdated(address(_reserve));
+  }
+
+  /**
+   * @notice Sets the address of the sortedOracles contract.
+   * @param _sortedOracles The new address of the sorted oracles contract.
+   */
+  function setSortedOracles(ISortedOracles _sortedOracles) public onlyOwner {
+    require(address(_sortedOracles) != address(0), "SortedOracles address must be set");
+    sortedOracles = _sortedOracles;
+    emit SortedOraclesUpdated(address(_sortedOracles));
+  }
+
+  /**
+   * @notice Creates a new exchange using the given parameters.
+   * @param _exchange the PoolExchange to create.
+   * @return exchangeId The id of the newly created exchange.
+   */
+  function createExchange(PoolExchange calldata _exchange) external onlyOwner returns (bytes32 exchangeId) {
+    PoolExchange memory exchange = _exchange;
+    require(address(exchange.pricingModule) != address(0), "pricingModule must be set");
+    require(exchange.asset0 != address(0), "asset0 must be set");
+    require(exchange.asset1 != address(0), "asset1 must be set");
+
+    exchangeId = keccak256(
+      abi.encodePacked(
+        IERC20Metadata(exchange.asset0).symbol(),
+        IERC20Metadata(exchange.asset1).symbol(),
+        exchange.pricingModule.name()
+      )
+    );
+    require(exchanges[exchangeId].asset0 == address(0), "An exchange with the specified assets and exchange exists");
+
+    validate(exchange);
+    (uint256 bucket0, uint256 bucket1) = getUpdatedBuckets(exchange);
+
+    exchange.bucket0 = bucket0;
+    exchange.bucket1 = bucket1;
+
+    exchanges[exchangeId] = exchange;
+    exchangeIds.push(exchangeId);
+
+    emit ExchangeCreated(exchangeId, exchange.asset0, exchange.asset1, address(exchange.pricingModule));
+  }
+
+  /**
+   * @notice Destroys a exchange with the given parameters if it exists and frees up
+   *         the collateral and stable allocation it was using.
+   * @param exchangeId the id of the exchange to destroy
+   * @param exchangeIdIndex The index of the exchangeId in the ids array
+   * @return destroyed A boolean indicating whether or not the exchange was successfully destroyed.
+   */
+  function destroyExchange(bytes32 exchangeId, uint256 exchangeIdIndex) external onlyOwner returns (bool destroyed) {
+    require(exchangeIdIndex < exchangeIds.length, "exchangeIdIndex not in range");
+    require(exchangeIds[exchangeIdIndex] == exchangeId, "exchangeId at index doesn't match");
+    PoolExchange memory exchange = exchanges[exchangeId];
+
+    delete exchanges[exchangeId];
+    exchangeIds[exchangeIdIndex] = exchangeIds[exchangeIds.length - 1];
+    exchangeIds.pop();
+    destroyed = true;
+
+    emit ExchangeDestroyed(exchangeId, exchange.asset0, exchange.asset1, address(exchange.pricingModule));
+  }
+
+  /**
+   * @notice Execute a token swap with fixed amountIn
+   * @param exchangeId The id of exchange, i.e. PoolExchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountIn The amount of tokenIn to be sold
+   * @return amountOut The amount of tokenOut to be bought
+   */
+  function swapIn(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external onlyBroker returns (uint256 amountOut) {
+    PoolExchange memory exchange = getPoolExchange(exchangeId);
+    bool bucketsUpdated;
+
+    (amountOut, bucketsUpdated) = _getAmountOut(exchange, tokenIn, tokenOut, amountIn);
+    executeSwap(exchangeId, exchange, tokenIn, amountIn, amountOut, bucketsUpdated);
+    return amountOut;
+  }
+
+  /**
+   * @notice Execute a token swap with fixed amountOut
+   * @param exchangeId The id of exchange, i.e. PoolExchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountOut The amount of tokenOut to be bought
+   * @return amountIn The amount of tokenIn to be sold
+   */
+  function swapOut(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external onlyBroker returns (uint256 amountIn) {
+    PoolExchange memory exchange = getPoolExchange(exchangeId);
+    bool bucketsUpdated;
+
+    (amountIn, bucketsUpdated) = _getAmountIn(exchange, tokenIn, tokenOut, amountOut);
+    executeSwap(exchangeId, exchange, tokenIn, amountIn, amountOut, bucketsUpdated);
+    return amountIn;
+  }
+
+  /* ==================== Private Functions ==================== */
+
+  /**
+   * @notice Execute a swap against the in memory exchange and write
+   * the new bucket sizes to storage.
+   * @param exchangeId The id of the exchange
+   * @param exchange The exchange to operate on
+   * @param tokenIn The token to be sold
+   * @param amountIn The amount of tokenIn to be sold
+   * @param amountOut The amount of tokenOut to be bought
+   * @param bucketsUpdated wether the buckets updated during the swap
+   */
+  function executeSwap(
+    bytes32 exchangeId,
+    PoolExchange memory exchange,
+    address tokenIn,
+    uint256 amountIn,
+    uint256 amountOut,
+    bool bucketsUpdated
+  ) internal {
+    if (bucketsUpdated) {
+      // solhint-disable-next-line not-rely-on-time
+      exchanges[exchangeId].lastBucketUpdate = now;
+      emit BucketsUpdated(exchangeId, exchange.bucket0, exchange.bucket1);
+    }
+
+    if (tokenIn == exchange.asset0) {
+      exchanges[exchangeId].bucket0 = exchange.bucket0 + amountIn;
+      exchanges[exchangeId].bucket1 = exchange.bucket1 - amountOut;
+    } else {
+      exchanges[exchangeId].bucket0 = exchange.bucket0 - amountOut;
+      exchanges[exchangeId].bucket1 = exchange.bucket1 + amountIn;
+    }
+  }
+
+  /**
+   * @notice Calculate amountOut of tokenOut received for a given amountIn of tokenIn
+   * @param exchange The exchange to operate on
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountIn The amount of tokenIn to be sold
+   * @return amountOut The amount of tokenOut to be bought
+   * @return bucketsUpdated Wether the buckets were updated during the quote
+   */
+  function _getAmountOut(
+    PoolExchange memory exchange,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) internal view returns (uint256 amountOut, bool bucketsUpdated) {
+    require(
+      (tokenIn == exchange.asset0 && tokenOut == exchange.asset1) || (tokenIn == exchange.asset1 && tokenOut == exchange.asset0),
+      "tokenIn and tokenOut must match exchange"
+    );
+
+    (exchange, bucketsUpdated) = updateBucketsIfNecessary(exchange);
+
+    if (tokenIn == exchange.asset0) {
+      amountOut = exchange.pricingModule.getAmountOut(
+        exchange.bucket0,
+        exchange.bucket1,
+        exchange.config.spread.unwrap(),
+        amountIn
+      );
+    } else {
+      amountOut = exchange.pricingModule.getAmountOut(
+        exchange.bucket1,
+        exchange.bucket0,
+        exchange.config.spread.unwrap(),
+        amountIn
+      );
+    }
+  }
+
+  /**
+   * @notice Calculate amountIn of tokenIn for a given amountIn of tokenIn
+   * @param exchange The exchange to operate on
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountOut The amount of tokenOut to be bought
+   * @return amountIn The amount of tokenIn to be sold
+   * @return bucketsUpdated Wether the buckets were updated during the quote
+   */
+  function _getAmountIn(
+    PoolExchange memory exchange,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) internal view returns (uint256 amountIn, bool bucketsUpdated) {
+    require(
+      (tokenIn == exchange.asset0 && tokenOut == exchange.asset1) || (tokenIn == exchange.asset1 && tokenOut == exchange.asset0),
+      "tokenIn and tokenOut must match exchange"
+    );
+
+    (exchange, bucketsUpdated) = updateBucketsIfNecessary(exchange);
+
+    if (tokenIn == exchange.asset0) {
+      amountIn = exchange.pricingModule.getAmountIn(
+        exchange.bucket0,
+        exchange.bucket1,
+        exchange.config.spread.unwrap(),
+        amountOut
+      );
+    } else {
+      amountIn = exchange.pricingModule.getAmountIn(
+        exchange.bucket1,
+        exchange.bucket0,
+        exchange.config.spread.unwrap(),
+        amountOut
+      );
+    }
+  }
+
+  /**
+   * @notice If conditions are met, update the exchange bucket sizes.
+   * @dev This doesn't checkpoint the exchange, just updates the in-memory one
+   * so it should be used in a context that then checkpoints the exchange.
+   * @param exchange The exchange being updated.
+   * @return exchangeAfter The updated exchange.
+   */
+  function updateBucketsIfNecessary(PoolExchange memory exchange) internal view returns (PoolExchange memory, bool updated) {
+    if (shouldUpdateBuckets(exchange)) {
+      (exchange.bucket0, exchange.bucket1) = getUpdatedBuckets(exchange);
+      updated = true;
+    }
+    return (exchange, updated);
+  }
+
+  /**
+   * @notice Determine if a exchange's buckets should be updated
+   * based on staleness of buckets and oracle rates.
+   * @param exchange The PoolExchange.
+   * @return shouldUpdate
+   */
+  function shouldUpdateBuckets(PoolExchange memory exchange) internal view returns (bool) {
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(exchange.config.oracleReportTarget);
+    // solhint-disable-next-line not-rely-on-time
+    bool timePassed = now >= exchange.lastBucketUpdate.add(exchange.config.bucketUpdateFrequency);
+    bool enoughReports = (sortedOracles.numRates(exchange.config.oracleReportTarget) >= exchange.config.minimumReports);
+    // solhint-disable-next-line not-rely-on-time
+    bool medianReportRecent = sortedOracles.medianTimestamp(exchange.config.oracleReportTarget) >
+      now.sub(exchange.config.bucketUpdateFrequency);
+    return timePassed && enoughReports && medianReportRecent && !isReportExpired;
+  }
+
+  /**
+   * @notice Calculate the new bucket sizes for a exchange.
+   * @param exchange The PoolExchange in context.
+   * @return bucket0 The size of bucket0.
+   * @return bucket1 The size of bucket1.
+   */
+  function getUpdatedBuckets(PoolExchange memory exchange) internal view returns (uint256 bucket0, uint256 bucket1) {
+    // TODO: Take max fraction/min supply in account when setting the bucket size
+    bucket0 = exchange.config.bucket0TargetSize;
+    uint256 exchangeRateNumerator;
+    uint256 exchangeRateDenominator;
+    (exchangeRateNumerator, exchangeRateDenominator) = getOracleExchangeRate(exchange.config.oracleReportTarget);
+
+    bucket1 = exchangeRateDenominator.mul(bucket0).div(exchangeRateNumerator);
+  }
+
+  /**
+   * @notice Get the exchange rate as numerator,denominator from sorted oracles
+   * and protect in case of a 0-denominator.
+   * @param target the reportTarget to read from SortedOracles
+   * @return rateNumerator
+   * @return rateDenominator
+   */
+  function getOracleExchangeRate(address target) internal view returns (uint256, uint256) {
+    uint256 rateNumerator;
+    uint256 rateDenominator;
+    (rateNumerator, rateDenominator) = sortedOracles.medianRate(target);
+    require(rateDenominator > 0, "exchange rate denominator must be greater than 0");
+    return (rateNumerator, rateDenominator);
+  }
+
+  /**
+   * @notice Valitates a PoolExchange's parameters and configuration
+   * @dev Reverts if not valid
+   * @param exchange The PoolExchange to validate
+   */
+  function validate(PoolExchange memory exchange) private view {
+    require(reserve.isStableAsset(exchange.asset0), "asset0 must be a stable registered with the reserve");
+    require(
+      reserve.isStableAsset(exchange.asset1) || reserve.isCollateralAsset(exchange.asset1),
+      "asset1 must be a stable or collateral registered with the reserve"
+    );
+
+    require(exchange.config.bucket0MaxFraction.unwrap() > 0, "bucket0MaxFraction must be greater than 0");
+
+    require(exchange.config.bucket0MaxFraction.lt(FixidityLib.fixed1()), "bucket0MaxFraction must be smaller than 1");
+
+    require(FixidityLib.lte(exchange.config.spread, FixidityLib.fixed1()), "Spread must be less than or equal to 1");
+
+    require(exchange.config.oracleReportTarget != address(0), "oracleReportTarget must be set");
+
+    // TODO: Stable bucket max fraction should not exceed available stable bucket fraction.
+    // TODO: minSupplyForStableBucketCap gt 0 & is there an aggregated value that needs to be checked
+  }
+}

--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -1,0 +1,237 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+import { IExchangeProvider } from "./interfaces/IExchangeProvider.sol";
+import { IBroker } from "./interfaces/IBroker.sol";
+import { IBrokerAdmin } from "./interfaces/IBrokerAdmin.sol";
+import { IReserve } from "./interfaces/IReserve.sol";
+import { IStableToken } from "./interfaces/IStableToken.sol";
+
+import { Initializable } from "./common/Initializable.sol";
+
+/**
+ * @title Broker
+ * @notice The broker executes swaps and keeps track of spending limits per pair.
+ */
+contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
+  /* ==================== State Variables ==================== */
+
+  address[] public exchangeProviders;
+  mapping(address => bool) public isExchangeProvider;
+
+  // Address of the reserve.
+  IReserve public reserve;
+
+  /* ==================== Constructor ==================== */
+
+  /**
+   * @notice Sets initialized == true on implementation contracts.
+   * @param test Set to true to skip implementation initialization.
+   */
+  constructor(bool test) public Initializable(test) {}
+
+  /**
+   * @notice Allows the contract to be upgradable via the proxy.
+   * @param _exchangeProviders The addresses of the ExchangeProvider contracts.
+   * @param _reserve The address of the Reserve contract.
+   */
+  function initialize(address[] calldata _exchangeProviders, address _reserve) external initializer {
+    _transferOwnership(msg.sender);
+    for (uint256 i = 0; i < _exchangeProviders.length; i++) {
+      addExchangeProvider(_exchangeProviders[i]);
+    }
+    setReserve(_reserve);
+  }
+
+  /* ==================== Mutative Functions ==================== */
+
+  /**
+   * @notice Add an exchange provider to the list of providers.
+   * @param exchangeProvider The address of the exchange provider to add.
+   * @return index The index of the newly added specified exchange provider.
+   */
+  function addExchangeProvider(address exchangeProvider) public onlyOwner returns (uint256 index) {
+    require(!isExchangeProvider[exchangeProvider], "ExchangeProvider already exists in the list");
+    require(exchangeProvider != address(0), "ExchangeProvider address can't be 0");
+    exchangeProviders.push(exchangeProvider);
+    isExchangeProvider[exchangeProvider] = true;
+    emit ExchangeProviderAdded(exchangeProvider);
+    index = exchangeProviders.length - 1;
+  }
+
+  /**
+   * @notice Remove an exchange provider from the list of providers.
+   * @param exchangeProvider The address of the exchange provider to remove.
+   * @param index The index of the exchange provider being removed.
+   */
+  function removeExchangeProvider(address exchangeProvider, uint256 index) public onlyOwner {
+    require(exchangeProviders[index] == exchangeProvider, "index into exchangeProviders list not mapped to an exchangeProvider");
+    exchangeProviders[index] = exchangeProviders[exchangeProviders.length - 1];
+    exchangeProviders.pop();
+    delete isExchangeProvider[exchangeProvider];
+    emit ExchangeProviderRemoved(exchangeProvider);
+  }
+
+  /**
+   * @notice Set the Mento reserve address.
+   * @param _reserve The Mento reserve address.
+   */
+  function setReserve(address _reserve) public onlyOwner {
+    require(_reserve != address(0), "Reserve address must be set");
+    emit ReserveSet(_reserve, address(reserve));
+    reserve = IReserve(_reserve);
+  }
+
+  /**
+   * @notice Calculate the amount of tokenIn to be sold for a given amountOut of tokenOut
+   * @param exchangeProvider the address of the exchange manager for the pair
+   * @param exchangeId The id of the exchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountOut The amount of tokenOut to be bought
+   * @return amountIn The amount of tokenIn to be sold
+   */
+  function getAmountIn(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external returns (uint256 amountIn) {
+    require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
+    amountIn = IExchangeProvider(exchangeProvider).getAmountIn(exchangeId, tokenIn, tokenOut, amountOut);
+  }
+
+  /**
+   * @notice Calculate the amount of tokenOut to be bought for a given amount of tokenIn to be sold
+   * @param exchangeProvider the address of the exchange manager for the pair
+   * @param exchangeId The id of the exchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountIn The amount of tokenIn to be sold
+   * @return amountOut The amount of tokenOut to be bought
+   */
+  function getAmountOut(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external returns (uint256 amountOut) {
+    require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
+    amountOut = IExchangeProvider(exchangeProvider).getAmountOut(exchangeId, tokenIn, tokenOut, amountIn);
+  }
+
+  /**
+   * @notice Execute a token swap with fixed amountIn.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountIn The amount of tokenIn to be sold.
+   * @param amountOutMin Minimum amountOut to be received - controls slippage.
+   * @return amountOut The amount of tokenOut to be bought.
+   */
+  function swapIn(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOutMin
+  ) external returns (uint256 amountOut) {
+    require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
+    amountOut = IExchangeProvider(exchangeProvider).swapIn(exchangeId, tokenIn, tokenOut, amountIn);
+    require(amountOut >= amountOutMin, "amountOutMin not met");
+    transferIn(msg.sender, tokenIn, amountIn);
+    transferOut(msg.sender, tokenOut, amountOut);
+    emit Swap(exchangeProvider, exchangeId, msg.sender, tokenIn, tokenOut, amountIn, amountOut);
+  }
+
+  /**
+   * @notice Execute a token swap with fixed amountOut.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountOut The amount of tokenOut to be bought.
+   * @param amountInMax Maximum amount of tokenIn that can be traded.
+   * @return amountIn The amount of tokenIn to be sold.
+   */
+  function swapOut(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut,
+    uint256 amountInMax
+  ) external returns (uint256 amountIn) {
+    require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
+    amountIn = IExchangeProvider(exchangeProvider).swapOut(exchangeId, tokenIn, tokenOut, amountOut);
+    require(amountIn <= amountInMax, "amountInMax exceeded");
+    transferIn(msg.sender, tokenIn, amountIn);
+    transferOut(msg.sender, tokenOut, amountOut);
+    emit Swap(exchangeProvider, exchangeId, msg.sender, tokenIn, tokenOut, amountIn, amountOut);
+  }
+
+  /* ==================== Private Functions ==================== */
+
+  /**
+   * @notice Transfer a specified Mento asset to the given address.
+   * If the specified asset is a stable asset it will be minted directly to the address. If
+   * the asset is a collateral asset it will be transferred from the reserve to the given address.
+   * @param to The address receiving the asset.
+   * @param token The asset to transfer.
+   * @param amount The amount of `token` to be transferred.
+   */
+  function transferOut(
+    address payable to,
+    address token,
+    uint256 amount
+  ) internal {
+    if (reserve.isStableAsset(token)) {
+      IStableToken(token).mint(to, amount);
+    } else if (reserve.isCollateralAsset(token)) {
+      reserve.transferCollateralAsset(token, to, amount);
+    } else {
+      revert("Token must be stable or collateral assert");
+    }
+  }
+
+  /**
+   * @notice Transfer a specified Mento asset into the reserve or the broker.
+   * If the specified asset is a stable asset it will be transfered to the broker
+   * and burned. If the asset is a collateral asset it will be transferred to the reserve.
+   * @param from The address to transfer the asset from.
+   * @param token The asset to transfer.
+   * @param amount The amount of `token` to be transferred.
+   */
+  function transferIn(
+    address payable from,
+    address token,
+    uint256 amount
+  ) internal {
+    if (reserve.isStableAsset(token)) {
+      IERC20(token).transferFrom(from, address(this), amount);
+      IStableToken(token).burn(amount);
+    } else if (reserve.isCollateralAsset(token)) {
+      IERC20(token).transferFrom(from, address(reserve), amount);
+    } else {
+      revert("Token must be stable or collateral assert");
+    }
+  }
+
+  /* ==================== View Functions ==================== */
+
+  /**
+   * @notice Get the list of registered exchange providers.
+   * @dev This can be used by UI or clients to discover all pairs.
+   * @return exchangeProviders the addresses of all exchange providers.
+   */
+  function getExchangeProviders() external view returns (address[] memory) {
+    return exchangeProviders;
+  }
+}

--- a/contracts/ConstantProductPricingModule.sol
+++ b/contracts/ConstantProductPricingModule.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { IPricingModule } from "./interfaces/IPricingModule.sol";
+
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import { Initializable } from "./common/Initializable.sol";
+import { FixidityLib } from "./common/FixidityLib.sol";
+
+contract ConstantProductPricingModule is IPricingModule, Initializable, Ownable {
+  using SafeMath for uint256;
+  using FixidityLib for FixidityLib.Fraction;
+
+  /* ==================== Constructor ==================== */
+
+  /**
+   * @notice Sets initialized == true on implementation contracts
+   * @param test Set to true to skip implementation initialization
+   */
+  constructor(bool test) public Initializable(test) {}
+
+  /**
+   * @notice Allows the contract to be upgradable via the proxy.
+   */
+  function initilize() external initializer {
+    _transferOwnership(msg.sender);
+  }
+
+  /* ==================== View Functions ==================== */
+
+  function getAmountOut(
+    uint256 tokenInBucketSize,
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountIn
+  ) external view returns (uint256) {
+    if (amountIn == 0) return 0;
+
+    FixidityLib.Fraction memory spreadFraction = FixidityLib.wrap(spread);
+    FixidityLib.Fraction memory netAmountIn = FixidityLib.fixed1().subtract(spreadFraction).multiply(
+      FixidityLib.newFixed(amountIn)
+    );
+
+    FixidityLib.Fraction memory numerator = netAmountIn.multiply(FixidityLib.newFixed(tokenOutBucketSize));
+    FixidityLib.Fraction memory denominator = FixidityLib.newFixed(tokenInBucketSize).add(netAmountIn);
+
+    // Can't use FixidityLib.divide because denominator can easily be greater
+    // than maxFixedDivisor.
+    // Fortunately, we expect an integer result, so integer division gives us as
+    // much precision as we could hope for.
+    return numerator.unwrap().div(denominator.unwrap());
+  }
+
+  function getAmountIn(
+    uint256 tokenInBucketSize,
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountOut
+  ) external view returns (uint256) {
+    FixidityLib.Fraction memory spreadFraction = FixidityLib.wrap(spread);
+
+    FixidityLib.Fraction memory numerator = FixidityLib.newFixed(amountOut.mul(tokenInBucketSize));
+    FixidityLib.Fraction memory denominator = FixidityLib.newFixed(tokenOutBucketSize.sub(amountOut)).multiply(
+      FixidityLib.fixed1().subtract(spreadFraction)
+    );
+
+    // See comment in getAmountOut.
+    return numerator.unwrap().div(denominator.unwrap());
+  }
+
+  function name() external view returns (string memory) {
+    return "ConstantProduct";
+  }
+}

--- a/contracts/Reserve.sol
+++ b/contracts/Reserve.sol
@@ -188,28 +188,28 @@ contract Reserve is IReserve, ICeloVersionedContract, Ownable, Initializable, Us
   /**
    * @notice Set the ratio of reserve for a given collateral asset
    * that is spendable per day.
-   * @param collateralAssets Collection of the addresses of collateral assets
+   * @param _collateralAssets Collection of the addresses of collateral assets
    * we're setting a limit for.
    * @param collateralAssetDailySpendingRatios Collection of the relative daily spending limits
    * of collateral assets.
    */
   function setDailySpendingRatioForCollateralAssets(
-    address[] memory collateralAssets,
+    address[] memory _collateralAssets,
     uint256[] memory collateralAssetDailySpendingRatios
   ) public onlyOwner {
     require(
-      collateralAssets.length == collateralAssetDailySpendingRatios.length,
+      _collateralAssets.length == collateralAssetDailySpendingRatios.length,
       "token addresses and spending ratio lengths have to be the same"
     );
-    for (uint256 i = 0; i < collateralAssets.length; i++) {
-      if (collateralAssets[i] != address(0) && collateralAssetDailySpendingRatios[i] != 0) {
-        require(checkIsCollateralAsset(collateralAssets[i]), "the address specified is not a reserve collateral asset");
+    for (uint256 i = 0; i < _collateralAssets.length; i++) {
+      if (_collateralAssets[i] != address(0) && collateralAssetDailySpendingRatios[i] != 0) {
+        require(checkIsCollateralAsset(_collateralAssets[i]), "the address specified is not a reserve collateral asset");
         require(
           FixidityLib.wrap(collateralAssetDailySpendingRatios[i]).lte(FixidityLib.fixed1()),
           "spending ratio cannot be larger than 1"
         );
-        collateralAssetDailySpendingRatio[collateralAssets[i]] = FixidityLib.wrap(collateralAssetDailySpendingRatios[i]);
-        emit DailySpendingRatioForCollateralAssetSet(collateralAssets[i], collateralAssetDailySpendingRatios[i]);
+        collateralAssetDailySpendingRatio[_collateralAssets[i]] = FixidityLib.wrap(collateralAssetDailySpendingRatios[i]);
+        emit DailySpendingRatioForCollateralAssetSet(_collateralAssets[i], collateralAssetDailySpendingRatios[i]);
       }
     }
   }

--- a/contracts/interfaces/IBiPoolManager.sol
+++ b/contracts/interfaces/IBiPoolManager.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { IPricingModule } from "./IPricingModule.sol";
+import { FixidityLib } from "../common/FixidityLib.sol";
+
+/**
+ * @title BiPool Manager interface
+ * @notice The two asset pool manager is responsible for
+ * managing the state of all two-asset virtual pools.
+ */
+interface IBiPoolManager {
+  /**
+   * @title PoolExchange
+   * @notice The PoolExchange is a type of asset exchange that
+   * that implements an AMM with two virtual buckets.
+   */
+  struct PoolExchange {
+    address asset0;
+    address asset1;
+    IPricingModule pricingModule;
+    uint256 bucket0;
+    uint256 bucket1;
+    uint256 lastBucketUpdate;
+    PoolConfig config;
+  }
+
+  /**
+   * @notice Variables related to bucket updates and sizing.
+   * @dev Broken down into a separate struct because the compiler
+   * version doesn't support structs with too many members.
+   * Sad reacts only.
+   */
+  struct PoolConfig {
+    FixidityLib.Fraction spread;
+    address oracleReportTarget; // can be a stable address or custom
+    uint256 bucketUpdateFrequency;
+    uint256 minimumReports;
+    uint256 bucket0TargetSize;
+    FixidityLib.Fraction bucket0MaxFraction;
+    uint256 minSupplyForBucket0Cap;
+  }
+
+  /**
+   * @notice Emitted when a new PoolExchange has been created.
+   * @param exchangeId The id of the new PoolExchange
+   * @param asset0 The address of asset0
+   * @param asset1 The address of asset1
+   * @param pricingModule the address of the pricingModule
+   */
+  event ExchangeCreated(bytes32 indexed exchangeId, address indexed asset0, address indexed asset1, address pricingModule);
+
+  /**
+   * @notice Emitted when a PoolExchange has been destroyed.
+   * @param exchangeId The id of the PoolExchange
+   * @param asset0 The address of asset0
+   * @param asset1 The address of asset1
+   * @param pricingModule the address of the pricingModule
+   */
+  event ExchangeDestroyed(bytes32 indexed exchangeId, address indexed asset0, address indexed asset1, address pricingModule);
+
+  /**
+   * @notice Emitted when the broker address is updated.
+   * @param newBroker The address of the new broker.
+   */
+  event BrokerUpdated(address indexed newBroker);
+
+  /**
+   * @notice Emitted when the reserve address is updated.
+   * @param newReserve The address of the new reserve.
+   */
+  event ReserveUpdated(address indexed newReserve);
+
+  /**
+   * @notice Emitted when the sortedOracles address is updated.
+   * @param newSortedOracles The address of the new sortedOracles.
+   */
+  event SortedOraclesUpdated(address indexed newSortedOracles);
+
+  /**
+   * @notice Emitted when the buckets for a specified exchange are updated.
+   * @param exchangeId The id of the exchange
+   * @param bucket0 The new bucket0 size
+   * @param bucket1 The new bucket1 size
+   */
+  event BucketsUpdated(bytes32 indexed exchangeId, uint256 bucket0, uint256 bucket1);
+
+  /**
+   * @notice Retrieves the pool with the specified poolId.
+   * @param exchangeId The id of the pool to be retrieved.
+   * @return exchange The PoolExchange with that ID.
+   */
+  function getPoolExchange(bytes32 exchangeId) external view returns (PoolExchange memory exchange);
+
+  /**
+   * @notice Get all exchange IDs.
+   * @return exchangeIds List of the exchangeIds.
+   */
+  function getExchangeIds() external view returns (bytes32[] memory exchangeIds);
+
+  /**
+   * @notice Create a PoolExchange with the provided data.
+   * @param exchange The PoolExchange to be created.
+   * @return exchangeId The id of the exchange.
+   */
+  function createExchange(PoolExchange calldata exchange) external returns (bytes32 exchangeId);
+
+  /**
+   * @notice Delete a PoolExchange.
+   * @param exchangeId The PoolExchange to be created.
+   * @param exchangeIdIndex The index of the exchangeId in the exchangeIds array.
+   * @return destroyed - true on successful delition.
+   */
+  function destroyExchange(bytes32 exchangeId, uint256 exchangeIdIndex) external returns (bool destroyed);
+}

--- a/contracts/interfaces/IBroker.sol
+++ b/contracts/interfaces/IBroker.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+
+/*
+ * @title Broker Interface for trader functions
+ * @notice The broker is responsible for executing swaps and keeping track of trading limits.
+ */
+interface IBroker {
+  /**
+   * @notice Emitted when a swap occurs.
+   * @param exchangeProvider The exchange provider used.
+   * @param exchangeId The id of the exchange used.
+   * @param trader The user that initiated the swap.
+   * @param tokenIn The address of the token that was sold.
+   * @param tokenOut The address of the token that was bought.
+   * @param amountIn The amount of token sold.
+   * @param amountOut The amount of token bought.
+   */
+  event Swap(
+    address exchangeProvider,
+    bytes32 indexed exchangeId,
+    address indexed trader,
+    address indexed tokenIn,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOut
+  );
+
+  /**
+   * @notice Execute a token swap with fixed amountIn.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountIn The amount of tokenIn to be sold.
+   * @param amountOutMin Minimum amountOut to be received - controls slippage.
+   * @return amountOut The amount of tokenOut to be bought.
+   */
+  function swapIn(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOutMin
+  ) external returns (uint256 amountOut);
+
+  /**
+   * @notice Execute a token swap with fixed amountOut.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountOut The amount of tokenOut to be bought.
+   * @param amountInMax Maximum amount of tokenIn that can be traded.
+   * @return amountIn The amount of tokenIn to be sold.
+   */
+  function swapOut(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut,
+    uint256 amountInMax
+  ) external returns (uint256 amountIn);
+
+  /**
+   * @notice Calculate amountOut of tokenOut received for a given amountIn of tokenIn.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountIn The amount of tokenIn to be sold.
+   * @return amountOut The amount of tokenOut to be bought.
+   */
+  function getAmountOut(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external returns (uint256 amountOut);
+
+  /**
+   * @notice Calculate amountIn of tokenIn needed for a given amountOut of tokenOut.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountOut The amount of tokenOut to be bought.
+   * @return amountIn The amount of tokenIn to be sold.
+   */
+  function getAmountIn(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external returns (uint256 amountIn);
+
+  /**
+   * @notice Get the list of registered exchange providers.
+   * @dev This can be used by UI or clients to discover all pairs.
+   * @return exchangeProviders the addresses of all exchange providers.
+   */
+  function getExchangeProviders() external view returns (address[] memory exchangeProviders);
+}

--- a/contracts/interfaces/IBrokerAdmin.sol
+++ b/contracts/interfaces/IBrokerAdmin.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+
+/*
+ * @title Broker Admin Interface
+ * @notice Contains admin functions to configure the broker that
+ *         should be only callable by the owner.
+ */
+interface IBrokerAdmin {
+  /**
+   * @notice Emitted when an ExchangeProvider is added.
+   * @param exchangeProvider The address of the ExchangeProvider.
+   */
+  event ExchangeProviderAdded(address indexed exchangeProvider);
+
+  /**
+   * @notice Emitted when an ExchangeProvider is removed.
+   * @param exchangeProvider The address of the ExchangeProvider.
+   */
+  event ExchangeProviderRemoved(address indexed exchangeProvider);
+
+  /**
+   * @notice Emitted when the reserve is updated.
+   * @param newAddress The new address.
+   * @param prevAddress The previous address.
+   */
+  event ReserveSet(address indexed newAddress, address indexed prevAddress);
+
+  /**
+   * @notice Remove an ExchangeProvider at a specified index.
+   * @param exchangeProvider The address of the ExchangeProvider to remove.
+   * @param index The index in the exchange providers array.
+   */
+  function removeExchangeProvider(address exchangeProvider, uint256 index) external;
+
+  /**
+   * @notice Add an ExchangeProvider.
+   * @param exchangeProvider The address of the ExchangeProvider to add.
+   * @return index The index where the ExchangeProvider was inserted.
+   */
+  function addExchangeProvider(address exchangeProvider) external returns (uint256 index);
+
+  /**
+   * @notice Set the Mento reserve address.
+   * @param reserve The Mento reserve address.
+   */
+  function setReserve(address reserve) external;
+}

--- a/contracts/interfaces/IExchangeProvider.sol
+++ b/contracts/interfaces/IExchangeProvider.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @title ExchangeProvider interface
+ * @notice The IExchangeProvider interface is the interface that the Broker uses
+ * to communicate with different exchange manager implementations like the BiPoolManager
+ */
+interface IExchangeProvider {
+  /**
+   * @notice Exchange - a struct that's used only by UIs (frontends/CLIs)
+   * in order to discover what asset swaps are possible within an
+   * exchange provider.
+   * It's up to the specific exchange provider to convert its internal
+   * representation to this universal struct. This conversion should
+   * only happen in view calls used for discovery.
+   * @param exchangeId The ID of the exchange, used to initiate swaps or get quotes.
+   * @param assets An array of addresses of ERC20 tokens that can be swapped.
+   */
+  struct Exchange {
+    bytes32 exchangeId;
+    address[] assets;
+  }
+
+  /**
+   * @notice Get all exchanges supported by the ExchangeProvider.
+   * @return exchanges An array of Exchange structs.
+   */
+  function getExchanges() external view returns (Exchange[] memory exchanges);
+
+  /**
+   * @notice Execute a token swap with fixed amountIn
+   * @param exchangeId The id of the exchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountIn The amount of tokenIn to be sold
+   * @return amountOut The amount of tokenOut to be bought
+   */
+  function swapIn(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external returns (uint256 amountOut);
+
+  /**
+   * @notice Execute a token swap with fixed amountOut
+   * @param exchangeId The id of the exchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountOut The amount of tokenOut to be bought
+   * @return amountIn The amount of tokenIn to be sold
+   */
+  function swapOut(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external returns (uint256 amountIn);
+
+  /**
+   * @notice Calculate amountOut of tokenOut received for a given amountIn of tokenIn
+   * @param exchangeId The id of the exchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountIn The amount of tokenIn to be sold
+   * @return amountOut The amount of tokenOut to be bought
+   */
+  function getAmountOut(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external view returns (uint256 amountOut);
+
+  /**
+   * @notice Calculate amountIn of tokenIn needed for a given amountOut of tokenOut
+   * @param exchangeId The id of the exchange to use
+   * @param tokenIn The token to be sold
+   * @param tokenOut The token to be bought
+   * @param amountOut The amount of tokenOut to be bought
+   * @return amountIn The amount of tokenIn to be sold
+   */
+  function getAmountIn(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external view returns (uint256 amountIn);
+}

--- a/contracts/interfaces/IPricingModule.sol
+++ b/contracts/interfaces/IPricingModule.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+
+/**
+ * @title Interface for a Mento Pricing Module.
+ * @notice A Mento pricing module represents an exchange relation between a pair of ERC20 assets.
+ */
+interface IPricingModule {
+  /**
+   * @notice Returns the output amount and new bucket sizes for a given input amount.
+   * @param tokenInBucketSize Size of the tokenIn bucket.
+   * @param tokenOutBucketSize Size of the tokenOut bucket.
+   * @param spread Spread charged on exchanges.
+   * @param amountIn Amount of tokenIn being paid in.
+   * @return amountOut Amount of tokenOut that will be paid out.
+   */
+  function getAmountOut(
+    uint256 tokenInBucketSize,
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountIn
+  ) external view returns (uint256 amountOut);
+
+  /**
+    * @notice Returns the input amount necessary for a given output amount.
+    * @param tokenInBucketSize Size of the tokenIn bucket.
+    * @param tokenOutBucketSize Size of the tokenOut bucket.
+   * @param spread Spread charged on exchanges.
+    * @param amountOut Amount of tokenIn being paid out.
+    * @return amountIn Amount of tokenOut that would have to be paid in.
+    */
+  function getAmountIn(
+    uint256 tokenInBucketSize,
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountOut
+  ) external view returns (uint256 amountIn);
+
+  /**
+   * @notice Retrieve the name of this pricing module.
+   * @return exchangeName The name of the pricing module.
+   */
+  function name() external view returns (string memory pricingModuleName);
+}

--- a/test/BiPoolManager.t.sol
+++ b/test/BiPoolManager.t.sol
@@ -1,0 +1,822 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+
+import { IReserve } from "contracts/interfaces/IReserve.sol";
+import { BiPoolManager } from "contracts/BiPoolManager.sol";
+import { IBiPoolManager } from "contracts/interfaces/IBiPoolManager.sol";
+import { IExchangeProvider } from "contracts/interfaces/IExchangeProvider.sol";
+import { ISortedOracles } from "contracts/interfaces/ISortedOracles.sol";
+import { IPricingModule } from "contracts/interfaces/IPricingModule.sol";
+
+import { MockReserve } from "./mocks/MockReserve.sol";
+import { MockERC20 } from "./mocks/MockERC20.sol";
+import { MockPricingModule } from "./mocks/MockPricingModule.sol";
+import { MockSortedOracles } from "./mocks/MockSortedOracles.sol";
+
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+// forge test --match-contract BiPoolManager -vvv
+contract BiPoolManagerTest is Test {
+  using FixidityLib for FixidityLib.Fraction;
+
+  /* ------- Events from IBiPoolManager ------- */
+
+  event ExchangeCreated(bytes32 indexed exchangeId, address indexed asset0, address indexed asset1, address pricingModule);
+  event ExchangeDestroyed(bytes32 indexed exchangeId, address indexed asset0, address indexed asset1, address pricingModule);
+  event BrokerUpdated(address indexed newBroker);
+  event ReserveUpdated(address indexed newReserve);
+  event SortedOraclesUpdated(address indexed newSortedOracles);
+  event BucketsUpdated(bytes32 indexed exchangeId, uint256 bucket0, uint256 bucket1);
+
+  /* ------------------------------------------- */
+
+  address deployer;
+  address notDeployer;
+  address broker;
+
+  MockERC20 cUSD;
+  MockERC20 cEUR;
+  MockERC20 USDCet;
+  MockERC20 CELO;
+
+  IPricingModule constantProduct;
+  MockSortedOracles sortedOracles;
+
+  MockReserve reserve;
+  BiPoolManager biPoolManager;
+
+  function newMockERC20(string memory name, string memory symbol) internal returns (MockERC20 token) {
+    token = new MockERC20(name, symbol);
+    vm.label(address(token), symbol);
+  }
+
+  function setUp() public {
+    vm.warp(60 * 60 * 24 * 30); // if we start at now == 0 we get some underflows
+    deployer = actor("deployer");
+    notDeployer = actor("notDeployer");
+    broker = actor("broker");
+
+    cUSD = newMockERC20("Celo Dollar", "cUSD");
+    cEUR = newMockERC20("Celo Euro", "cEUR");
+    USDCet = newMockERC20("Portal USDC", "USDCet");
+    CELO = newMockERC20("CELO", "CELO");
+
+    constantProduct = new MockPricingModule("ConstantProduct");
+    sortedOracles = new MockSortedOracles();
+
+    reserve = new MockReserve();
+    biPoolManager = new BiPoolManager(true);
+
+    vm.mockCall(address(reserve), abi.encodeWithSelector(reserve.isStableAsset.selector, address(cUSD)), abi.encode(true));
+
+    vm.mockCall(address(reserve), abi.encodeWithSelector(reserve.isStableAsset.selector, address(cEUR)), abi.encode(true));
+
+    vm.mockCall(address(reserve), abi.encodeWithSelector(reserve.isCollateralAsset.selector, address(USDCet)), abi.encode(true));
+
+    vm.mockCall(address(reserve), abi.encodeWithSelector(reserve.isCollateralAsset.selector, address(CELO)), abi.encode(true));
+
+    changePrank(deployer);
+
+    biPoolManager.initialize(broker, IReserve(address(reserve)), ISortedOracles(address(sortedOracles)));
+  }
+
+  function mockOracleRate(address target, uint256 rateNumerator) internal {
+    sortedOracles.setMedianRate(target, rateNumerator);
+  }
+
+  function createExchange(MockERC20 asset0, MockERC20 asset1) internal returns (bytes32) {
+    return createExchange(asset0, asset1, IPricingModule(constantProduct));
+  }
+
+  function createExchange(
+    MockERC20 asset0,
+    MockERC20 asset1,
+    IPricingModule pricingModule
+  ) internal returns (bytes32 exchangeId) {
+    return createExchange(asset0, asset1, pricingModule, address(asset0));
+  }
+
+  function createExchange(
+    MockERC20 asset0,
+    MockERC20 asset1,
+    IPricingModule pricingModule,
+    address oracleReportTarget
+  ) internal returns (bytes32 exchangeId) {
+    return
+      createExchange(
+        asset0,
+        asset1,
+        pricingModule,
+        oracleReportTarget,
+        FixidityLib.wrap(0.1 * 1e24), // spread
+        1e26, // bucket0TargetSize
+        FixidityLib.wrap(0.2 * 1e24) // bucket0MaxFraction
+      );
+  }
+
+  function createExchange(
+    MockERC20 asset0,
+    MockERC20 asset1,
+    IPricingModule pricingModule,
+    address oracleReportTarget,
+    FixidityLib.Fraction memory spread,
+    uint256 bucket0TargetSize,
+    FixidityLib.Fraction memory bucket0MaxFraction
+  ) internal returns (bytes32 exchangeId) {
+    BiPoolManager.PoolExchange memory exchange;
+    exchange.asset0 = address(asset0);
+    exchange.asset1 = address(asset1);
+    exchange.pricingModule = pricingModule;
+
+    BiPoolManager.PoolConfig memory config;
+    config.oracleReportTarget = oracleReportTarget;
+    config.bucket0TargetSize = bucket0TargetSize;
+    config.bucket0MaxFraction = bucket0MaxFraction;
+    config.bucketUpdateFrequency = 60 * 5; // 5 minutes
+    config.minimumReports = 5;
+    config.spread = spread;
+
+    exchange.config = config;
+
+    return biPoolManager.createExchange(exchange);
+  }
+
+  function mockGetAmountIn(
+    bytes32 _exchangeId,
+    address tokenIn,
+    uint256 amountIn,
+    uint256 amountOut
+  ) internal {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(_exchangeId);
+    uint256 bucketIn;
+    uint256 bucketOut;
+
+    if (tokenIn == exchange.asset0) {
+      bucketIn = exchange.bucket0;
+      bucketOut = exchange.bucket1;
+    } else {
+      bucketIn = exchange.bucket1;
+      bucketOut = exchange.bucket0;
+    }
+
+    vm.mockCall(
+      address(constantProduct),
+      abi.encodeWithSelector(
+        constantProduct.getAmountIn.selector,
+        bucketIn,
+        bucketOut,
+        exchange.config.spread.unwrap(),
+        amountOut
+      ),
+      abi.encode(amountIn)
+    );
+  }
+
+  function mockGetAmountOut(
+    bytes32 _exchangeId,
+    address tokenIn,
+    uint256 amountIn,
+    uint256 amountOut
+  ) internal {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(_exchangeId);
+    uint256 bucketIn;
+    uint256 bucketOut;
+
+    if (tokenIn == exchange.asset0) {
+      bucketIn = exchange.bucket0;
+      bucketOut = exchange.bucket1;
+    } else {
+      bucketIn = exchange.bucket1;
+      bucketOut = exchange.bucket0;
+    }
+
+    vm.mockCall(
+      address(constantProduct),
+      abi.encodeWithSelector(
+        constantProduct.getAmountOut.selector,
+        bucketIn,
+        bucketOut,
+        exchange.config.spread.unwrap(),
+        amountIn
+      ),
+      abi.encode(amountOut)
+    );
+  }
+}
+
+contract BiPoolManagerTest_initilizerSettersGetters is BiPoolManagerTest {
+  /* ---------- Initilizer ---------- */
+
+  function test_initilize_shouldSetOwner() public {
+    assertEq(biPoolManager.owner(), deployer);
+  }
+
+  function test_initilize_shouldSetBroker() public {
+    assertEq(biPoolManager.broker(), broker);
+  }
+
+  function test_initilize_shouldSetReserve() public {
+    assertEq(address(biPoolManager.reserve()), address(reserve));
+  }
+
+  function test_initilize_shouldSetSortedOracles() public {
+    assertEq(address(biPoolManager.sortedOracles()), address(sortedOracles));
+  }
+
+  /* ---------- Setters ---------- */
+
+  function test_setBroker_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    biPoolManager.setBroker(address(0));
+  }
+
+  function test_setBroker_whenAddressIsZero_shouldRevert() public {
+    vm.expectRevert("Broker address must be set");
+    biPoolManager.setBroker(address(0));
+  }
+
+  function test_setBroker_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    address newBroker = actor("newBroker");
+    vm.expectEmit(true, true, true, true);
+    emit BrokerUpdated(newBroker);
+
+    biPoolManager.setBroker(newBroker);
+
+    assertEq(biPoolManager.broker(), newBroker);
+  }
+
+  function test_setReserve_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    biPoolManager.setReserve(IReserve(address(0)));
+  }
+
+  function test_setReserve_whenAddressIsZero_shouldRevert() public {
+    vm.expectRevert("Reserve address must be set");
+    biPoolManager.setReserve(IReserve(address(0)));
+  }
+
+  function test_setReserve_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    address newReserve = actor("newReserve");
+    vm.expectEmit(true, true, true, true);
+    emit ReserveUpdated(newReserve);
+
+    biPoolManager.setReserve(IReserve(newReserve));
+
+    assertEq(address(biPoolManager.reserve()), newReserve);
+  }
+
+  function test_setSortedOracles_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    biPoolManager.setSortedOracles(ISortedOracles(address(0)));
+  }
+
+  function test_setSortedOracles_whenAddressIsZero_shouldRevert() public {
+    vm.expectRevert("SortedOracles address must be set");
+    biPoolManager.setSortedOracles(ISortedOracles(address(0)));
+  }
+
+  function test_setSortedOracles_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    address newSortedOracles = actor("newSortedOracles");
+    vm.expectEmit(true, true, true, true);
+    emit SortedOraclesUpdated(newSortedOracles);
+
+    biPoolManager.setSortedOracles(ISortedOracles(newSortedOracles));
+
+    assertEq(address(biPoolManager.sortedOracles()), newSortedOracles);
+  }
+
+  /* ---------- Getters ---------- */
+
+  function testFail_getPoolExchange_whenExchangeDoesNotExist_shouldRevert() public {
+    bytes32 exchangeId = keccak256(abi.encodePacked(cUSD.symbol(), USDCet.symbol(), constantProduct.name()));
+
+    biPoolManager.getPoolExchange(exchangeId);
+  }
+
+  function test_getPoolExchange_whenPoolExists_shouldReturnPool() public {
+    mockOracleRate(address(cUSD), 1e24);
+    bytes32 exchangeId = createExchange(cUSD, USDCet);
+    BiPoolManager.PoolExchange memory existingExchange = biPoolManager.getPoolExchange(exchangeId);
+    assertEq(existingExchange.asset0, address(cUSD));
+    assertEq(existingExchange.asset1, address(USDCet));
+  }
+}
+
+contract BiPoolManagerTest_createExchange is BiPoolManagerTest {
+  function test_createExchange_whenNotCalledByOwner_shouldRevert() public {
+    BiPoolManager.PoolExchange memory newexchange;
+    changePrank(notDeployer);
+
+    vm.expectRevert("Ownable: caller is not the owner");
+    biPoolManager.createExchange(newexchange);
+  }
+
+  function test_createExchange_whenPoolWithIdExists_shouldRevert() public {
+    mockOracleRate(address(cUSD), 1e24);
+    createExchange(cUSD, USDCet);
+
+    vm.expectRevert("An exchange with the specified assets and exchange exists");
+    createExchange(cUSD, USDCet);
+  }
+
+  function test_createExchange_whenAsset0IsNotRegistered_shouldRevert() public {
+    MockERC20 nonReserveStable = newMockERC20("Non Reserve Stable Asset", "NRSA");
+    vm.expectRevert("asset0 must be a stable registered with the reserve");
+    createExchange(nonReserveStable, CELO);
+  }
+
+  function test_createExchange_whenAsset0IsCollateral_shouldRevert() public {
+    vm.expectRevert("asset0 must be a stable registered with the reserve");
+    createExchange(USDCet, CELO);
+  }
+
+  function test_createExchange_whenAsset1IsNotRegistered_shouldRevert() public {
+    MockERC20 nonReserveCollateral = newMockERC20("Non Reserve Collateral Asset", "NRCA");
+    vm.expectRevert("asset1 must be a stable or collateral registered with the reserve");
+    createExchange(cUSD, nonReserveCollateral);
+  }
+
+  function test_createExchange_whenBucket0MaxFractionIsZero_shouldRevert() public {
+    vm.expectRevert("bucket0MaxFraction must be greater than 0");
+    createExchange(
+      cUSD,
+      CELO,
+      constantProduct,
+      address(cUSD),
+      FixidityLib.wrap(0.1 * 1e24), // spread
+      1e24, // bucket0TargetSize
+      FixidityLib.wrap(0) // bucket0MaxFraction
+    );
+  }
+
+  function test_createExchange_whenBucket0MaxFractionIsOne_shouldRevert() public {
+    vm.expectRevert("bucket0MaxFraction must be smaller than 1");
+    createExchange(
+      cUSD,
+      CELO,
+      constantProduct,
+      address(cUSD),
+      FixidityLib.wrap(0.1 * 1e24), // spread
+      1e24, // bucket0TargetSize
+      FixidityLib.wrap(1 * 1e24) // bucket0MaxFraction
+    );
+  }
+
+  function test_createExchange_whenMentoExchangeIsNotSet_shouldRevert() public {
+    vm.expectRevert("pricingModule must be set");
+    createExchange(cUSD, CELO, IPricingModule(address(0)));
+  }
+
+  function test_createExchange_whenAsset0IsNotSet_shouldRevert() public {
+    vm.expectRevert("asset0 must be set");
+    createExchange(MockERC20(address(0)), CELO);
+  }
+
+  function test_createExchange_whenAsset1IsNotSet_shouldRevert() public {
+    vm.expectRevert("asset1 must be set");
+    createExchange(cUSD, MockERC20(address(0)));
+  }
+
+  function test_createExchange_whenOracleReportTargetIsNotSet_shouldRevert() public {
+    vm.expectRevert("oracleReportTarget must be set");
+    createExchange(cUSD, CELO, constantProduct, address(0));
+  }
+
+  function test_createExchange_whenSpreadNotLTEOne_shouldRevert() public {
+    vm.expectRevert("Spread must be less than or equal to 1");
+    createExchange(
+      cUSD,
+      CELO,
+      constantProduct,
+      address(cUSD),
+      FixidityLib.wrap(2 * 1e24), // spread
+      1e26, // bucket0TargetSize
+      FixidityLib.wrap(0.1 * 1e24) // bucket0MaxFraction
+    );
+  }
+
+  function test_createExchange_whenInfoIsValid_shouldUpdateMappingAndEmit() public {
+    bytes32 exchangeId = keccak256(abi.encodePacked(cUSD.symbol(), CELO.symbol(), constantProduct.name()));
+
+    mockOracleRate(address(cUSD), 2 * 1e24);
+    vm.expectEmit(true, true, true, false);
+    emit ExchangeCreated(exchangeId, address(cUSD), address(CELO), address(constantProduct));
+    createExchange(cUSD, CELO);
+
+    IExchangeProvider.Exchange[] memory exchanges = biPoolManager.getExchanges();
+    assertEq(exchanges.length, 1);
+    assertEq(exchanges[0].exchangeId, exchangeId);
+  }
+
+  function test_createExchange_whenInfoIsValid_setsBucketSizesCorrectly() public {
+    mockOracleRate(address(cUSD), 2 * 1e24); // 1 CELO == 2 cUSD
+    bytes32 exchangeId = createExchange(
+      cUSD,
+      CELO,
+      constantProduct,
+      address(cUSD),
+      FixidityLib.wrap(0.1 * 1e24), // spread
+      1e24, // bucket0TargetSize
+      FixidityLib.wrap(0.1 * 1e24) // bucket0MaxFraction
+    );
+
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+    assertEq(exchange.bucket0, 1e24);
+    assertEq(exchange.bucket1, 5e23); // exchange.bucket0 / 2
+  }
+}
+
+contract BiPoolManagerTest_destroyExchange is BiPoolManagerTest {
+  function test_destroyExchange_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    biPoolManager.destroyExchange(0x0, 0);
+  }
+
+  function test_destroyExchange_whenNoExchangesExist_shouldRevert() public {
+    vm.expectRevert("exchangeIdIndex not in range");
+    biPoolManager.destroyExchange(0x0, 0);
+  }
+
+  function test_destroyExchange_whenExchangeExistsButTheIdIsWrong_shouldRevert() public {
+    mockOracleRate(address(cUSD), 2e24);
+    createExchange(cUSD, USDCet);
+    vm.expectRevert("exchangeId at index doesn't match");
+    biPoolManager.destroyExchange(0x0, 0);
+  }
+
+  function test_destroyExchange_whenExchangeExistsButTheIndexIsTooLarge_shouldRevert() public {
+    mockOracleRate(address(cUSD), 2e24);
+    createExchange(cUSD, USDCet);
+    vm.expectRevert("exchangeIdIndex not in range");
+    biPoolManager.destroyExchange(0x0, 1);
+  }
+
+  function test_destroyExchange_whenExchangeExists_shouldUpdateAndEmit() public {
+    mockOracleRate(address(cUSD), 2e24);
+    bytes32 exchangeId = createExchange(cUSD, USDCet);
+    vm.expectEmit(true, true, true, true);
+    emit ExchangeDestroyed(exchangeId, address(cUSD), address(USDCet), address(constantProduct));
+    biPoolManager.destroyExchange(exchangeId, 0);
+  }
+
+  function test_destroyExchange_whenMultipleExchangesExist_shouldUpdateTheIdList() public {
+    mockOracleRate(address(cUSD), 2e24);
+    bytes32 exchangeId0 = createExchange(cUSD, USDCet);
+    bytes32 exchangeId1 = createExchange(cUSD, CELO);
+
+    vm.expectEmit(true, true, true, true);
+    emit ExchangeDestroyed(exchangeId0, address(cUSD), address(USDCet), address(constantProduct));
+    biPoolManager.destroyExchange(exchangeId0, 0);
+
+    IExchangeProvider.Exchange[] memory exchanges = biPoolManager.getExchanges();
+    assertEq(exchanges.length, 1);
+    assertEq(exchanges[0].exchangeId, exchangeId1);
+  }
+}
+
+contract BiPoolManagerTest_withExchange is BiPoolManagerTest {
+  bytes32 exchangeId;
+
+  function setUp() public {
+    super.setUp();
+
+    mockOracleRate(address(cUSD), 2e24);
+    exchangeId = createExchange(cUSD, CELO);
+  }
+}
+
+contract BiPoolManagerTest_quote is BiPoolManagerTest_withExchange {
+  /* ---------- getAmountOut ---------- */
+  function test_getAmountOut_whenExchangeDoesntExist_itReverts() public {
+    vm.expectRevert("An exchange with the specified id does not exist");
+    biPoolManager.getAmountOut(0x0, address(0), address(0), 1e24);
+  }
+
+  function test_getAmountOut_whenTokenInNotInexchange_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.getAmountOut(exchangeId, address(cEUR), address(cUSD), 1e24);
+  }
+
+  function test_getAmountOut_whenTokenOutNotInexchange_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.getAmountOut(exchangeId, address(cUSD), address(cEUR), 1e24);
+  }
+
+  function test_getAmountOut_whenTokenInEqualsTokenOut_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.getAmountOut(exchangeId, address(cUSD), address(cUSD), 1e24);
+  }
+
+  function test_getAmountOut_whenTokenInIsAsset0_itDelegatesToThePricingModule() public {
+    uint256 amountIn = 1e24;
+    uint256 mockAmountOut = 0.5 * 1e24;
+
+    mockGetAmountOut(exchangeId, address(cUSD), amountIn, mockAmountOut);
+    uint256 amountOut = biPoolManager.getAmountOut(exchangeId, address(cUSD), address(CELO), amountIn);
+    assertEq(amountOut, mockAmountOut);
+  }
+
+  function test_getAmountOut_whenTokenInIsAsset1_itDelegatesToThePricingModule() public {
+    uint256 amountIn = 1e24;
+    uint256 mockAmountOut = 0.5 * 1e24;
+
+    mockGetAmountOut(exchangeId, address(CELO), amountIn, mockAmountOut);
+    uint256 amountOut = biPoolManager.getAmountOut(exchangeId, address(CELO), address(cUSD), amountIn);
+    assertEq(amountOut, mockAmountOut);
+  }
+
+  /* ---------- getAmountIn ---------- */
+
+  function test_getAmountIn_whenExchangeDoesntExist_itReverts() public {
+    vm.expectRevert("An exchange with the specified id does not exist");
+    biPoolManager.getAmountIn(0x0, address(0), address(0), 1e24);
+  }
+
+  function test_getAmountIn_whenTokenInNotInexchange_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.getAmountIn(exchangeId, address(cEUR), address(cUSD), 1e24);
+  }
+
+  function test_getAmountIn_whenTokenOutNotInexchange_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.getAmountIn(exchangeId, address(cUSD), address(cEUR), 1e24);
+  }
+
+  function test_getAmountIn_whenTokenInEqualsTokenOut_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.getAmountIn(exchangeId, address(cUSD), address(cUSD), 1e24);
+  }
+
+  function test_getAmountIn_whenTokenInIsAsset0_itDelegatesToThePricingModule() public {
+    uint256 amountOut = 1e24;
+    uint256 mockAmountIn = 0.5 * 1e24;
+
+    mockGetAmountIn(exchangeId, address(cUSD), mockAmountIn, amountOut);
+    uint256 amountIn = biPoolManager.getAmountIn(exchangeId, address(cUSD), address(CELO), amountOut);
+    assertEq(amountIn, mockAmountIn);
+  }
+
+  function test_getAmountIn_whenTokenInIsAsset1_itDelegatesToThePricingModule() public {
+    uint256 amountOut = 1e24;
+    uint256 mockAmountIn = 0.5 * 1e24;
+
+    mockGetAmountIn(exchangeId, address(CELO), mockAmountIn, amountOut);
+    uint256 amountIn = biPoolManager.getAmountIn(exchangeId, address(CELO), address(cUSD), amountOut);
+    assertEq(amountIn, mockAmountIn);
+  }
+}
+
+contract BiPoolManagerTest_swap is BiPoolManagerTest_withExchange {
+  function setUp() public {
+    super.setUp();
+    changePrank(broker);
+  }
+
+  /* ---------- swapIn ---------- */
+  function test_swapIn_whenNotBroker_itReverts() public {
+    changePrank(deployer);
+    vm.expectRevert("Caller is not the Broker");
+    biPoolManager.swapIn(0x0, address(0), address(0), 1e24);
+  }
+
+  function test_swapIn_whenExchangeDoesntExist_itReverts() public {
+    vm.expectRevert("An exchange with the specified id does not exist");
+    biPoolManager.swapIn(0x0, address(0), address(0), 1e24);
+  }
+
+  function test_swapIn_whenTokenInNotInexchange_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.swapIn(exchangeId, address(cEUR), address(cUSD), 1e24);
+  }
+
+  function test_swapIn_whenTokenOutNotInexchange_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.swapIn(exchangeId, address(cUSD), address(cEUR), 1e24);
+  }
+
+  function test_swapIn_whenTokenInEqualsTokenOut_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.swapIn(exchangeId, address(cUSD), address(cUSD), 1e24);
+  }
+
+  function test_swapIn_whenTokenInIsAsset0_itDelegatesToThePricingModule() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+
+    uint256 amountIn = 1e24;
+    uint256 mockAmountOut = 0.5 * 1e24;
+
+    mockGetAmountOut(exchangeId, address(cUSD), amountIn, mockAmountOut);
+    uint256 amountOut = biPoolManager.swapIn(exchangeId, address(cUSD), address(CELO), amountIn);
+
+    BiPoolManager.PoolExchange memory exchangeAfter = biPoolManager.getPoolExchange(exchangeId);
+    assertEq(amountOut, mockAmountOut);
+    assertEq(exchangeAfter.bucket0, exchange.bucket0 + amountIn);
+    assertEq(exchangeAfter.bucket1, exchange.bucket1 - amountOut);
+  }
+
+  function test_swapIn_whenTokenInIsAsset1_itDelegatesToThePricingModule() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+
+    uint256 amountIn = 1e24;
+    uint256 mockAmountOut = 0.5 * 1e24;
+
+    mockGetAmountOut(exchangeId, address(CELO), amountIn, mockAmountOut);
+    uint256 amountOut = biPoolManager.swapIn(exchangeId, address(CELO), address(cUSD), amountIn);
+
+    BiPoolManager.PoolExchange memory exchangeAfter = biPoolManager.getPoolExchange(exchangeId);
+    assertEq(amountOut, mockAmountOut);
+    assertEq(exchangeAfter.bucket0, exchange.bucket0 - amountOut);
+    assertEq(exchangeAfter.bucket1, exchange.bucket1 + amountIn);
+  }
+
+  /* ---------- swapOut --------- */
+  function test_swapOut_whenNotBroker_itReverts() public {
+    changePrank(deployer);
+    vm.expectRevert("Caller is not the Broker");
+    biPoolManager.swapOut(0x0, address(0), address(0), 1e24);
+  }
+
+  function test_swapOut_whenExchangeDoesntExist_itReverts() public {
+    vm.expectRevert("An exchange with the specified id does not exist");
+    biPoolManager.swapOut(0x0, address(0), address(0), 1e24);
+  }
+
+  function test_swapOut_whenTokenInNotInPool_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.swapOut(exchangeId, address(cEUR), address(cUSD), 1e24);
+  }
+
+  function test_swapOut_whenTokenOutNotInexchange_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.swapOut(exchangeId, address(cUSD), address(cEUR), 1e24);
+  }
+
+  function test_swapOut_whenTokenInEqualsTokenOut_itReverts() public {
+    vm.expectRevert("tokenIn and tokenOut must match exchange");
+    biPoolManager.swapOut(exchangeId, address(cUSD), address(cUSD), 1e24);
+  }
+
+  function test_swapOut_whenTokenInIsAsset0_itDelegatesToThePricingModule() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+
+    uint256 amountOut = 1e24;
+    uint256 mockAmountIn = 0.5 * 1e24;
+
+    mockGetAmountIn(exchangeId, address(cUSD), mockAmountIn, amountOut);
+    uint256 amountIn = biPoolManager.swapOut(exchangeId, address(cUSD), address(CELO), amountOut);
+
+    BiPoolManager.PoolExchange memory exchangeAfter = biPoolManager.getPoolExchange(exchangeId);
+    assertEq(amountIn, mockAmountIn);
+    assertEq(exchangeAfter.bucket0, exchange.bucket0 + amountIn);
+    assertEq(exchangeAfter.bucket1, exchange.bucket1 - amountOut);
+  }
+
+  function test_swapOut_whenTokenInIsAsset1_itDelegatesToThePricingModule() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+
+    uint256 amountOut = 1e24;
+    uint256 mockAmountIn = 0.6 * 1e24;
+
+    mockGetAmountIn(exchangeId, address(CELO), mockAmountIn, amountOut);
+    uint256 amountIn = biPoolManager.swapOut(exchangeId, address(CELO), address(cUSD), amountOut);
+
+    BiPoolManager.PoolExchange memory exchangeAfter = biPoolManager.getPoolExchange(exchangeId);
+    assertEq(amountIn, mockAmountIn);
+    assertEq(exchangeAfter.bucket0, exchange.bucket0 - amountOut);
+    assertEq(exchangeAfter.bucket1, exchange.bucket1 + amountIn);
+  }
+}
+
+contract BiPoolManagerTest_bucketUpdates is BiPoolManagerTest_withExchange {
+  function setUp() public {
+    super.setUp();
+    changePrank(broker);
+  }
+
+  function swap(
+    bytes32 exchangeId,
+    uint256 amountIn,
+    uint256 amountOut
+  ) internal {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+    mockGetAmountOut(exchangeId, exchange.asset0, amountIn, amountOut);
+    biPoolManager.swapIn(exchangeId, exchange.asset0, exchange.asset1, amountIn);
+  }
+
+  function test_swapIn_whenBucketsAreStale_updatesBuckets() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+    swap(exchangeId, exchange.bucket0 / 2, exchange.bucket1 / 2); // debalance exchange
+
+    vm.warp(exchange.config.bucketUpdateFrequency + 1);
+    sortedOracles.setNumRates(address(cUSD), 10);
+    sortedOracles.setMedianTimestamp(address(cUSD), now);
+
+    vm.expectEmit(true, true, true, true);
+    uint256 bucket0TargetSize = exchange.config.bucket0TargetSize;
+    emit BucketsUpdated(
+      exchangeId,
+      bucket0TargetSize,
+      bucket0TargetSize / 2 // due to sortedOracles exchange rate 2:1
+    );
+
+    uint256 amountIn = 1e24;
+    uint256 amountOut = biPoolManager.swapIn(exchangeId, exchange.asset0, exchange.asset1, 1e24);
+
+    // Refresh exchange
+    exchange = biPoolManager.getPoolExchange(exchangeId);
+
+    assertEq(bucket0TargetSize + amountIn, exchange.bucket0);
+    assertEq((bucket0TargetSize / 2) - amountOut, exchange.bucket1);
+  }
+
+  function test_swapIn_whenBucketsAreNotStale_doesNotUpdateBuckets() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+    swap(exchangeId, exchange.bucket0 / 2, exchange.bucket1 / 2); // debalance exchange
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+    uint256 bucket0BeforeSwap = exchange.bucket0;
+    uint256 bucket1BeforeSwap = exchange.bucket1;
+
+    uint256 amountIn = 1e24;
+    uint256 amountOut = biPoolManager.swapIn(exchangeId, exchange.asset0, exchange.asset1, 1e24);
+
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+
+    /*
+     * XXX: Because forge doesn't support an inverse to `expectEmit` we
+     * can't verify that calling swap doesn't emit BucketsUpdated
+     * but we can verify that the buckets were not reset before
+     * the swap, but are based on the "debalanced" exchange.
+     */
+
+    assertEq(bucket0BeforeSwap + amountIn, exchange.bucket0);
+    assertEq(bucket1BeforeSwap - amountOut, exchange.bucket1);
+  }
+
+  function test_swapIn_whenBucketsAreStale_butMinReportsNotMet_doesNotUpdateBuckets() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+    swap(exchangeId, exchange.bucket0 / 2, exchange.bucket1 / 2); // debalance exchange
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+    uint256 bucket0BeforeSwap = exchange.bucket0;
+    uint256 bucket1BeforeSwap = exchange.bucket1;
+
+    vm.warp(exchange.config.bucketUpdateFrequency + 1);
+    sortedOracles.setNumRates(address(cUSD), 4);
+    sortedOracles.setMedianTimestampToNow(address(cUSD));
+
+    uint256 amountIn = 1e24;
+    uint256 amountOut = biPoolManager.swapIn(exchangeId, exchange.asset0, exchange.asset1, 1e24);
+
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+
+    assertEq(bucket0BeforeSwap + amountIn, exchange.bucket0);
+    assertEq(bucket1BeforeSwap - amountOut, exchange.bucket1);
+  }
+
+  function test_swapIn_whenBucketsAreStale_butReportIsExpired_doesNotUpdateBuckets() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+    swap(exchangeId, exchange.bucket0 / 2, exchange.bucket1 / 2); // debalance exchange
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+    uint256 bucket0BeforeSwap = exchange.bucket0;
+    uint256 bucket1BeforeSwap = exchange.bucket1;
+
+    vm.warp(exchange.config.bucketUpdateFrequency + 1);
+    sortedOracles.setOldestReportExpired(address(cUSD));
+    sortedOracles.setNumRates(address(cUSD), 10);
+    sortedOracles.setMedianTimestampToNow(address(cUSD));
+
+    uint256 amountIn = 1e24;
+    uint256 amountOut = biPoolManager.swapIn(exchangeId, exchange.asset0, exchange.asset1, 1e24);
+
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+
+    assertEq(bucket0BeforeSwap + amountIn, exchange.bucket0);
+    assertEq(bucket1BeforeSwap - amountOut, exchange.bucket1);
+  }
+
+  function test_swapIn_whenBucketsAreStale_butMedianTimestampIsOld_doesNotUpdateBuckets() public {
+    BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+    swap(exchangeId, exchange.bucket0 / 2, exchange.bucket1 / 2); // debalance exchange
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+    uint256 bucket0BeforeSwap = exchange.bucket0;
+    uint256 bucket1BeforeSwap = exchange.bucket1;
+
+    vm.warp(exchange.config.bucketUpdateFrequency + 1);
+    sortedOracles.setNumRates(address(cUSD), 10);
+    sortedOracles.setMedianTimestamp(address(cUSD), now - exchange.config.bucketUpdateFrequency);
+
+    uint256 amountIn = 1e24;
+    uint256 amountOut = biPoolManager.swapIn(exchangeId, exchange.asset0, exchange.asset1, 1e24);
+
+    exchange = biPoolManager.getPoolExchange(exchangeId); // Refresh exchange
+
+    assertEq(bucket0BeforeSwap + amountIn, exchange.bucket0);
+    assertEq(bucket1BeforeSwap - amountOut, exchange.bucket1);
+  }
+}

--- a/test/Broker.t.sol
+++ b/test/Broker.t.sol
@@ -1,0 +1,441 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import { Broker } from "contracts/Broker.sol";
+import { IExchangeProvider } from "contracts/interfaces/IExchangeProvider.sol";
+import { IReserve } from "contracts/interfaces/IReserve.sol";
+import { IStableToken } from "contracts/interfaces/IStableToken.sol";
+import { MockStableToken } from "./mocks/MockStableToken.sol";
+import { MockReserve } from "./mocks/MockReserve.sol";
+import { DummyERC20 } from "./utils/DummyErc20.sol";
+
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+// forge test --match-contract Broker -vvv
+contract BrokerTest is Test {
+  event Swap(
+    address exchangeProvider,
+    bytes32 indexed exchangeId,
+    address indexed trader,
+    address indexed tokenIn,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOut
+  );
+  event ExchangeProviderAdded(address indexed exchangeProvider);
+  event ExchangeProviderRemoved(address indexed exchangeProvider);
+  event ReserveSet(address indexed newAddress, address indexed prevAddress);
+
+  address deployer = actor("deployer");
+  address notDeployer = actor("notDeployer");
+  address trader = actor("trader");
+  address randomExchangeProvider = actor("randomExchangeProvider");
+  address randomAsset = actor("randomAsset");
+
+  MockReserve reserve;
+  MockStableToken stableAsset;
+  DummyERC20 collateralAsset;
+
+  Broker broker;
+
+  IExchangeProvider exchangeProvider;
+  address exchangeProvider1 = actor("exchangeProvider1");
+  address exchangeProvider2 = actor("exchangeProvider2");
+
+  address[] public exchangeProviders;
+
+  function setUp() public {
+    /* Dependencies and actors */
+    reserve = new MockReserve();
+    collateralAsset = new DummyERC20();
+    stableAsset = new MockStableToken();
+    randomAsset = actor("randomAsset");
+    broker = new Broker(true);
+    exchangeProvider = IExchangeProvider(actor("exchangeProvider"));
+
+    reserve.addToken(address(stableAsset));
+    reserve.addCollateralAsset(address(collateralAsset));
+
+    changePrank(deployer);
+    exchangeProviders.push(exchangeProvider1);
+    exchangeProviders.push(exchangeProvider2);
+    exchangeProviders.push((address(exchangeProvider)));
+    broker.initialize(exchangeProviders, address(reserve));
+    changePrank(trader);
+  }
+}
+
+contract BrokerTest_initilizerAndSetters is BrokerTest {
+  /* ---------- Initilizer ---------- */
+
+  function test_initilize_shouldSetOwner() public {
+    assertEq(broker.owner(), deployer);
+  }
+
+  function test_initilize_shouldSetExchangeProviderAddresseses() public {
+    assertEq(broker.getExchangeProviders(), exchangeProviders);
+  }
+
+  function test_initilize_shouldSetReserve() public {
+    assertEq(address(broker.reserve()), address(reserve));
+  }
+
+  /* ---------- Setters ---------- */
+
+  function test_addExchangeProvider_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    broker.addExchangeProvider(address(0));
+  }
+
+  function test_addExchangeProvider_whenAddressIsZero_shouldRevert() public {
+    changePrank(deployer);
+    vm.expectRevert("ExchangeProvider address can't be 0");
+    broker.addExchangeProvider(address(0));
+  }
+
+  function test_addExchangeProvider_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    changePrank(deployer);
+    address newExchangeProvider = actor("newExchangeProvider");
+    vm.expectEmit(true, false, false, false);
+    emit ExchangeProviderAdded(newExchangeProvider);
+    broker.addExchangeProvider(newExchangeProvider);
+    address[] memory updatedExchangeProviders = broker.getExchangeProviders();
+    assertEq(updatedExchangeProviders[updatedExchangeProviders.length - 1], newExchangeProvider);
+    assertEq(broker.isExchangeProvider(newExchangeProvider), true);
+  }
+
+  function test_addExchangeProvider_whenAlreadyAdded_shouldRevert() public {
+    changePrank(deployer);
+    vm.expectRevert("ExchangeProvider already exists in the list");
+    broker.addExchangeProvider(address(exchangeProvider));
+  }
+
+  function test_removeExchangeProvider_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    changePrank(deployer);
+    vm.expectEmit(true, true, true, true);
+    emit ExchangeProviderRemoved(exchangeProvider1);
+    broker.removeExchangeProvider(exchangeProvider1, 0);
+    assert(broker.getExchangeProviders()[0] != exchangeProvider1);
+  }
+
+  function test_removeExchangeProvider_whenAddressDoesNotExist_shouldRevert() public {
+    changePrank(deployer);
+    vm.expectRevert("index into exchangeProviders list not mapped to an exchangeProvider");
+    broker.removeExchangeProvider(notDeployer, 1);
+  }
+
+  function test_removeExchangeProvider_whenIndexOutOfRange_shouldRevert() public {
+    changePrank(deployer);
+    vm.expectRevert("index into exchangeProviders list not mapped to an exchangeProvider");
+    broker.removeExchangeProvider(exchangeProvider1, 1);
+  }
+
+  function test_removeExchangeProvider_whenNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    broker.removeExchangeProvider(exchangeProvider1, 0);
+  }
+
+  function test_setReserve_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    broker.setReserve(address(0));
+  }
+
+  function test_setReserve_whenAddressIsZero_shouldRevert() public {
+    changePrank(deployer);
+    vm.expectRevert("Reserve address must be set");
+    broker.setReserve(address(0));
+  }
+
+  function test_setReserve_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    changePrank(deployer);
+    address newReserve = actor("newReserve");
+    vm.expectEmit(true, false, false, false);
+    emit ReserveSet(newReserve, address(reserve));
+
+    broker.setReserve(newReserve);
+    assertEq(address(broker.reserve()), newReserve);
+  }
+}
+
+contract BrokerTest_getAmounts is BrokerTest {
+  bytes32 exchangeId = keccak256(abi.encode("exhcangeId"));
+
+  function test_getAmountIn_whenExchangeProviderWasNotSet_shouldRevert() public {
+    vm.expectRevert("ExchangeProvider does not exist");
+    broker.getAmountIn(randomExchangeProvider, exchangeId, address(stableAsset), address(collateralAsset), 1e24);
+  }
+
+  function test_getAmountIn_whenExchangeProviderIsSet_shouldReceiveCall() public {
+    uint256 amountOut = 1e17;
+    uint256 mockAmountIn = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.getAmountIn.selector,
+        exchangeId,
+        address(stableAsset),
+        address(collateralAsset),
+        amountOut
+      ),
+      abi.encode(mockAmountIn)
+    );
+
+    uint256 amountIn = broker.getAmountIn(
+      address(exchangeProvider),
+      exchangeId,
+      address(stableAsset),
+      address(collateralAsset),
+      amountOut
+    );
+
+    assertEq(amountIn, mockAmountIn);
+  }
+
+  function test_getAmountOut_whenExchangeProviderWasNotSet_shouldRevert() public {
+    vm.expectRevert("ExchangeProvider does not exist");
+    broker.getAmountOut(randomExchangeProvider, exchangeId, randomAsset, randomAsset, 1e24);
+  }
+
+  function test_getAmountOut_whenExchangeProviderIsSet_shouldReceiveCall() public {
+    uint256 amountIn = 1e17;
+    uint256 mockAmountOut = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.getAmountOut.selector,
+        exchangeId,
+        address(stableAsset),
+        address(collateralAsset),
+        amountIn
+      ),
+      abi.encode(mockAmountOut)
+    );
+
+    uint256 amountOut = broker.getAmountOut(
+      address(exchangeProvider),
+      exchangeId,
+      address(stableAsset),
+      address(collateralAsset),
+      amountIn
+    );
+
+    assertEq(amountOut, mockAmountOut);
+  }
+}
+
+contract BrokerTest_swap is BrokerTest {
+  bytes32 exchangeId = keccak256(abi.encode("exhcangeId"));
+
+  function test_swapIn_whenAmoutOutMinNotMet_shouldRevert() public {
+    uint256 amountIn = 1e16;
+    uint256 mockAmountOut = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.swapIn.selector,
+        exchangeId,
+        address(stableAsset),
+        address(collateralAsset),
+        amountIn
+      ),
+      abi.encode(mockAmountOut)
+    );
+
+    vm.expectRevert("amountOutMin not met");
+    broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), amountIn, 1e17);
+  }
+
+  function test_swapOut_whenAmoutInMaxExceeded_shouldRevert() public {
+    uint256 amountOut = 1e16;
+    uint256 mockAmountIn = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.swapOut.selector,
+        exchangeId,
+        address(stableAsset),
+        address(collateralAsset),
+        amountOut
+      ),
+      abi.encode(mockAmountIn)
+    );
+
+    vm.expectRevert("amountInMax exceeded");
+    broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), amountOut, 1e15);
+  }
+
+  function test_swapIn_whenTokenInStableAsset_shouldUpdateAndEmit() public {
+    deal(address(collateralAsset), address(reserve), 1e16);
+    deal(address(collateralAsset), trader, 1e16);
+    stableAsset.mint(address(broker), 1e16);
+    stableAsset.mint(address(trader), 1e16);
+
+    changePrank(trader);
+    uint256 amountIn = 1e16;
+    uint256 mockAmountOut = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.swapIn.selector,
+        exchangeId,
+        address(stableAsset),
+        address(collateralAsset),
+        amountIn
+      ),
+      abi.encode(mockAmountOut)
+    );
+
+    vm.expectEmit(true, true, true, true);
+    emit Swap(address(exchangeProvider), exchangeId, trader, address(stableAsset), address(collateralAsset), amountIn, 1e16);
+    uint256 amountOut = broker.swapIn(
+      address(exchangeProvider),
+      exchangeId,
+      address(stableAsset),
+      address(collateralAsset),
+      amountIn,
+      1e16
+    );
+
+    assertEq(1e16, amountOut);
+    assertEq(stableAsset.balanceOf(trader), 0);
+    assertEq(stableAsset.balanceOf(address(broker)), 1e16);
+    assertEq(IERC20(collateralAsset).balanceOf(trader), 2e16);
+    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 0);
+  }
+
+  function test_swapIn_whenTokenInCollateralAsset_shouldUpdateAndEmit() public {
+    deal(address(collateralAsset), address(reserve), 1e16);
+    deal(address(collateralAsset), trader, 1e16);
+    stableAsset.mint(address(broker), 1e16);
+    stableAsset.mint(address(trader), 1e16);
+
+    changePrank(trader);
+    IERC20(collateralAsset).approve(address(broker), 1e16);
+    uint256 amountIn = 1e16;
+    uint256 mockAmountOut = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.swapOut.selector,
+        exchangeId,
+        address(collateralAsset),
+        address(stableAsset),
+        amountIn
+      ),
+      abi.encode(mockAmountOut)
+    );
+
+    vm.expectEmit(true, true, true, true);
+    emit Swap(address(exchangeProvider), exchangeId, trader, address(collateralAsset), address(stableAsset), amountIn, 1e16);
+    uint256 amountOut = broker.swapOut(
+      address(exchangeProvider),
+      exchangeId,
+      address(collateralAsset),
+      address(stableAsset),
+      amountIn,
+      1e16
+    );
+
+    assertEq(1e16, amountOut);
+    assertEq(IERC20(collateralAsset).balanceOf(trader), 0);
+    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 2e16);
+    assertEq(stableAsset.balanceOf(trader), 2e16);
+  }
+
+  function test_swapOut_whenTokenInStableAsset_shoulUpdateAndEmit() public {
+    deal(address(collateralAsset), address(reserve), 1e16);
+    deal(address(collateralAsset), trader, 1e16);
+    stableAsset.mint(address(broker), 1e16);
+    stableAsset.mint(address(trader), 1e16);
+
+    changePrank(trader);
+    uint256 amountOut = 1e16;
+    uint256 mockAmountIn = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.swapOut.selector,
+        exchangeId,
+        address(stableAsset),
+        address(collateralAsset),
+        amountOut
+      ),
+      abi.encode(mockAmountIn)
+    );
+
+    vm.expectEmit(true, true, true, true);
+    emit Swap(address(exchangeProvider), exchangeId, trader, address(stableAsset), address(collateralAsset), amountOut, 1e16);
+
+    uint256 amountIn = broker.swapOut(
+      address(exchangeProvider),
+      exchangeId,
+      address(stableAsset),
+      address(collateralAsset),
+      amountOut,
+      1e16
+    );
+
+    assertEq(1e16, amountIn);
+    assertEq(stableAsset.balanceOf(trader), 0);
+    assertEq(stableAsset.balanceOf(address(broker)), 1e16);
+    assertEq(IERC20(collateralAsset).balanceOf(trader), 2e16);
+    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 0);
+  }
+
+  function test_swapOut_whenTokenInCollateralAsset_shouldUpdateAndEmit() public {
+    deal(address(collateralAsset), address(reserve), 1e16);
+    deal(address(collateralAsset), trader, 1e16);
+    stableAsset.mint(address(broker), 1e16);
+    stableAsset.mint(address(trader), 1e16);
+
+    changePrank(trader);
+    IERC20(collateralAsset).approve(address(broker), 1e16);
+    uint256 amountOut = 1e16;
+    uint256 mockAmountIn = 1e16;
+
+    vm.mockCall(
+      address(exchangeProvider),
+      abi.encodeWithSelector(
+        exchangeProvider.swapOut.selector,
+        exchangeId,
+        address(collateralAsset),
+        address(stableAsset),
+        amountOut
+      ),
+      abi.encode(mockAmountIn)
+    );
+
+    vm.expectEmit(true, true, true, true);
+    emit Swap(address(exchangeProvider), exchangeId, trader, address(collateralAsset), address(stableAsset), amountOut, 1e16);
+    uint256 amountIn = broker.swapOut(
+      address(exchangeProvider),
+      exchangeId,
+      address(collateralAsset),
+      address(stableAsset),
+      amountOut,
+      1e16
+    );
+
+    assertEq(1e16, amountIn);
+    assertEq(IERC20(collateralAsset).balanceOf(trader), 0);
+    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 2e16);
+    assertEq(stableAsset.balanceOf(trader), 2e16);
+  }
+
+  function test_swapOut_whenExchangeManagerWasNotSet_shouldRevert() public {
+    vm.expectRevert("ExchangeProvider does not exist");
+    broker.swapOut(randomExchangeProvider, exchangeId, randomAsset, randomAsset, 2e24, 1e24);
+  }
+}

--- a/test/ConstantProductPricingModule.t.sol
+++ b/test/ConstantProductPricingModule.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { stdStorage } from "forge-std/Test.sol";
+
+import { ConstantProductPricingModule } from "contracts/ConstantProductPricingModule.sol";
+import { Exchange } from "contracts/Exchange.sol";
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+import { IPricingModule } from "contracts/interfaces/IPricingModule.sol";
+
+import { MockSortedOracles } from "./mocks/MockSortedOracles.sol";
+import { WithRegistry } from "./utils/WithRegistry.sol";
+
+contract LegacyExchangeWrapper {
+  address constant registryAddress = 0x000000000000000000000000000000000000ce10;
+  using stdStorage for stdStorage.StdStorage;
+  stdStorage.StdStorage internal stdstore;
+
+  Exchange exchange;
+
+  bytes4 constant STABLE_BUCKET_SIG = bytes4(keccak256("stableBucket()"));
+  bytes4 constant GOLD_BUCKET_SIG = bytes4(keccak256("goldBucket()"));
+
+  constructor() public {
+    exchange = new Exchange(true);
+    exchange.initialize(registryAddress, "StableToken", 5 * 1e23, 5 * 1e23, 60 * 60, 2, 1e24, 5 * 1e23);
+  }
+
+  function getAmountOut(
+    uint256 tokenInBucketSize,
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountIn
+  ) external returns (uint256 amountOut) {
+    setupExchange(tokenInBucketSize, tokenOutBucketSize, spread);
+    return exchange.getBuyTokenAmount(amountIn, false);
+  }
+
+  function getAmountIn(
+    uint256 tokenInBucketSize,
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountOut
+  ) external returns (uint256 amountIn) {
+    setupExchange(tokenInBucketSize, tokenOutBucketSize, spread);
+    return exchange.getSellTokenAmount(amountOut, false);
+  }
+
+  function setupExchange(
+    uint256 stableBucket,
+    uint256 goldBucket,
+    uint256 spread
+  ) internal {
+    exchange.setSpread(spread);
+    stdstore.target(address(exchange)).sig(STABLE_BUCKET_SIG).checked_write(stableBucket);
+    stdstore.target(address(exchange)).sig(GOLD_BUCKET_SIG).checked_write(goldBucket);
+  }
+}
+
+contract ConstantProductPricingModuleTest is Test, WithRegistry {
+  IPricingModule constantProduct;
+  LegacyExchangeWrapper legacyExchange;
+  MockSortedOracles sortedOracles;
+
+  uint256 pc1 = 1 * 1e22;
+  uint256 pc5 = 5 * 1e22;
+  uint256 pc10 = 1e23;
+
+  function setUp() public {
+    vm.warp(24 * 60 * 60);
+    changePrank(actor("deployer"));
+    sortedOracles = new MockSortedOracles();
+    sortedOracles.setNumRates(address(0), 10);
+
+    registry.setAddressFor("SortedOracles", address(sortedOracles));
+    constantProduct = new ConstantProductPricingModule(true);
+    legacyExchange = new LegacyExchangeWrapper();
+  }
+
+  function test_getAmountOut_compareWithLegacyExchange_t1() public {
+    uint256 expectedAmountOut = legacyExchange.getAmountOut(1e24, 2e24, pc1, 1e23);
+    uint256 newAmountOut = constantProduct.getAmountOut(1e24, 2e24, pc1, 1e23);
+
+    assertEq(newAmountOut, expectedAmountOut);
+  }
+
+  function test_getAmountOut_compareWithLegacyExchange_t2() public {
+    uint256 expectedAmountOut = legacyExchange.getAmountOut(11e24, 23e24, pc5, 3e23);
+    uint256 newAmountOut = constantProduct.getAmountOut(11e24, 23e24, pc5, 3e23);
+
+    assertEq(newAmountOut, expectedAmountOut);
+  }
+
+  function test_getAmountIn_compareWithLegacyExchange_t1() public {
+    uint256 expectedAmountIn = legacyExchange.getAmountIn(1e24, 2e24, pc1, 1e23);
+    uint256 newAmountIn = constantProduct.getAmountIn(1e24, 2e24, pc1, 1e23);
+
+    assertEq(newAmountIn, expectedAmountIn);
+  }
+
+  function test_getAmountIn_compareWithLegacyExchange_t2() public {
+    uint256 expectedAmountIn = legacyExchange.getAmountIn(11e24, 23e24, pc5, 3e23);
+    uint256 newAmountIn = constantProduct.getAmountIn(11e24, 23e24, pc5, 3e23);
+
+    assertEq(newAmountIn, expectedAmountIn);
+  }
+}

--- a/test/ConstantSumPricingModule.t.sol
+++ b/test/ConstantSumPricingModule.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.5.13;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { ConstantSumPricingModule } from "contracts/ConstantSumPricingModule.sol";
+import {IPricingModule} from "contracts/interfaces/IPricingModule.sol";
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+contract ConstantSumPricingModuleTest is Test {
+    IPricingModule constantSum;
+
+    function setUp() public {
+        constantSum = new ConstantSumPricingModule(true);
+    }
+
+    //Testing concrete Case
+    //amountOut = (1-spread)*amountIn = (1-0.1)*10^18 = 0.9*10^18 = 900000000000000000 Wei
+    function test_getAmountOut_forCorrectCalculation() public {
+        uint256 amountOut = constantSum.getAmountOut(10**24, 10**24, 100000000000000000000000 , 10**18);
+        assertEq(amountOut, 900000000000000000);
+    }
+
+    //Fuzz testing
+    //uint176 for bucket and amountIn, 
+    //because the maximum value that can be converted to fix point in FixidityLib is uint177
+    //uint80 for spread, because the spread needs to be smaller than 1. 
+    //This is also enforced by the Exchange contract when settin a spread   
+    function test_getAmountOut_forRobustness(
+        uint176 tokenInBucketSize,
+        uint176 tokenOutBucketSize, 
+        uint80 spread,
+        uint176 amountIn
+        ) public {
+        vm.assume(spread < FixidityLib.fixed1().value);
+        vm.assume(amountIn <= tokenOutBucketSize);
+
+        uint256 amountOut = constantSum.getAmountOut(tokenInBucketSize, tokenOutBucketSize, spread, amountIn );
+    }
+
+    //Testing concrete Case 
+    //amountIn = amountOut/(1-spread) = 10^18 / (1 - 0.1) = 10^18 / (0.9) = 1111111111111111111.1111111111111111 
+    //Wei = 1111111111111111111 Wei
+    function test_getAmountIn_forCorrectCalculation() public {
+        uint256 amountOut = constantSum.getAmountIn(10**24, 10**24, 100000000000000000000000 , 10**18);
+        assertEq(amountOut, 1111111111111111111);
+    }
+    //Fuzz testing
+    //uint176 for bucket and amountOut, 
+    //because the maximum value that can be converted to fix point in FixidityLib is uint177.
+    //uint80 for spread, because the spread needs to be smaller than 1.
+    //This is also enforced by the Exchange contract when setting the spread. 
+    function test_getAmountIn_forRobustness(
+        uint176 tokenInBucketSize,
+        uint176 tokenOutBucketSize,
+        uint80 spread,
+        uint176 amountOut) public {
+        vm.assume(spread < FixidityLib.fixed1().value);
+        vm.assume(amountOut<= tokenOutBucketSize);
+        uint256 amountIn = constantSum.getAmountIn(tokenInBucketSize, tokenOutBucketSize, spread, amountOut); 
+    }
+} 

--- a/test/Exchange.t.sol
+++ b/test/Exchange.t.sol
@@ -476,7 +476,7 @@ contract ExchangeTest_sell is ExchangeTest_stableActivated {
     }
 
     function test_sellCelo_revertsIfApprovalIsWrong(uint256 amount) public {
-        vm.assume(amount <= sellerCeloBalance);
+        vm.assume(amount < sellerCeloBalance);
         approveExchange(amount, true);
         uint256 expectedStableAmount = getBuyTokenAmount(amount, initialCeloBucket, initialStableBucket);
         vm.expectRevert("transfer value exceeded sender's allowance for recipient");

--- a/test/SortedOracles.t.sol
+++ b/test/SortedOracles.t.sol
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.5.13;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { SortedOracles } from "contracts/SortedOracles.sol";
+
+import "../contracts/common/linkedlists/SortedLinkedListWithMedian.sol";
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+contract SortedOraclesTest is Test{
+
+    // Declare SortedOracles events for matching
+    event ReportExpirySet(uint256 reportExpiry);
+    event TokenReportExpirySet(address token, uint256 reportExpiry);
+    event OracleAdded(address indexed token, address indexed oracleAddress); 
+    event OracleRemoved(address indexed token, address indexed oracleAddress);
+    event OracleReportRemoved(address indexed token, address indexed oracle);
+    event MedianUpdated(address indexed token, uint256 value);
+    event OracleReported(address indexed token, address indexed oracle, uint256 timestamp, uint256 value);
+
+
+
+    SortedOracles sortedOracles;
+    address owner;
+    address rando;
+    address token;
+    address oracle;
+    uint256 aReportExpiry = 3600;
+    uint256 fixed1 = FixidityLib.unwrap(FixidityLib.fixed1());
+
+
+
+    function setUp() public{
+        sortedOracles = new SortedOracles(true);
+        sortedOracles.initialize(aReportExpiry);
+        owner = address(this);
+        rando = address(2);
+        token = address(3);
+        oracle = address(4);
+    }
+
+    /**
+    * @notice Test helper function. Submits n Reports for a token from n different Oracles. 
+    */
+
+    function submitNReports(uint256 n) public {
+        sortedOracles.addOracle(token, oracle);
+        changePrank(oracle);
+        sortedOracles.report(token, fixed1*10, address(0), address(0));
+        for(uint256 i = 5; i < 5+n-1; i++){
+            address anotherOracle = address(i);
+            changePrank(owner);
+            sortedOracles.addOracle(token, anotherOracle);
+            changePrank(address(i));
+            sortedOracles.report(token, fixed1*10, oracle, address(0));
+        }
+        changePrank(owner);
+    }
+}
+
+/**
+* @notice Tests
+*/
+
+contract SortedOracles_initialize is SortedOraclesTest{
+
+    function test_initialize_shouldHaveSetTheOwner() public {
+        assertEq(sortedOracles.owner(),owner);
+    }
+
+    function test_initialize_shouldHaveSetReportExpiryToAReportExpiry() public{
+        assertEq(sortedOracles.reportExpirySeconds(), aReportExpiry);
+    }
+
+    function test_initialize_whenCalledAgain_shouldRevert() public{
+        vm.expectRevert("contract already initialized");
+        sortedOracles.initialize(aReportExpiry);
+    }
+}
+
+
+contract SortedOracles_setReportExpiry is SortedOraclesTest {
+
+    function test_setReportExpiry_shouldUpdateReportExpiry() public {
+        sortedOracles.setReportExpiry(aReportExpiry+1);
+        assertEq(sortedOracles.reportExpirySeconds(), aReportExpiry+1);
+    }
+
+    function test_setReportExpiry_shouldEmitEvent() public {
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit ReportExpirySet(aReportExpiry+1);
+        sortedOracles.setReportExpiry(aReportExpiry+1);
+    } 
+
+    function test_setReportExpiry_whenCalledByNonOwner_shouldRevert() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        changePrank(rando);
+        sortedOracles.setReportExpiry(aReportExpiry+1);
+    }
+}
+
+
+contract SortedOracles_setTokenReportExpiry is SortedOraclesTest {
+
+    uint256 aNewReportExpiry = aReportExpiry + 1;
+
+    function test_setTokenReportExpiry_shouldUpdateTokenReportExpiry() public {
+        sortedOracles.setTokenReportExpiry(token, aNewReportExpiry);
+        assertEq(sortedOracles.tokenReportExpirySeconds(token), aNewReportExpiry);
+    }
+
+    function test_setTokenReportExpiry_shouldEmitTokenReportExpirySetEvent() public {
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit TokenReportExpirySet(token, aNewReportExpiry);
+        sortedOracles.setTokenReportExpiry(token, aNewReportExpiry);
+    } 
+
+    function test_setTokenReportExpiry_whenCalledByNonOwner_shouldRevert() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        changePrank(rando);
+        sortedOracles.setTokenReportExpiry(token, aNewReportExpiry);
+    }
+}
+
+
+contract SortedOracles_getTokenReportExpiry is SortedOraclesTest {
+
+    function test_getTokenReportExpirySeconds_whenNoTokeLevelExpiryIsSet_shouldReturnContractLevel() public{
+        assertEq(sortedOracles.getTokenReportExpirySeconds(token), aReportExpiry);
+    }
+
+    function test_getTokenReportExpirySeconds_whenTokeLevelExpiryIsSet_shouldReturnTokenLevel() public{
+        sortedOracles.setTokenReportExpiry(token, aReportExpiry+1);
+        assertEq(sortedOracles.getTokenReportExpirySeconds(token), aReportExpiry+1);
+    }
+}
+
+
+contract SortedOracles_addOracles is SortedOraclesTest {
+
+    function test_addOracle_shouldAddAnOracle() public {
+        sortedOracles.addOracle(token, oracle);
+        assertTrue(sortedOracles.isOracle(token, oracle));
+    }
+
+    function test_addOracle_shouldEmitEvent() public {
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit OracleAdded(token, oracle);
+        sortedOracles.addOracle(token, oracle);
+    }
+
+    function test_addOracle_whenTokenIsTheNullAddress_shouldRevert() public{
+        vm.expectRevert("token addr was null or oracle addr was null or oracle addr is not an oracle for token addr");
+        sortedOracles.addOracle(address(0), oracle);
+    }
+
+    function test_addOracle_whenOracleIsTheNullAddress_shouldRevert() public{
+        vm.expectRevert("token addr was null or oracle addr was null or oracle addr is not an oracle for token addr");
+        sortedOracles.addOracle(token, address(0));
+    }
+
+    function test_addOracle_whenOracleHasBeenAdded_shouldRevert() public{
+        sortedOracles.addOracle(token, oracle);
+        vm.expectRevert("token addr was null or oracle addr was null or oracle addr is not an oracle for token addr");
+        sortedOracles.addOracle(token, oracle);
+    }
+
+    function test_addOracle_whenCalledByNonOwner_shouldRevert() public{
+        vm.expectRevert("Ownable: caller is not the owner");
+        changePrank(rando);
+        sortedOracles.addOracle(token, oracle);
+    }
+}
+
+
+contract SortedOracles_RemoveOracles is SortedOraclesTest {
+
+    function test_removeOracle_shouldRemoveAnOracle() public{
+        sortedOracles.addOracle(token, oracle);
+        sortedOracles.removeOracle(token, oracle, 0);
+        assertFalse(sortedOracles.isOracle(token,oracle));
+    }
+
+    function test_removeOracle_whenMoreThanOneReportExists_shouldDecreaseNumberOfRates() public {
+        submitNReports(2);
+        sortedOracles.removeOracle(token, oracle, 0);
+        assertEq(sortedOracles.numRates(token), 1);
+    }
+
+    function test_removeOracle_whenMoreThanOneReportExists_shouldDecreaseNumberOfTimestamps() public {
+        submitNReports(2);
+        sortedOracles.removeOracle(token, oracle, 0);
+        assertEq(sortedOracles.numTimestamps(token), 1);
+    }
+
+    function test_removeOracle_whenMoreThanOneReportExists_shouldEmitOracleRemovedOracleReportRemovedMedianUpdatedEvent() public { 
+        submitNReports(1);
+        sortedOracles.addOracle(token, address(6));
+        changePrank(address(6));
+        sortedOracles.report(token, fixed1*12, oracle, address(0));
+        
+        vm.expectEmit(true,true,true,true, address(sortedOracles));
+        emit OracleReportRemoved(token, address(6));
+        vm.expectEmit(true,true,true,true, address(sortedOracles));
+        emit MedianUpdated(token,fixed1*10);
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit OracleRemoved(token, address(6));
+
+        changePrank(owner);
+        sortedOracles.removeOracle(token, address(6), 1);
+    }   
+
+    function test_removeOracle_whenOneReportExists_shouldNotDecreaseNumberOfRates() public {
+        submitNReports(1);
+        sortedOracles.removeOracle(token, oracle, 0);
+        assertEq(sortedOracles.numRates(token), 1);
+    }
+
+    function test_removeOracle_whenOneReportExists_shouldNotResetTheMedianRate() public {
+        submitNReports(1);
+        (uint256 numeratorBefore,) = sortedOracles.medianRate(token);
+        sortedOracles.removeOracle(token, oracle, 0);
+        (uint256 numeratorAfter, ) = sortedOracles.medianRate(token);
+        assertEq(numeratorBefore,numeratorAfter);
+    }
+
+    function test_removeOracle_whenOneReportExists_shouldNotDecreaseNumberOfTimestamps() public {
+        submitNReports(1);
+        sortedOracles.removeOracle(token, oracle, 0);
+        assertEq(sortedOracles.numTimestamps(token), 1);
+    }
+
+    function test_removeOracle_whenOneReportExists_shouldNotResetTheMedianTimestamp() public {
+        submitNReports(1);
+        uint256 medianTimestampBefore = sortedOracles.medianTimestamp(token);
+        sortedOracles.removeOracle(token, oracle, 0);
+        uint256 medianTimestampAfter = sortedOracles.medianTimestamp(token);
+        assertEq(medianTimestampBefore,medianTimestampAfter);
+    }
+
+    function testFail_removeOracle_whenOneReportExists_shouldNotEmitTheOracleReportedAndMedianUpdatedEvent() public {
+        /*
+        testFail feals impricise here. 
+        ToDo: Better way of testing this case :)  
+        */
+        submitNReports(1);
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit OracleReportRemoved(token, oracle);
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit MedianUpdated(token, 0);
+        sortedOracles.removeOracle(token, oracle, 0);
+    }
+
+    function test_removeOracle_whenOneReportExists_shouldEmitTheOracleRemovedEvent() public {
+        submitNReports(1);
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit OracleRemoved(token, oracle);
+        sortedOracles.removeOracle(token, oracle, 0);
+    }
+
+     function test_removeOracle_shouldRevertWhenIdexIsWrong() public {
+        submitNReports(1);
+        vm.expectRevert("token addr null or oracle addr null or index of token oracle not mapped to oracle addr");
+        sortedOracles.removeOracle(token, oracle, 1);
+    }
+
+    function test_removeOracle_shouldRevertWhenAddressIsWrong() public {
+        submitNReports(1);
+        vm.expectRevert("token addr null or oracle addr null or index of token oracle not mapped to oracle addr");
+        sortedOracles.removeOracle(token, address(15), 0);
+    }
+
+    function test_removeOracle_shouldRevertWhenCalledByNonOwner() public {
+        submitNReports(1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        changePrank(rando);
+        sortedOracles.removeOracle(token, address(15), 0);
+    }
+}
+
+
+contract SortedOracles_removeExpiredReports is SortedOraclesTest {
+
+    function test_removeExpiredReports_whenNoReportExists_shouldRevert() public{
+        sortedOracles.addOracle(token, oracle);
+        vm.expectRevert("token addr null or trying to remove too many reports");
+        sortedOracles.removeExpiredReports(token,1);
+    }
+
+    function test_removeExpiredReports_whenOnlyOneReportExists_shouldRevert() public{
+        sortedOracles.addOracle(token, oracle);
+        changePrank(oracle);
+        sortedOracles.report(token, fixed1, address(0), address(0));
+        vm.expectRevert("token addr null or trying to remove too many reports");
+        sortedOracles.removeExpiredReports(token,1);
+    }
+
+     function test_removeExpiredReports_whenOldestReportIsNotExpired_shouldDoNothing() public {
+        submitNReports(5);
+        sortedOracles.removeExpiredReports(token,3);
+        assertEq(sortedOracles.numTimestamps(token), 5);
+     }
+
+    function test_removeExpiredReports_whenLessThanNReportsAreExpired_shouldRemoveAllExpiredAndStop() public {
+        //first 5 expired reports
+        submitNReports(5);
+        skip(aReportExpiry);
+        //two reports that aren't expired
+        sortedOracles.addOracle(token, address(10));
+        changePrank(address(10));
+        sortedOracles.report(token, fixed1*10, oracle, address(0));
+        changePrank(owner);
+        sortedOracles.addOracle(token, address(11));
+        changePrank(address(11));
+        sortedOracles.report(token, fixed1*10, oracle, address(0));
+
+        changePrank(owner);
+        sortedOracles.removeExpiredReports(token,6);
+        assertEq(sortedOracles.numTimestamps(token), 2);
+    }
+
+    function test_removeExpiredReports_whenNLargerThanNumberOfTimestamps_shouldRevert() public {
+        submitNReports(5);
+        vm.expectRevert("token addr null or trying to remove too many reports");
+        sortedOracles.removeExpiredReports(token,7);
+    }
+
+    function test_removeExpiredReports_whenNReportsAreExpired_shouldRemoveNReports() public {
+        submitNReports(6);
+        skip(aReportExpiry);
+        sortedOracles.removeExpiredReports(token,5);
+        assertEq(sortedOracles.numTimestamps(token), 1);
+    }
+}
+
+
+contract SortedOracles_isOldestReportExpired is SortedOraclesTest {
+
+    function test_isOldestReportExpired_whenNoReportsExist_shouldReturnTrue() public{
+        //added this skip because foundry starts at a block time of 0 
+        //without the skip isOldestReortExpired would return false when no reports exist 
+        skip(aReportExpiry);
+        sortedOracles.addOracle(token, oracle);
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertTrue(isReportExpired);
+    }
+
+    function test_isOldestReportExpired_whenReportIsExpired_shouldReturnTrue() public {
+        submitNReports(1);
+        skip(aReportExpiry);
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertTrue(isReportExpired);
+    }
+
+    function test_isOldestReportExpired_whenReportIsntExpired_shouldReturnFalse() public {
+        submitNReports(1);
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertFalse(isReportExpired);
+    }
+
+    function test_isOldestReportExpired_whenTokenSpecificExpiryIsntExceeded_shoulReturnFalse() public {
+        submitNReports(1);
+        sortedOracles.setTokenReportExpiry(token, aReportExpiry*2);
+        //neither general nor specific Expiry expired 
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertFalse(isReportExpired);
+        //general Expiry expired but not specific
+        skip(aReportExpiry);
+        (isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertFalse(isReportExpired);
+    }
+
+    function test_isOldestReportExpired_whenSpecificTokenExpiryIsExceeded_shouldReturnTrue() public {
+        submitNReports(1);
+        sortedOracles.setTokenReportExpiry(token, aReportExpiry*2);
+        skip(aReportExpiry*2);
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertTrue(isReportExpired);
+    }
+
+    function test_isOldestReportExpired_whenSpecificExpiryIsLowerButNotExpired_shouldReturnFalse() public {
+        submitNReports(1);
+        sortedOracles.setTokenReportExpiry(token, aReportExpiry * 1/2);
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertFalse(isReportExpired);
+    }
+
+    function test_isOldestReportExpired_whenSpecificExpiryIsLowerAndGeneralExpiryIsExceeded_shouldReturnTrue() public {
+        submitNReports(1);
+        sortedOracles.setTokenReportExpiry(token, aReportExpiry * 1/2);
+        skip(aReportExpiry);
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertTrue(isReportExpired);
+    }
+
+     function test_isOldestReportExpired_whenSpecificExpiryIsLowerAndSpecificExpiryIsExceeded_shouldReturnTrue() public {
+        submitNReports(1);
+        sortedOracles.setTokenReportExpiry(token, aReportExpiry * 1/2);
+        skip(aReportExpiry*1/2);
+        (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+        assertTrue(isReportExpired);
+    }
+
+}
+
+contract SortedOracles_report is SortedOraclesTest {
+
+    function test_report_shouldIncreaseTheNumberOfRates() public {
+        assertEq(sortedOracles.numRates(token), 0);
+        submitNReports(1);
+        assertEq(sortedOracles.numRates(token), 1);
+    }
+
+    function test_report_shouldSetTheMedianRate() public{
+        sortedOracles.addOracle(token, oracle);
+        changePrank(oracle);
+        sortedOracles.report(token, fixed1*10, address(0), address(0));
+        (uint256 numerator,uint256 denominator) = sortedOracles.medianRate(token);
+        assertEq(numerator, fixed1*10);
+        assertEq(denominator, fixed1);
+    }
+
+    function test_report_shouldIncreaseTheNumberOfTimestamps() public {
+        assertEq(sortedOracles.numTimestamps(token), 0);
+        submitNReports(1);
+        assertEq(sortedOracles.numTimestamps(token), 1);
+    }
+
+    function test_report_shouldSetTheMedianTimestamp() public {
+        submitNReports(1);
+        assertEq(block.timestamp, sortedOracles.medianTimestamp(token));
+    }
+
+    function test_report_shouldEmitTheOracleReportedAndMedianUpdatedEvent() public {
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit OracleReported(token, oracle, block.timestamp, fixed1*10);
+        vm.expectEmit(true, true, true, true, address(sortedOracles));
+        emit MedianUpdated(token, fixed1*10);
+        submitNReports(1);
+    }
+
+    function test_report_whenCalledByNonOracle_shouldRevert() public {
+        changePrank(rando);
+        vm.expectRevert("sender was not an oracle for token addr");
+        sortedOracles.report(token, fixed1, address(0), address(0));
+    }
+
+    function test_report_whenOneReportBySameOracleExists_shouldResetMedianRate() public {
+        submitNReports(1);
+        (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(token);
+        assertEq(numerator, fixed1*10);
+        assertEq(denominator, fixed1);
+
+        changePrank(oracle);
+        sortedOracles.report(token, fixed1*20, address(0), address(0));
+        (numerator, denominator) = sortedOracles.medianRate(token);
+        assertEq(numerator, fixed1*20);
+        assertEq(denominator, fixed1);
+    }
+
+    function test_report_whenOneReportBySameOracleExists_shouldNotChangeNumberOfTotalReports() public {
+        submitNReports(1);
+        uint256 initialNumberOfReports = sortedOracles.numRates(token);
+        changePrank(oracle);
+        sortedOracles.report(token, fixed1*20, address(0), address(0));
+        assertEq(initialNumberOfReports,sortedOracles.numRates(token));
+    }
+
+    function test_report_whenMultipleReportsExistTheMostRecent_shouldUpdateListOfRatesCorrectly() public {
+        address anotherOracle = address(5);
+        uint256 oracleValue1 = fixed1;
+        uint256 oracleValue2 = fixed1*2;
+        uint256 oracleValue3 = fixed1*3;
+        sortedOracles.addOracle(token,anotherOracle);
+        sortedOracles.addOracle(token,oracle);
+
+        changePrank(anotherOracle);
+        sortedOracles.report(token, oracleValue1, address(0), address(0));
+        changePrank(oracle);
+        sortedOracles.report(token, oracleValue2, anotherOracle, address(0));
+
+        //confirm correct setUp
+        changePrank(owner);
+        (address[] memory oracles, uint256[] memory rates, ) = sortedOracles.getRates(token);
+        assertEq(oracle, oracles[0]);
+        assertEq(oracleValue2, rates[0]);
+        assertEq(anotherOracle, oracles[1]);
+        assertEq(oracleValue1, rates[1]);
+
+        changePrank(oracle);
+        sortedOracles.report(token, oracleValue3, anotherOracle, address(0));
+
+        changePrank(owner);
+        (oracles, rates, ) = sortedOracles.getRates(token);
+        assertEq(oracle, oracles[0]);
+        assertEq(oracleValue3, rates[0]);
+        assertEq(anotherOracle, oracles[1]);
+        assertEq(oracleValue1, rates[1]);
+    }
+
+    function test_report_whenMultipleReportsExistTheMostRecent_shouldUpdateTimestampsCorrectly() public{
+        address anotherOracle = address(5);
+        uint256 oracleValue1 = fixed1;
+        uint256 oracleValue2 = fixed1*2;
+        uint256 oracleValue3 = fixed1*3;
+        sortedOracles.addOracle(token,anotherOracle);
+        sortedOracles.addOracle(token,oracle);
+
+
+        changePrank(anotherOracle);
+        uint256 timestamp0 = block.timestamp;
+        sortedOracles.report(token, oracleValue1, address(0), address(0));
+        skip(5);
+
+        uint256 timestamp1 = block.timestamp;
+        changePrank(oracle);
+        sortedOracles.report(token, oracleValue2, anotherOracle, address(0));
+        skip(5);
+
+        //confirm correct setUp
+        changePrank(owner);
+        (address[] memory oracles, uint256[] memory timestamps, ) = sortedOracles.getTimestamps(token);
+        assertEq(oracle, oracles[0]);
+        assertEq(timestamp1, timestamps[0]);
+        assertEq(anotherOracle, oracles[1]);
+        assertEq(timestamp0, timestamps[1]);
+
+        
+        changePrank(oracle);
+        uint256 timestamp3 = block.timestamp;
+        sortedOracles.report(token, oracleValue3, anotherOracle, address(0));
+
+        changePrank(owner);
+        (oracles, timestamps, ) = sortedOracles.getTimestamps(token);
+        assertEq(oracle, oracles[0]);
+        assertEq(timestamp3, timestamps[0]);
+
+        assertEq(anotherOracle, oracles[1]);
+        assertEq(timestamp0, timestamps[1]);
+        
+    }
+}

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.13;
+
+contract MockERC20 {
+  string private _name;
+  string private _symbol;
+
+  constructor(string memory name_, string memory symbol_) public {
+    _name = name_;
+    _symbol = symbol_;
+  }
+
+  function name() public view returns (string memory) {
+    return _name;
+  }
+
+  function symbol() public view returns (string memory) {
+    return _symbol;
+  }
+}

--- a/test/mocks/MockPricingModule.sol
+++ b/test/mocks/MockPricingModule.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.13;
+
+import { IPricingModule } from "contracts/interfaces/IPricingModule.sol";
+
+contract MockPricingModule is IPricingModule {
+  string private _name;
+
+  constructor(string memory name_) public {
+    _name = name_;
+  }
+
+  function name() external view returns (string memory) {
+    return _name;
+  }
+
+  function getAmountOut(
+    uint256,
+    uint256,
+    uint256,
+    uint256
+  ) external view returns (uint256) {
+    return 0;
+  }
+
+  function getAmountIn(
+    uint256,
+    uint256,
+    uint256,
+    uint256
+  ) external view returns (uint256) {
+    return 0;
+  }
+}

--- a/test/mocks/MockReserve.sol
+++ b/test/mocks/MockReserve.sol
@@ -7,45 +7,60 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
  * @title A mock Reserve for testing.
  */
 contract MockReserve {
-    mapping(address => bool) public tokens;
+  mapping(address => bool) public tokens;
+  mapping(address => bool) public collateralAssets;
 
-    IERC20 public goldToken;
+  IERC20 public goldToken;
 
-    // solhint-disable-next-line no-empty-blocks
-    function() external payable {}
+  // solhint-disable-next-line no-empty-blocks
+  function() external payable {}
 
-    function setGoldToken(address goldTokenAddress) external {
-        goldToken = IERC20(goldTokenAddress);
-    }
+  function setGoldToken(address goldTokenAddress) external {
+    goldToken = IERC20(goldTokenAddress);
+  }
 
-    function transferGold(address to, uint256 value) external returns (bool) {
-        require(goldToken.transfer(to, value), "gold token transfer failed");
-        return true;
-    }
+  function transferGold(address to, uint256 value) external returns (bool) {
+    require(goldToken.transfer(to, value), "gold token transfer failed");
+    return true;
+  }
 
-    function transferExchangeGold(address to, uint256 value) external returns (bool) {
-        require(goldToken.transfer(to, value), "gold token transfer failed");
-        return true;
-    }
+  function transferExchangeGold(address to, uint256 value) external returns (bool) {
+    require(goldToken.transfer(to, value), "gold token transfer failed");
+    return true;
+  }
 
-    function addToken(address token) external returns (bool) {
-        tokens[token] = true;
-        return true;
-    }
+  function transferCollateralAsset(
+    address tokenAddress,
+    address payable to,
+    uint256 amount
+  ) external returns (bool) {
+    require(IERC20(tokenAddress).transfer(to, amount), "asset transfer failed");
+    return true;
+  }
 
-    function burnToken(address) external pure returns (bool) {
-        return true;
-    }
+  function addToken(address token) external returns (bool) {
+    tokens[token] = true;
+    return true;
+  }
 
-    function getUnfrozenReserveGoldBalance() external view returns (uint256) {
-        return address(this).balance;
-    }
+  function addCollateralAsset(address token) external returns (bool) {
+    collateralAssets[token] = true;
+    return true;
+  }
 
-    function isStableAsset(address) external view returns (bool) {
-        return false;
-    }
+  function burnToken(address) external pure returns (bool) {
+    return true;
+  }
 
-    function isCollateralAsset(address) external view returns (bool) {
-        return false;
-    }
+  function getUnfrozenReserveGoldBalance() external view returns (uint256) {
+    return address(this).balance;
+  }
+
+  function isStableAsset(address token) external view returns (bool) {
+    return tokens[token];
+  }
+
+  function isCollateralAsset(address token) external view returns (bool) {
+    return collateralAssets[token];
+  }
 }


### PR DESCRIPTION
### Description
- migrated the SortedOracles test from the celo mono-repo to foundry 

### Other changes
- fixed an off by one error in the Exchange.t.sol
- before the amount had a range from `[0 - sellerCeloBalance]` using Fuzz testing 
- in the case of the amount being equal to `sellerCeloBalance` the call isn't failing because the `'transfer value exceeded sender's allowance for recipient'` but because the `'transfer value exceeded balance of sender'`

### Related issues
- Fixes #[18] [Ticket](https://github.com/orgs/mento-protocol/projects/5/views/1)