### PR TITLE
feat: make broker capable of minting and burning STs

### DIFF
--- a/contracts/StableToken.sol
+++ b/contracts/StableToken.sol
@@ -42,6 +42,7 @@ contract StableToken is
     event TransferComment(string comment);
 
     bytes32 constant GRANDA_MENTO_REGISTRY_ID = keccak256(abi.encodePacked("GrandaMento"));
+    bytes32 constant BROKER_REGISTRY_ID = keccak256(abi.encodePacked("Broker"));
 
     string internal name_;
     string internal symbol_;
@@ -233,7 +234,8 @@ contract StableToken is
         require(
             msg.sender == registry.getAddressForOrDie(getExchangeRegistryId()) ||
                 msg.sender == registry.getAddressFor(VALIDATORS_REGISTRY_ID) ||
-                msg.sender == registry.getAddressFor(GRANDA_MENTO_REGISTRY_ID),
+                msg.sender == registry.getAddressFor(GRANDA_MENTO_REGISTRY_ID)||
+                msg.sender == registry.getAddressFor(BROKER_REGISTRY_ID),
             "Sender not authorized to mint"
         );
         return _mint(to, value);
@@ -281,7 +283,8 @@ contract StableToken is
     function burn(uint256 value) external updateInflationFactor returns (bool) {
         require(
             msg.sender == registry.getAddressForOrDie(getExchangeRegistryId()) ||
-                msg.sender == registry.getAddressFor(GRANDA_MENTO_REGISTRY_ID),
+                msg.sender == registry.getAddressFor(GRANDA_MENTO_REGISTRY_ID)||
+                msg.sender == registry.getAddressFor(BROKER_REGISTRY_ID),
             "Sender not authorized to burn"
         );
         uint256 units = _valueToUnits(inflationState.factor, value);

--- a/test/utils/McMintIntegration.sol
+++ b/test/utils/McMintIntegration.sol
@@ -52,6 +52,7 @@ contract McMintIntegration is Test, WithRegistry {
   address cUSD_USDCet_oracleReportTarget;
   address cEUR_USDCet_oracleReportTarget;
   address cUSD_cEUR_oracleReportTarget;
+  address exchange;
 
   bytes32 pair_cUSD_CELO_ID;
   bytes32 pair_cEUR_CELO_ID;
@@ -67,6 +68,7 @@ contract McMintIntegration is Test, WithRegistry {
     changePrank(actor("deployer"));
     celoToken = new Token("Celo", "cGLD", 18);
     usdcToken = new Token("USDCet", "USDCet", 18);
+    exchange = address(21);
 
     address[] memory initialAddresses = new address[](0);
     uint256[] memory initialBalances = new uint256[](0);
@@ -81,7 +83,7 @@ contract McMintIntegration is Test, WithRegistry {
       60 * 60 * 24 * 7,
       initialAddresses,
       initialBalances,
-      "Broker"
+      "Exchange"
     );
 
     cEURToken = new StableToken(true);
@@ -94,11 +96,12 @@ contract McMintIntegration is Test, WithRegistry {
       60 * 60 * 24 * 7,
       initialAddresses,
       initialBalances,
-      "Broker"
+      "Exchange"
     );
 
     vm.label(address(cUSDToken), "cUSD");
     vm.label(address(cEURToken), "cEUR");
+    registry.setAddressFor("Exchange", address(exchange));
 
     /* ===== Deploy reserve ===== */
 


### PR DESCRIPTION
### Description

- added the `BROKER_REGISTRY_ID` to the StableToken contract 
- both `mint()` and `burn()` now also check whether the caller is the broker address from the registry
- thereby allowing a registered broker to mint and burn 

### Tested

- the integration test mentioned in the acceptance criteria has not been migrated yet and therefore needs to be updated later on

### Related issues

- Fixes #32 

