### PR TITLE
chore: revert codebase to pre StableToken bucket cap

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "openzeppelin-solidity/contracts/math/Math.sol";
 import "./interfaces/IExchange.sol";
 import "./interfaces/ISortedOracles.sol";
 import "./interfaces/IReserve.sol";
@@ -35,10 +34,8 @@ contract Exchange is
     event MinimumReportsSet(uint256 minimumReports);
     event StableTokenSet(address indexed stable);
     event SpreadSet(uint256 spread);
-    event StableBucketMaxFractionSet(uint256 stableBucketMaxFraction);
     event ReserveFractionSet(uint256 reserveFraction);
     event BucketsUpdated(uint256 goldBucket, uint256 stableBucket);
-    event MinSupplyForStableBucketCapSet(uint256 minSupplyForStableBucketCap);
 
     FixidityLib.Fraction public spread;
 
@@ -58,9 +55,6 @@ contract Exchange is
     uint256 public minimumReports;
 
     bytes32 public stableTokenRegistryId;
-
-    uint256 public minSupplyForStableBucketCap;
-    FixidityLib.Fraction public stableBucketMaxFraction;
 
     modifier updateBucketsIfNecessary() {
         _updateBucketsIfNecessary();
@@ -84,7 +78,7 @@ contract Exchange is
             uint256
         )
     {
-        return (1, 3, 0, 0);
+        return (1, 2, 0, 0);
     }
 
     /**
@@ -104,9 +98,6 @@ contract Exchange is
      * @param _minimumReports The minimum number of fresh reports that need to be
      * present in the oracle to update buckets
      * commit to the gold bucket
-     * @param _minSupplyForStableBucketCap The minimum amount of stabletoken supply
-     * considered for the stable token bucket cap
-     * @param _stableBucketMaxFraction The value for stable bucket Fraction CAP
      */
     function initialize(
         address registryAddress,
@@ -114,9 +105,7 @@ contract Exchange is
         uint256 _spread,
         uint256 _reserveFraction,
         uint256 _updateFrequency,
-        uint256 _minimumReports,
-        uint256 _minSupplyForStableBucketCap,
-        uint256 _stableBucketMaxFraction
+        uint256 _minimumReports
     ) external initializer {
         _transferOwnership(msg.sender);
         setRegistry(registryAddress);
@@ -125,8 +114,6 @@ contract Exchange is
         setReserveFraction(_reserveFraction);
         setUpdateFrequency(_updateFrequency);
         setMinimumReports(_minimumReports);
-        setMinSupplyForStableBucketCap(_minSupplyForStableBucketCap);
-        setStableBucketMaxFraction(_stableBucketMaxFraction);
     }
 
     /**
@@ -325,17 +312,6 @@ contract Exchange is
     }
 
     /**
-     * @notice Allows owner to set the Stable Bucket Fraction Cap
-     * @param newStableBucketMaxFraction The new value for the Stable Bucket Fraction CAP
-     */
-    function setStableBucketMaxFraction(uint256 newStableBucketMaxFraction) public onlyOwner {
-        stableBucketMaxFraction = FixidityLib.wrap(newStableBucketMaxFraction);
-        require(stableBucketMaxFraction.lt(FixidityLib.fixed1()), "Bucket fraction must be smaller than 1");
-        require(newStableBucketMaxFraction > 0, "bucket fraction must be greather than 0");
-        emit StableBucketMaxFractionSet(newStableBucketMaxFraction);
-    }
-
-    /**
      * @notice Allows owner to set the Reserve Fraction
      * @param newReserveFraction The new value for the reserve fraction
      */
@@ -343,17 +319,6 @@ contract Exchange is
         reserveFraction = FixidityLib.wrap(newReserveFraction);
         require(reserveFraction.lt(FixidityLib.fixed1()), "reserve fraction must be smaller than 1");
         emit ReserveFractionSet(newReserveFraction);
-    }
-
-    /**
-     * @notice Allows owner to set the minSupplyForStableBucketCap,
-     *  the minimal stableToken supply considered for the stableToken cap
-     * @param newMinSupplyForStableBucketCap The new value for the minSupplyForStableBucketCap
-     */
-    function setMinSupplyForStableBucketCap(uint256 newMinSupplyForStableBucketCap) public onlyOwner {
-        minSupplyForStableBucketCap = newMinSupplyForStableBucketCap;
-        require(newMinSupplyForStableBucketCap > 0, "Min supply for stable bucket cap must be greather than 0");
-        emit MinSupplyForStableBucketCapSet(newMinSupplyForStableBucketCap);
     }
 
     function _setStableToken(address newStableToken) internal {
@@ -435,26 +400,7 @@ contract Exchange is
         uint256 exchangeRateDenominator;
         (exchangeRateNumerator, exchangeRateDenominator) = getOracleExchangeRate();
         uint256 updatedStableBucket = exchangeRateNumerator.mul(updatedGoldBucket).div(exchangeRateDenominator);
-        uint256 maxStableBucketSize = getStableBucketCap();
-        // Check if the bucket is bigger that the cap
-        if (updatedStableBucket > maxStableBucketSize) {
-            // Resize down CELO bucket
-            uint256 cappedUpdatedGoldBucket = exchangeRateDenominator.mul((maxStableBucketSize)).div(
-                exchangeRateNumerator
-            );
-            return (cappedUpdatedGoldBucket, maxStableBucketSize);
-        }
         return (updatedGoldBucket, updatedStableBucket);
-    }
-
-    /**
-     * @notice returns the max size the stableToken can be set during a bucket update.
-     * if the supply of stableToken is smaller than minSupplyForStableBucketCap,
-     * the cap is calculated based on minSupplyForStableBucketCap.
-     */
-    function getStableBucketCap() public view returns (uint256) {
-        uint256 stableTokenSupply = Math.max(IERC20(stable).totalSupply(), minSupplyForStableBucketCap);
-        return FixidityLib.newFixed(stableTokenSupply).multiply(stableBucketMaxFraction).fromFixed();
     }
 
     function getUpdatedGoldBucket() private view returns (uint256) {

--- a/contracts/ExchangeBRL.sol
+++ b/contracts/ExchangeBRL.sol
@@ -27,6 +27,6 @@ contract ExchangeBRL is Exchange {
             uint256
         )
     {
-        return (1, 3, 0, 0);
+        return (1, 2, 0, 0);
     }
 }

--- a/contracts/ExchangeEUR.sol
+++ b/contracts/ExchangeEUR.sol
@@ -27,6 +27,6 @@ contract ExchangeEUR is Exchange {
             uint256
         )
     {
-        return (1, 3, 0, 0);
+        return (1, 2, 0, 0);
     }
 }

--- a/contracts/interfaces/IExchange.sol
+++ b/contracts/interfaces/IExchange.sol
@@ -26,6 +26,4 @@ interface IExchange {
     function getSellTokenAmount(uint256, bool) external view returns (uint256);
 
     function getBuyAndSellBuckets(bool) external view returns (uint256, uint256);
-
-    function getStableBucketCap() external view returns (uint256);
 }

--- a/test/Exchange.t.sol
+++ b/test/Exchange.t.sol
@@ -29,8 +29,6 @@ contract ExchangeTest is Test, WithRegistry, TokenHelpers {
     event SpreadSet(uint256 spread);
     event ReserveFractionSet(uint256 reserveFraction);
     event BucketsUpdated(uint256 celoBucket, uint256 stableBucket);
-    event StableBucketMaxFractionSet(uint256 stableBucketMaxFraction);
-    event MinSupplyForStableBucketCapSet(uint256 minSupplyForStableBucketCap);
 
     address deployer;
     address rando;
@@ -50,8 +48,6 @@ contract ExchangeTest is Test, WithRegistry, TokenHelpers {
     uint256 constant stableAmountForRate = 2000000000000000000000000;
     uint256 initialStableBucket = initialCeloBucket * 2;
     FixidityLib.Fraction spread = FixidityLib.newFixedFraction(3, 1000);
-    uint256 constant minSupplyForStableBucketCap = 1e24;
-    uint256 constant stableBucketMaxFraction = 45454545454545456000000;
 
     function setUp() public {
         deployer = actor("deployer");
@@ -103,9 +99,7 @@ contract ExchangeTest is Test, WithRegistry, TokenHelpers {
             FixidityLib.unwrap(spread),
             FixidityLib.unwrap(reserveFraction),
             bucketUpdateFrequency,
-            2,
-            minSupplyForStableBucketCap,
-            stableBucketMaxFraction
+            2
         );
     }
 
@@ -171,9 +165,7 @@ contract Exchange_initializeAndSetters is ExchangeTest {
             FixidityLib.unwrap(FixidityLib.newFixedFraction(3, 1000)),
             FixidityLib.unwrap(FixidityLib.newFixedFraction(5, 100)),
             60 * 60,
-            2,
-            minSupplyForStableBucketCap,
-            stableBucketMaxFraction
+            2
         );
     }
 
@@ -269,93 +261,12 @@ contract Exchange_initializeAndSetters is ExchangeTest {
         vm.expectRevert("Ownable: caller is not the owner");
         exchange.setReserveFraction(0);
     }
-
-    function test_StableBucketMaxFraction_setsValueAndEmits() public {
-        uint256 newStableBucketMaxFraction = 90909090909090910000000;
-        vm.expectEmit(true, true, true, true, address(exchange));
-        emit StableBucketMaxFractionSet(newStableBucketMaxFraction);
-        exchange.setStableBucketMaxFraction(newStableBucketMaxFraction);
-        assert(exchange.stableBucketMaxFraction() == newStableBucketMaxFraction);
-    }
-
-    function test_StableBucketMaxFraction_NeverMoreThan1_AlwaysLessThan0() public {
-        vm.expectRevert("Bucket fraction must be smaller than 1");
-        exchange.setStableBucketMaxFraction(1e24);
-        vm.expectRevert("bucket fraction must be greather than 0");
-        exchange.setStableBucketMaxFraction(0);
-    }
-
-    function test_setstableBucketMaxFraction_isOnlyCallableByOwner() public {
-        changePrank(rando);
-        vm.expectRevert("Ownable: caller is not the owner");
-        exchange.setStableBucketMaxFraction(0);
-    }
-
-    function test_StableBucketMinSupply_setsValueAndEmits() public {
-        uint256 newMinSupplyForStableBucketCap = 2e24;
-        vm.expectEmit(true, true, true, true, address(exchange));
-        emit MinSupplyForStableBucketCapSet(newMinSupplyForStableBucketCap);
-        exchange.setMinSupplyForStableBucketCap(newMinSupplyForStableBucketCap);
-        assert(exchange.minSupplyForStableBucketCap() == newMinSupplyForStableBucketCap);
-    }
-
-    function test_setMinSupplyForStableBucketCap_NeverSetTo0() public {
-        vm.expectRevert("Min supply for stable bucket cap must be greather than 0");
-        exchange.setMinSupplyForStableBucketCap(0);
-    }
-
-    function test_setMinSupplyForStableBucketCap_isOnlyCallableByOwner() public {
-        changePrank(rando);
-        vm.expectRevert("Ownable: caller is not the owner");
-        exchange.setMinSupplyForStableBucketCap(0);
-    }
 }
 
 contract ExchangeTest_stableActivated is ExchangeTest {
     function setUp() public {
         super.setUp();
         exchange.activateStable();
-    }
-}
-
-contract ExchangeTest_stableBucket_hasBeenCapped is ExchangeTest {
-    function setUp() public {
-        super.setUp();
-        // bump the price by 2000, leaving with 4K CELO per dollar
-        sortedOracles.setMedianRate(address(stableToken), SafeMath.mul(2e24, 2000));
-        exchange.activateStable();
-    }
-
-    function test_itHasTheRightPrice_AfterTheCap() public {
-        (uint256 tradableGold, uint256 mintableStable) = exchange.getBuyAndSellBuckets(false);
-        assertEq(SafeMath.div(mintableStable, tradableGold), 4000);
-    }
-}
-
-contract ExchangeTest_stableBucket_needsToBeCapped is ExchangeTest {
-    function setUp() public {
-        super.setUp();
-        registry.setAddressFor("Exchange", exchange.owner());
-        sortedOracles.setMedianRate(address(stableToken), 2e24);
-        stableToken.mint(deployer, 61e24); // 6M
-        registry.setAddressFor("Exchange", address(exchange));
-        exchange.activateStable();
-    }
-
-    function test_hasCorrect_stableBucketMaxFraction() public {
-        assertEq(exchange.stableBucketMaxFraction(), 45454545454545456000000);
-    }
-
-    function test_DoesntHitTheCap_shouldNotResize() public {
-        (uint256 tradableGold, uint256 mintableStable) = exchange.getBuyAndSellBuckets(false);
-        assertEq(mintableStable, 1e21);
-        assertEq(tradableGold, 5e20);
-        // the buckets hold the price
-        assertEq(SafeMath.div(mintableStable, tradableGold), 2);
-    }
-
-    function test_HasCorrectGetStableBucketCap() public {
-        assert(exchange.getStableBucketCap() == 2772727272727272816000000);
     }
 }
 


### PR DESCRIPTION
### Description

hotfix: revert codebase to StableToken bucket cap 
 - cherry-picked Ninas [commit](https://github.com/mento-protocol/mento-core/pull/45/commits/0850ada75fa5f8b51efe51ff91ca582999fdb98f) from develop to also apply changes on main

### Related issues

- Fixes #45 