### PR TITLE
feat(broker): trading limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 **/cache
 **/node_modules
 **/out
+.vscode/
 
 # files
 *.env

--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -31,6 +31,8 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
   // Address of the reserve.
   IReserve public reserve;
 
+  uint256 private constant MAX_INT256 = uint256(-1) / 2;
+
   /* ==================== Constructor ==================== */
 
   /**
@@ -264,6 +266,9 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
   ) internal {
     bytes32 tokenIn = bytes32(uint256(uint160(_tokenIn)));
     bytes32 tokenOut = bytes32(uint256(uint160(_tokenOut)));
+    require(amountIn <= uint256(MAX_INT256), "amountIn too large");
+    require(amountOut <= uint256(MAX_INT256), "amountOut too large");
+
 
     guardTradingLimit(
       exchangeId ^ tokenIn,

--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -283,9 +283,9 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
   }
 
   function guardTradingLimit(bytes32 tradingLimitId, int256 deltaFlow, address token) internal {
-    TradingLimits.State memory tradingLimitState = tradingLimitsState[tradingLimitId];
     TradingLimits.Config memory tradingLimitConfig = tradingLimitsConfig[tradingLimitId];
     if (tradingLimitConfig.flags > 0) {
+      TradingLimits.State memory tradingLimitState = tradingLimitsState[tradingLimitId];
       tradingLimitState = tradingLimitState.update(
         tradingLimitConfig, 
         deltaFlow, 

--- a/contracts/common/TradingLimits.sol
+++ b/contracts/common/TradingLimits.sol
@@ -1,0 +1,100 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+library TradingLimits {
+    uint8 private constant L0 = 1; // 0b001 Limit0
+    uint8 private constant L1 = 2; // 0b010 Limit1
+    uint8 private constant LG = 4; // 0b100 LimitGlobal
+
+    struct Data {
+        uint32 timestep0;
+        uint32 lastUpdated0;
+        int48 limit0;
+        int48 netflow0;
+        uint32 timestep1;
+        uint32 lastUpdated1;
+        int48 limit1;
+        int48 netflow1;
+        int48 limitGlobal;
+        int48 netflowGlobal;
+        uint8 flags;
+    }
+
+    function configure(Data memory self, Data memory config) internal view  returns (Data memory) {
+        require(
+            config.flags & L0 == 0 || config.timestep0 > 0, 
+            "timestep0 can't be zero if active"
+        );
+        require(
+            config.flags & L1 == 0 || config.timestep1 > 0, 
+            "timestep1 can't be zero if active"
+        );
+
+        if (config.flags & L0 > 0) {
+            self.timestep0 = config.timestep0;
+            self.lastUpdated0 = uint32(block.timestamp);
+            self.limit0 = config.limit0;
+            self.netflow0 = 0;
+        } else {
+            self.timestep0 = 0;
+            self.lastUpdated0 = 0;
+            self.limit0 = 0;
+            self.netflow0 = 0;
+        }
+
+        if (config.flags & L1 > 0)  {
+            self.timestep1 = config.timestep1;
+            self.lastUpdated1 = uint32(block.timestamp);
+            self.limit1 = config.limit1;
+            self.netflow1 = 0;
+        } else {
+            self.timestep1 = 0;
+            self.lastUpdated1 = 0;
+            self.limit1 = 0;
+            self.netflow1 = 0;
+        }
+
+        if (config.flags & LG > 0) {
+            self.limitGlobal = config.limitGlobal;
+        } else {
+            self.limitGlobal = 0;
+        }
+
+        self.flags = config.flags;
+        return self;
+    }
+
+    function update(Data memory self, int256 _deltaFlow, uint8 decimals) internal view returns (Data memory) {
+        int48 deltaFlow = int48(_deltaFlow / int256((10 ** uint256(decimals))));
+
+        if (block.timestamp > self.lastUpdated0 + self.timestep0) {
+            self.netflow0 = 0;
+            self.lastUpdated0 = uint32(block.timestamp);
+        }
+        if (block.timestamp > self.lastUpdated1 + self.timestep1) {
+            self.netflow1 = 0;
+            self.lastUpdated1 = uint32(block.timestamp);
+        }
+
+        self.netflow0 += (self.flags & L0) * deltaFlow;
+        self.netflow1 += (self.flags & L1) * deltaFlow;
+        self.netflowGlobal += (self.flags & LG) * deltaFlow;
+        return self;
+    }
+
+    function isValid(Data memory self) internal pure returns (bool) {
+        if ((self.flags & L0) > 0 && 
+            (-1 * self.limit0 > self.netflow0 || self.netflow0 > self.limit0)) {
+            revert("L0 Exceeded");
+        }
+        if ((self.flags & L1) > 0 && 
+            (-1 * self.limit1 > self.netflow1 || self.netflow1 > self.limit1)) {
+            revert("L1 Exceeded");
+        }
+        if ((self.flags & LG) > 0 && 
+            (-1 * self.limitGlobal > self.netflowGlobal || self.netflowGlobal > self.limitGlobal)) {
+            revert("LG Exceeded");
+        }
+        return true;
+    }
+}

--- a/contracts/common/TradingLimits.sol
+++ b/contracts/common/TradingLimits.sol
@@ -24,7 +24,7 @@ library TradingLimits {
         uint8 flags;
     }
 
-    function validate(Config memory self) internal view returns (bool) {
+    function validate(Config memory self) internal pure returns (bool) {
         require(
            self.flags & L1 == 0 || self.flags & L0 != 0,
            "L1 without L0 not allowed"

--- a/contracts/common/TradingLimits.sol
+++ b/contracts/common/TradingLimits.sol
@@ -6,95 +6,83 @@ library TradingLimits {
     uint8 private constant L1 = 2; // 0b010 Limit1
     uint8 private constant LG = 4; // 0b100 LimitGlobal
 
-    struct Data {
-        uint32 timestep0;
+    struct State {
         uint32 lastUpdated0;
-        int48 limit0;
-        int48 netflow0;
-        uint32 timestep1;
         uint32 lastUpdated1;
-        int48 limit1;
+        int48 netflow0;
         int48 netflow1;
-        int48 limitGlobal;
         int48 netflowGlobal;
+    }
+
+    struct Config {
+        uint32 timestep0;
+        uint32 timestep1;
+        int48 limit0;
+        int48 limit1;
+        int48 limitGlobal;
         uint8 flags;
     }
 
-    function configure(Data memory self, Data memory config) internal view  returns (Data memory) {
+    function validate(Config memory self) internal view returns (bool) {
         require(
-            config.flags & L0 == 0 || config.timestep0 > 0, 
+           self.flags & L1 == 0 || self.flags & L0 != 0,
+           "L1 without L0 not allowed"
+        );
+        require(
+            self.flags & L0 == 0 || self.timestep0 > 0, 
             "timestep0 can't be zero if active"
         );
         require(
-            config.flags & L1 == 0 || config.timestep1 > 0, 
+            self.flags & L1 == 0 || self.timestep1 > 0, 
             "timestep1 can't be zero if active"
         );
 
-        if (config.flags & L0 > 0) {
-            self.timestep0 = config.timestep0;
-            self.lastUpdated0 = uint32(block.timestamp);
-            self.limit0 = config.limit0;
-            self.netflow0 = 0;
-        } else {
-            self.timestep0 = 0;
-            self.lastUpdated0 = 0;
-            self.limit0 = 0;
-            self.netflow0 = 0;
-        }
-
-        if (config.flags & L1 > 0)  {
-            self.timestep1 = config.timestep1;
-            self.lastUpdated1 = uint32(block.timestamp);
-            self.limit1 = config.limit1;
-            self.netflow1 = 0;
-        } else {
-            self.timestep1 = 0;
-            self.lastUpdated1 = 0;
-            self.limit1 = 0;
-            self.netflow1 = 0;
-        }
-
-        if (config.flags & LG > 0) {
-            self.limitGlobal = config.limitGlobal;
-        } else {
-            self.limitGlobal = 0;
-        }
-
-        self.flags = config.flags;
-        return self;
+        return true;
     }
 
-    function update(Data memory self, int256 _deltaFlow, uint8 decimals) internal view returns (Data memory) {
-        int48 deltaFlow = int48(_deltaFlow / int256((10 ** uint256(decimals))));
-
-        if (block.timestamp > self.lastUpdated0 + self.timestep0) {
-            self.netflow0 = 0;
-            self.lastUpdated0 = uint32(block.timestamp);
-        }
-        if (block.timestamp > self.lastUpdated1 + self.timestep1) {
-            self.netflow1 = 0;
-            self.lastUpdated1 = uint32(block.timestamp);
-        }
-
-        self.netflow0 += (self.flags & L0) * deltaFlow;
-        self.netflow1 += (self.flags & L1) * deltaFlow;
-        self.netflowGlobal += (self.flags & LG) * deltaFlow;
-        return self;
-    }
-
-    function isValid(Data memory self) internal pure returns (bool) {
-        if ((self.flags & L0) > 0 && 
-            (-1 * self.limit0 > self.netflow0 || self.netflow0 > self.limit0)) {
+    function verify(State memory self, Config memory config) internal pure returns (bool) {
+        if ((config.flags & L0) > 0 && 
+            (-1 * config.limit0 > self.netflow0 || self.netflow0 > config.limit0)) {
             revert("L0 Exceeded");
         }
-        if ((self.flags & L1) > 0 && 
-            (-1 * self.limit1 > self.netflow1 || self.netflow1 > self.limit1)) {
+        if ((config.flags & L1) > 0 && 
+            (-1 * config.limit1 > self.netflow1 || self.netflow1 > config.limit1)) {
             revert("L1 Exceeded");
         }
-        if ((self.flags & LG) > 0 && 
-            (-1 * self.limitGlobal > self.netflowGlobal || self.netflowGlobal > self.limitGlobal)) {
+        if ((config.flags & LG) > 0 && 
+            (-1 * config.limitGlobal > self.netflowGlobal || self.netflowGlobal > config.limitGlobal)) {
             revert("LG Exceeded");
         }
         return true;
+    }
+
+    function update(
+        State memory self, 
+        Config memory config, 
+        int256 _deltaFlow, 
+        uint8 decimals
+    ) internal view returns (State memory) {
+        int48 deltaFlow = int48(_deltaFlow / int256((10 ** uint256(decimals))));
+
+        if (config.flags & L0 > 0) {
+            if (block.timestamp > self.lastUpdated0 + config.timestep0) {
+                self.netflow0 = 0;
+                self.lastUpdated0 = uint32(block.timestamp);
+            }
+            self.netflow0 += deltaFlow;
+
+            if (config.flags & L1 > 0) {
+                if (block.timestamp > self.lastUpdated1 + config.timestep1) {
+                    self.netflow1 = 0;
+                    self.lastUpdated1 = uint32(block.timestamp);
+                }
+                self.netflow1 += deltaFlow;
+            }
+        }
+        if (config.flags & LG > 0) {
+            self.netflowGlobal +=  deltaFlow;
+        }
+
+        return self;
     }
 }

--- a/contracts/common/TradingLimits.sol
+++ b/contracts/common/TradingLimits.sol
@@ -1,6 +1,41 @@
 pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
+/**
+ * @title TradingLimits
+ * @author Mento Team
+ * @notice This library provides data structs and utility functions for 
+ * defining and verifying trading limits on the netflow of an asset.
+ * There are three limits that can be defined:
+ * - L0: A timewindow based limit, verifies that that:
+ *       -1 * limit0 <= netflow0 <= limit0.
+ *       for a netflow0 that resets every timespan0 seconds
+ * - L1: A timewindow based limit, verifies that that:
+ *       -1 * limit1 <= netflow1 <= limit1.
+ *       for a netflow1 that resets every timespan0 second
+ * - LG: A global (or lifetime) limit that ensures that:
+ *       -1 * limitGlobal <= netflowGlobal <= limitGlobal,
+ *       for a netflowGlobal that never resets.
+ * @dev All contained functions are pure or view and marked internal to 
+ * be inlined on consuming contracts at compile time for gas efficiency.
+ * Both State and Config structs are designed to be packed in one 
+ * storage slot each.
+ * In order to pack both the state and config into one slot each,
+ * some assumptions are made:
+ * 1. limit{0,1,Global} and netflow{0,1,Global} are recorded with 
+ *    ZERO decimals precision to fit in an int48 each. 
+ *    Any subunit delta in netflow will be rounded up to one unit.
+ * 2. netflow{0,1,Global} have to fit in int48, thus have to fit in the range:
+ *    -140_737_488_355_328 to 140_737_488_355_328, which can cover most
+ *    tokens of interest, but will break down for tokens which trade
+ *    in large unit values.
+ * 3. timespan{0,1} and lastUpdated{0,1} have to fit in int32 therefore
+ *    the timestamps will overflow sometime in the year 2102.
+ *
+ * The library ensures that netflow0 and netflow1 are reset during
+ * the update phase, but does not control how the full State gets
+ * updated if the Config changes, this is left to the library consumer.
+ */
 library TradingLimits {
     uint8 private constant L0 = 1; // 0b001 Limit0
     uint8 private constant L1 = 2; // 0b010 Limit1
@@ -24,7 +59,12 @@ library TradingLimits {
         uint8 flags;
     }
 
-    function validate(Config memory self) internal pure returns (bool) {
+    /**
+     * @notice Validate a trading limit configuration.
+     * @dev Reverts if the configuration is malformed.
+     * @param self the Config struct to check.
+     */
+    function validate(Config memory self) internal pure {
         require(
            self.flags & L1 == 0 || self.flags & L0 != 0,
            "L1 without L0 not allowed"
@@ -37,11 +77,15 @@ library TradingLimits {
             self.flags & L1 == 0 || self.timestep1 > 0, 
             "timestep1 can't be zero if active"
         );
-
-        return true;
     }
 
-    function verify(State memory self, Config memory config) internal pure returns (bool) {
+    /**
+     * @notice Verify a trading limit State with a provided Config.
+     * @dev Reverts if the limits are exceeded.
+     * @param self the trading limit State to check.
+     * @param config the trading limit Config to check against.
+     */
+    function verify(State memory self, Config memory config) internal pure {
         if ((config.flags & L0) > 0 && 
             (-1 * config.limit0 > self.netflow0 || self.netflow0 > config.limit0)) {
             revert("L0 Exceeded");
@@ -54,9 +98,42 @@ library TradingLimits {
             (-1 * config.limitGlobal > self.netflowGlobal || self.netflowGlobal > config.limitGlobal)) {
             revert("LG Exceeded");
         }
-        return true;
     }
 
+    /**
+     * @notice Reset an existing state with a new config.
+     * It keps netflows of enabled limits and resets when disabled.
+     * It resets all timestamp checkpoints to reset time-window limits
+     * on next swap.
+     * @param self the trading limit state to reset.
+     * @param config the updated config to reset against.
+     * @return the reset state.
+     */
+    function reset(State memory self, Config memory config) internal pure returns (State memory) {
+        // Ensure the next swap will reset the trading limits windows.
+        self.lastUpdated0 = 0;
+        self.lastUpdated1 = 0;
+        if (config.flags & L0 == 0) {
+            self.netflow0 = 0;
+        }
+        if (config.flags & L1 == 0) {
+            self.netflow1 = 0;
+        }
+        if (config.flags & LG == 0) {
+            self.netflowGlobal = 0;
+        }
+        return self;
+    }
+
+    /**
+     * @notice  Updates a trading limit State in the context of a Config with the deltaFlow provided.
+     * @dev Reverts if the values provided cause overflows.
+     * @param self the trading limit State to update.
+     * @param config the trading limit Config for the provided State.
+     * @param _deltaFlow the delta flow to add to the netflow.
+     * @param decimals the number of decimals the _deltaFlow is denominated in.
+     * @return State the updated state.
+     */
     function update(
         State memory self, 
         Config memory config, 
@@ -72,20 +149,36 @@ library TradingLimits {
                 self.netflow0 = 0;
                 self.lastUpdated0 = uint32(block.timestamp);
             }
-            self.netflow0 += deltaFlowUnits;
+            self.netflow0 = safeINT48Add(self.netflow0, deltaFlowUnits);
 
             if (config.flags & L1 > 0) {
                 if (block.timestamp > self.lastUpdated1 + config.timestep1) {
                     self.netflow1 = 0;
                     self.lastUpdated1 = uint32(block.timestamp);
                 }
-                self.netflow1 += deltaFlowUnits;
+                self.netflow1 = safeINT48Add(self.netflow1, deltaFlowUnits);
             }
         }
         if (config.flags & LG > 0) {
-            self.netflowGlobal +=  deltaFlowUnits;
+            self.netflowGlobal = safeINT48Add(self.netflowGlobal, deltaFlowUnits);
         }
 
         return self;
+    }
+
+    /**
+     * @notice Safe add two int48s.
+     * @dev Reverts if addition causes over/underflow.
+     * @param a number to add.
+     * @param b number to add.
+     * @return int48 result of addition.
+     */
+    function safeINT48Add(int48 a, int48 b) internal pure returns (int48) {
+        int256 c = int256(a) + int256(b); 
+        require(
+            c >= -1 * MAX_INT48 && c <= MAX_INT48,
+            "int48 addition overflow"
+        );
+        return int48(c);
     }
 }

--- a/contracts/common/interfaces/IERC20Metadata.sol
+++ b/contracts/common/interfaces/IERC20Metadata.sol
@@ -1,0 +1,87 @@
+pragma solidity ^0.5.0;
+
+interface IERC20Metadata {
+      /**
+     * @dev Returns the name of the token.
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token.
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the decimals places of the token.
+     */
+    function decimals() external view returns (uint8);
+
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/test/Broker.t.sol
+++ b/test/Broker.t.sol
@@ -8,13 +8,17 @@ import { IExchangeProvider } from "contracts/interfaces/IExchangeProvider.sol";
 import { IReserve } from "contracts/interfaces/IReserve.sol";
 import { IStableToken } from "contracts/interfaces/IStableToken.sol";
 import { MockStableToken } from "./mocks/MockStableToken.sol";
+import { MockExchangeProvider } from "./mocks/MockExchangeProvider.sol";
 import { MockReserve } from "./mocks/MockReserve.sol";
 import { DummyERC20 } from "./utils/DummyErc20.sol";
 
 import { FixidityLib } from "contracts/common/FixidityLib.sol";
+import { TradingLimits } from "contracts/common/TradingLimits.sol";
 
 // forge test --match-contract Broker -vvv
 contract BrokerTest is Test {
+  using FixidityLib for FixidityLib.Fraction;
+
   event Swap(
     address exchangeProvider,
     bytes32 indexed exchangeId,
@@ -40,7 +44,7 @@ contract BrokerTest is Test {
 
   Broker broker;
 
-  IExchangeProvider exchangeProvider;
+  MockExchangeProvider exchangeProvider;
   address exchangeProvider1 = actor("exchangeProvider1");
   address exchangeProvider2 = actor("exchangeProvider2");
 
@@ -49,11 +53,11 @@ contract BrokerTest is Test {
   function setUp() public {
     /* Dependencies and actors */
     reserve = new MockReserve();
-    collateralAsset = new DummyERC20();
+    collateralAsset = new DummyERC20("Collateral", "CL", 18);
     stableAsset = new MockStableToken();
     randomAsset = actor("randomAsset");
     broker = new Broker(true);
-    exchangeProvider = IExchangeProvider(actor("exchangeProvider"));
+    exchangeProvider = new MockExchangeProvider();
 
     reserve.addToken(address(stableAsset));
     reserve.addCollateralAsset(address(collateralAsset));
@@ -165,36 +169,31 @@ contract BrokerTest_initilizerAndSetters is BrokerTest {
 contract BrokerTest_getAmounts is BrokerTest {
   bytes32 exchangeId = keccak256(abi.encode("exhcangeId"));
 
+  function setUp() public {
+    super.setUp();
+    exchangeProvider.setRate(
+      exchangeId, 
+      address(stableAsset),
+      address(collateralAsset),
+      FixidityLib.newFixedFraction(25, 10).unwrap()
+    );
+  }
+
   function test_getAmountIn_whenExchangeProviderWasNotSet_shouldRevert() public {
     vm.expectRevert("ExchangeProvider does not exist");
     broker.getAmountIn(randomExchangeProvider, exchangeId, address(stableAsset), address(collateralAsset), 1e24);
   }
 
   function test_getAmountIn_whenExchangeProviderIsSet_shouldReceiveCall() public {
-    uint256 amountOut = 1e17;
-    uint256 mockAmountIn = 1e16;
-
-    vm.mockCall(
-      address(exchangeProvider),
-      abi.encodeWithSelector(
-        exchangeProvider.getAmountIn.selector,
-        exchangeId,
-        address(stableAsset),
-        address(collateralAsset),
-        amountOut
-      ),
-      abi.encode(mockAmountIn)
-    );
-
     uint256 amountIn = broker.getAmountIn(
       address(exchangeProvider),
       exchangeId,
       address(stableAsset),
       address(collateralAsset),
-      amountOut
+      1e18
     );
 
-    assertEq(amountIn, mockAmountIn);
+    assertEq(amountIn, 25e17);
   }
 
   function test_getAmountOut_whenExchangeProviderWasNotSet_shouldRevert() public {
@@ -203,19 +202,15 @@ contract BrokerTest_getAmounts is BrokerTest {
   }
 
   function test_getAmountOut_whenExchangeProviderIsSet_shouldReceiveCall() public {
-    uint256 amountIn = 1e17;
-    uint256 mockAmountOut = 1e16;
-
-    vm.mockCall(
+    vm.expectCall(
       address(exchangeProvider),
       abi.encodeWithSelector(
         exchangeProvider.getAmountOut.selector,
         exchangeId,
         address(stableAsset),
         address(collateralAsset),
-        amountIn
-      ),
-      abi.encode(mockAmountOut)
+        1e18
+      )
     );
 
     uint256 amountOut = broker.getAmountOut(
@@ -223,160 +218,159 @@ contract BrokerTest_getAmounts is BrokerTest {
       exchangeId,
       address(stableAsset),
       address(collateralAsset),
-      amountIn
+      1e18
     );
-
-    assertEq(amountOut, mockAmountOut);
+    assertEq(amountOut, 4e17);
   }
 }
 
 contract BrokerTest_swap is BrokerTest {
-  bytes32 exchangeId = keccak256(abi.encode("exhcangeId"));
-
-  function test_swapIn_whenAmoutOutMinNotMet_shouldRevert() public {
-    uint256 amountIn = 1e16;
-    uint256 mockAmountOut = 1e16;
-
-    vm.mockCall(
-      address(exchangeProvider),
-      abi.encodeWithSelector(
-        exchangeProvider.swapIn.selector,
-        exchangeId,
-        address(stableAsset),
-        address(collateralAsset),
-        amountIn
-      ),
-      abi.encode(mockAmountOut)
-    );
-
-    vm.expectRevert("amountOutMin not met");
-    broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), amountIn, 1e17);
+  struct AccountBalanceSnapshot {
+    uint256 stable;
+    uint256 collateral;
   }
 
-  function test_swapOut_whenAmoutInMaxExceeded_shouldRevert() public {
+  struct BalanceSnapshot {
+    AccountBalanceSnapshot trader;
+    AccountBalanceSnapshot reserve;
+    AccountBalanceSnapshot broker;
+  }
+
+  bytes32 exchangeId = keccak256(abi.encode("exhcangeId"));
+
+  function setUp() public {
+    super.setUp();
+    exchangeProvider.setRate(
+      exchangeId, 
+      address(stableAsset),
+      address(collateralAsset),
+      FixidityLib.newFixedFraction(25, 10).unwrap()
+    );
+
+    deal(address(collateralAsset), address(reserve), 1e24);
+    deal(address(collateralAsset), trader, 1e24);
+    stableAsset.mint(trader, 1e22);
+  }
+
+  function makeBalanceSnapshot() internal view returns (BalanceSnapshot memory bs) {
+    bs.trader.stable = stableAsset.balanceOf(trader);
+    bs.trader.collateral = collateralAsset.balanceOf(trader);
+    bs.reserve.stable = stableAsset.balanceOf(address(reserve));
+    bs.reserve.collateral = collateralAsset.balanceOf(address(reserve));
+    bs.broker.stable = stableAsset.balanceOf(address(broker));
+    bs.broker.collateral = collateralAsset.balanceOf(address(broker));
+  }
+
+  function test_swapIn_whenAmountOutMinNotMet_shouldRevert() public {
+    uint256 amountIn = 1e16;
+
+    vm.expectRevert("amountOutMin not met");
+    broker.swapIn(
+      address(exchangeProvider), 
+      exchangeId, 
+      address(stableAsset), 
+      address(collateralAsset),
+      1e16,
+      1e20
+    );
+  }
+
+  function test_swapOut_whenAmountInMaxExceeded_shouldRevert() public {
     uint256 amountOut = 1e16;
     uint256 mockAmountIn = 1e16;
-
-    vm.mockCall(
-      address(exchangeProvider),
-      abi.encodeWithSelector(
-        exchangeProvider.swapOut.selector,
-        exchangeId,
-        address(stableAsset),
-        address(collateralAsset),
-        amountOut
-      ),
-      abi.encode(mockAmountIn)
-    );
 
     vm.expectRevert("amountInMax exceeded");
     broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), amountOut, 1e15);
   }
 
   function test_swapIn_whenTokenInStableAsset_shouldUpdateAndEmit() public {
-    deal(address(collateralAsset), address(reserve), 1e16);
-    deal(address(collateralAsset), trader, 1e16);
-    stableAsset.mint(address(broker), 1e16);
-    stableAsset.mint(address(trader), 1e16);
-
     changePrank(trader);
     uint256 amountIn = 1e16;
-    uint256 mockAmountOut = 1e16;
-
-    vm.mockCall(
-      address(exchangeProvider),
-      abi.encodeWithSelector(
-        exchangeProvider.swapIn.selector,
-        exchangeId,
-        address(stableAsset),
-        address(collateralAsset),
-        amountIn
-      ),
-      abi.encode(mockAmountOut)
+    uint256 expectedAmountOut = exchangeProvider.getAmountOut(
+      exchangeId, 
+      address(stableAsset), 
+      address(collateralAsset), 
+      amountIn
     );
 
+    BalanceSnapshot memory balBefore = makeBalanceSnapshot();
+
     vm.expectEmit(true, true, true, true);
-    emit Swap(address(exchangeProvider), exchangeId, trader, address(stableAsset), address(collateralAsset), amountIn, 1e16);
+    emit Swap(address(exchangeProvider), exchangeId, trader, address(stableAsset), address(collateralAsset), amountIn, expectedAmountOut);
     uint256 amountOut = broker.swapIn(
       address(exchangeProvider),
       exchangeId,
       address(stableAsset),
       address(collateralAsset),
       amountIn,
-      1e16
+      expectedAmountOut
     );
 
-    assertEq(1e16, amountOut);
-    assertEq(stableAsset.balanceOf(trader), 0);
-    assertEq(stableAsset.balanceOf(address(broker)), 1e16);
-    assertEq(IERC20(collateralAsset).balanceOf(trader), 2e16);
-    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 0);
+    BalanceSnapshot memory balAfter = makeBalanceSnapshot();
+    assertEq(amountOut, expectedAmountOut);
+    assertEq(balAfter.trader.stable, balBefore.trader.stable - amountIn);
+    assertEq(balAfter.trader.collateral, balBefore.trader.collateral + expectedAmountOut);
+    assertEq(balAfter.reserve.collateral, balBefore.reserve.collateral - expectedAmountOut);
+    assertEq(balAfter.reserve.stable, 0);
+    assertEq(balAfter.broker.stable, 0);
+    assertEq(balAfter.broker.collateral, 0);
   }
 
   function test_swapIn_whenTokenInCollateralAsset_shouldUpdateAndEmit() public {
-    deal(address(collateralAsset), address(reserve), 1e16);
-    deal(address(collateralAsset), trader, 1e16);
-    stableAsset.mint(address(broker), 1e16);
-    stableAsset.mint(address(trader), 1e16);
-
     changePrank(trader);
-    IERC20(collateralAsset).approve(address(broker), 1e16);
     uint256 amountIn = 1e16;
-    uint256 mockAmountOut = 1e16;
-
-    vm.mockCall(
-      address(exchangeProvider),
-      abi.encodeWithSelector(
-        exchangeProvider.swapOut.selector,
-        exchangeId,
-        address(collateralAsset),
-        address(stableAsset),
-        amountIn
-      ),
-      abi.encode(mockAmountOut)
+    uint256 expectedAmountOut = exchangeProvider.getAmountOut(
+      exchangeId, 
+      address(collateralAsset), 
+      address(stableAsset), 
+      amountIn
     );
 
+    IERC20(collateralAsset).approve(address(broker), amountIn);
+    BalanceSnapshot memory balBefore = makeBalanceSnapshot();
+
     vm.expectEmit(true, true, true, true);
-    emit Swap(address(exchangeProvider), exchangeId, trader, address(collateralAsset), address(stableAsset), amountIn, 1e16);
-    uint256 amountOut = broker.swapOut(
+    emit Swap(
+      address(exchangeProvider), 
+      exchangeId, 
+      trader, 
+      address(collateralAsset), 
+      address(stableAsset), 
+      amountIn, 
+      expectedAmountOut
+    );
+    uint256 amountOut = broker.swapIn(
       address(exchangeProvider),
       exchangeId,
       address(collateralAsset),
       address(stableAsset),
       amountIn,
-      1e16
+      expectedAmountOut
     );
 
-    assertEq(1e16, amountOut);
-    assertEq(IERC20(collateralAsset).balanceOf(trader), 0);
-    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 2e16);
-    assertEq(stableAsset.balanceOf(trader), 2e16);
+    BalanceSnapshot memory balAfter = makeBalanceSnapshot();
+    assertEq(amountOut, expectedAmountOut);
+    assertEq(balAfter.trader.collateral, balBefore.trader.collateral - amountIn);
+    assertEq(balAfter.reserve.collateral, balBefore.reserve.collateral + amountIn);
+    assertEq(balAfter.trader.stable, balBefore.trader.stable + expectedAmountOut);
+    assertEq(balAfter.reserve.stable, 0);
+    assertEq(balAfter.broker.stable, 0);
+    assertEq(balAfter.broker.collateral, 0);
   }
 
   function test_swapOut_whenTokenInStableAsset_shoulUpdateAndEmit() public {
-    deal(address(collateralAsset), address(reserve), 1e16);
-    deal(address(collateralAsset), trader, 1e16);
-    stableAsset.mint(address(broker), 1e16);
-    stableAsset.mint(address(trader), 1e16);
-
     changePrank(trader);
     uint256 amountOut = 1e16;
-    uint256 mockAmountIn = 1e16;
-
-    vm.mockCall(
-      address(exchangeProvider),
-      abi.encodeWithSelector(
-        exchangeProvider.swapOut.selector,
-        exchangeId,
-        address(stableAsset),
-        address(collateralAsset),
-        amountOut
-      ),
-      abi.encode(mockAmountIn)
+    uint256 expectedAmountIn = exchangeProvider.getAmountIn(
+      exchangeId, 
+      address(stableAsset), 
+      address(collateralAsset), 
+      amountOut
     );
 
+    BalanceSnapshot memory balBefore = makeBalanceSnapshot();
     vm.expectEmit(true, true, true, true);
-    emit Swap(address(exchangeProvider), exchangeId, trader, address(stableAsset), address(collateralAsset), amountOut, 1e16);
+    emit Swap(address(exchangeProvider), exchangeId, trader, address(stableAsset), address(collateralAsset), expectedAmountIn, amountOut);
 
     uint256 amountIn = broker.swapOut(
       address(exchangeProvider),
@@ -384,58 +378,95 @@ contract BrokerTest_swap is BrokerTest {
       address(stableAsset),
       address(collateralAsset),
       amountOut,
-      1e16
+      expectedAmountIn
     );
 
-    assertEq(1e16, amountIn);
-    assertEq(stableAsset.balanceOf(trader), 0);
-    assertEq(stableAsset.balanceOf(address(broker)), 1e16);
-    assertEq(IERC20(collateralAsset).balanceOf(trader), 2e16);
-    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 0);
+    BalanceSnapshot memory balAfter = makeBalanceSnapshot();
+    assertEq(amountIn, expectedAmountIn);
+    assertEq(balAfter.trader.collateral, balBefore.trader.collateral + amountOut);
+    assertEq(balAfter.reserve.collateral, balBefore.reserve.collateral - amountOut);
+    assertEq(balAfter.trader.stable, balBefore.trader.stable - expectedAmountIn);
+    assertEq(balAfter.reserve.stable, 0);
+    assertEq(balAfter.broker.stable, 0);
+    assertEq(balAfter.broker.collateral, 0);
   }
 
   function test_swapOut_whenTokenInCollateralAsset_shouldUpdateAndEmit() public {
-    deal(address(collateralAsset), address(reserve), 1e16);
-    deal(address(collateralAsset), trader, 1e16);
-    stableAsset.mint(address(broker), 1e16);
-    stableAsset.mint(address(trader), 1e16);
-
     changePrank(trader);
-    IERC20(collateralAsset).approve(address(broker), 1e16);
     uint256 amountOut = 1e16;
-    uint256 mockAmountIn = 1e16;
-
-    vm.mockCall(
-      address(exchangeProvider),
-      abi.encodeWithSelector(
-        exchangeProvider.swapOut.selector,
-        exchangeId,
-        address(collateralAsset),
-        address(stableAsset),
-        amountOut
-      ),
-      abi.encode(mockAmountIn)
+    uint256 expectedAmountIn = exchangeProvider.getAmountIn(
+      exchangeId, 
+      address(collateralAsset), 
+      address(stableAsset), 
+      amountOut
     );
 
+    IERC20(collateralAsset).approve(address(broker), expectedAmountIn);
+    BalanceSnapshot memory balBefore = makeBalanceSnapshot();
+
     vm.expectEmit(true, true, true, true);
-    emit Swap(address(exchangeProvider), exchangeId, trader, address(collateralAsset), address(stableAsset), amountOut, 1e16);
+    emit Swap(address(exchangeProvider), exchangeId, trader, address(collateralAsset), address(stableAsset), expectedAmountIn, amountOut);
     uint256 amountIn = broker.swapOut(
       address(exchangeProvider),
       exchangeId,
       address(collateralAsset),
       address(stableAsset),
       amountOut,
-      1e16
+      expectedAmountIn
     );
 
-    assertEq(1e16, amountIn);
-    assertEq(IERC20(collateralAsset).balanceOf(trader), 0);
-    assertEq(IERC20(collateralAsset).balanceOf(address(reserve)), 2e16);
-    assertEq(stableAsset.balanceOf(trader), 2e16);
+    BalanceSnapshot memory balAfter = makeBalanceSnapshot();
+    assertEq(amountIn, expectedAmountIn);
+    assertEq(balAfter.trader.collateral, balBefore.trader.collateral - expectedAmountIn);
+    assertEq(balAfter.reserve.collateral, balBefore.reserve.collateral + expectedAmountIn);
+    assertEq(balAfter.trader.stable, balBefore.trader.stable + amountOut);
+    assertEq(balAfter.reserve.stable, 0);
+    assertEq(balAfter.broker.stable, 0);
+    assertEq(balAfter.broker.collateral, 0);
   }
 
   function test_swapOut_whenExchangeManagerWasNotSet_shouldRevert() public {
     vm.expectRevert("ExchangeProvider does not exist");
     broker.swapOut(randomExchangeProvider, exchangeId, randomAsset, randomAsset, 2e24, 1e24);
+  }
+
+  function test_swapIn_whenTradingLimitWasNotMet_shouldSwap() public {
+    TradingLimits.Config memory config;
+    config.flags = 1;
+    config.timestep0 = 10000;
+    config.limit0 = 1000;
+    changePrank(deployer);
+    broker.configureTradingLimit(exchangeId, address(stableAsset), config);
+    changePrank(trader);
+
+    IERC20(collateralAsset).approve(address(broker), 1e21);
+    uint256 amountOut = broker.swapIn(
+      address(exchangeProvider),
+      exchangeId,
+      address(collateralAsset),
+      address(stableAsset),
+      1e20,
+      1e16
+    );
+  }
+
+  function test_swapIn_whenTradingLimitWasMet_shouldNotSwap() public {
+    TradingLimits.Config memory config;
+    config.flags = 1;
+    config.timestep0 = 10000;
+    config.limit0 = 100;
+    changePrank(deployer);
+    broker.configureTradingLimit(exchangeId, address(stableAsset), config);
+    changePrank(trader);
+
+    vm.expectRevert(bytes("L0 Exceeded"));
+    uint256 amountOut = broker.swapIn(
+      address(exchangeProvider),
+      exchangeId,
+      address(stableAsset),
+      address(collateralAsset),
+      5e20,
+      0
+    );
   }
 }

--- a/test/Broker.t.sol
+++ b/test/Broker.t.sol
@@ -262,8 +262,6 @@ contract BrokerTest_swap is BrokerTest {
   }
 
   function test_swapIn_whenAmountOutMinNotMet_shouldRevert() public {
-    uint256 amountIn = 1e16;
-
     vm.expectRevert("amountOutMin not met");
     broker.swapIn(
       address(exchangeProvider), 
@@ -276,11 +274,8 @@ contract BrokerTest_swap is BrokerTest {
   }
 
   function test_swapOut_whenAmountInMaxExceeded_shouldRevert() public {
-    uint256 amountOut = 1e16;
-    uint256 mockAmountIn = 1e16;
-
     vm.expectRevert("amountInMax exceeded");
-    broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), amountOut, 1e15);
+    broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 1e16, 1e15);
   }
 
   function test_swapIn_whenTokenInStableAsset_shouldUpdateAndEmit() public {
@@ -440,7 +435,7 @@ contract BrokerTest_swap is BrokerTest {
     changePrank(trader);
 
     IERC20(collateralAsset).approve(address(broker), 1e21);
-    uint256 amountOut = broker.swapIn(
+    broker.swapIn(
       address(exchangeProvider),
       exchangeId,
       address(collateralAsset),
@@ -460,7 +455,7 @@ contract BrokerTest_swap is BrokerTest {
     changePrank(trader);
 
     vm.expectRevert(bytes("L0 Exceeded"));
-    uint256 amountOut = broker.swapIn(
+    broker.swapIn(
       address(exchangeProvider),
       exchangeId,
       address(stableAsset),

--- a/test/Reserve.t.sol
+++ b/test/Reserve.t.sol
@@ -49,8 +49,8 @@ contract ReserveTest is Test, WithRegistry, TokenHelpers {
 
   Reserve reserve;
   MockSortedOracles sortedOracles;
-  DummyERC20 dummyToken1 = new DummyERC20();
-  DummyERC20 dummyToken2 = new DummyERC20();
+  DummyERC20 dummyToken1 = new DummyERC20("DummyToken1", "DT1", 18);
+  DummyERC20 dummyToken2 = new DummyERC20("DummyToken2", "DT2", 18);
 
   function setUp() public {
     rando = actor("rando");

--- a/test/common/TradingLimits.t.sol
+++ b/test/common/TradingLimits.t.sol
@@ -226,4 +226,13 @@ contract TradingLimitsTest is Test {
         assertEq(state.netflow1, 0);
         assertEq(state.netflowGlobal, 100);
     }
+
+    function test_update_withSubUnitAmounts_updatesAs1() public {
+        state = state.update(configLG(500000), 1e6, 18);
+        assertEq(state.netflowGlobal, 1);
+    }
+    function test_update_withTooLargeAmount_reverts() public {
+        vm.expectRevert(bytes("dFlow too large"));
+        state = state.update(configLG(500000), 3*10e32, 18);
+    }
 }

--- a/test/common/TradingLimits.t.sol
+++ b/test/common/TradingLimits.t.sol
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { TradingLimits } from "contracts/common/TradingLimits.sol";
+
+// forge test --match-contract TradingLimits -vvv
+contract TradingLimitsTest is Test {
+    using TradingLimits for TradingLimits.Data;
+
+    uint8 private constant L0 = 1; // 0b001
+    uint8 private constant L1 = 2; // 0b010
+    uint8 private constant LG = 4; // 0b100
+
+    TradingLimits.Data private tradingLimit;
+
+    function setUp() public {
+        TradingLimits.Data memory _tradingLimit;
+        tradingLimit = _tradingLimit;
+    }
+
+    /* ==================== #configure ==================== */
+
+    function test_configure_whenNothingOn_withL0() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 100;
+        config.limit0 = 1000;
+        config.flags = L0;
+        
+        tradingLimit = tradingLimit.configure(config);
+
+        assertEq(uint256(tradingLimit.timestep0), 100);
+        assertEq(tradingLimit.limit0, 1000);
+        assertEq(tradingLimit.lastUpdated0, block.timestamp);
+
+        assertEq(uint256(tradingLimit.timestep1), 0);
+        assertEq(tradingLimit.limit1, 0);
+        assertEq(uint256(tradingLimit.lastUpdated1), 0);
+
+        assertEq(tradingLimit.limitGlobal, 0);
+        assertEq(uint256(tradingLimit.flags), uint256(L0));
+    }
+
+    function test_configure_whenNothingOn_withL0L1() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 100;
+        config.limit0 = 1000;
+        config.timestep1 = 1000;
+        config.limit1 = 10000;
+        config.flags = L0 | L1;
+
+        tradingLimit = tradingLimit.configure(config);
+
+        assertEq(uint256(tradingLimit.timestep0), 100);
+        assertEq(tradingLimit.limit0, 1000);
+        assertEq(tradingLimit.lastUpdated0, block.timestamp);
+
+        assertEq(uint256(tradingLimit.timestep1), 1000);
+        assertEq(tradingLimit.limit1, 10000);
+        assertEq(tradingLimit.lastUpdated0, block.timestamp);
+
+        assertEq(tradingLimit.limitGlobal, 0);
+        assertEq(uint256(tradingLimit.flags), uint256(L0 | L1));
+    }
+
+    function test_configure_whenNothingOn_withL0L1LG() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 100;
+        config.limit0 = 1000;
+        config.timestep1 = 1000;
+        config.limit1 = 10000;
+        config.limitGlobal = 100000;
+        config.flags = L0 | L1 | LG;
+
+        tradingLimit = tradingLimit.configure(config);
+
+        assertEq(uint256(tradingLimit.timestep0), 100);
+        assertEq(tradingLimit.limit0, 1000);
+        assertEq(tradingLimit.lastUpdated0, block.timestamp);
+
+        assertEq(uint256(tradingLimit.timestep1), 1000);
+        assertEq(tradingLimit.limit1, 10000);
+        assertEq(tradingLimit.lastUpdated0, block.timestamp);
+
+        assertEq(tradingLimit.limitGlobal, 100000);
+        assertEq(uint256(tradingLimit.flags), uint256(L0 | L1 | LG));
+    }
+
+    function test_configure_whenL0On_withL0() public {
+        TradingLimits.Data memory config0;
+        config0.timestep0 = 500;
+        config0.limit0 = 1230;
+        config0.flags = L0;
+
+        tradingLimit = tradingLimit.configure(config0);
+
+        TradingLimits.Data memory config1;
+        config1.timestep0 = 100;
+        config1.limit0 = 1000;
+        config1.flags = L0;
+        
+        tradingLimit = tradingLimit.configure(config1);
+
+
+        assertEq(uint256(tradingLimit.timestep0), 100);
+        assertEq(tradingLimit.limit0, 1000);
+        assertEq(tradingLimit.lastUpdated0, block.timestamp);
+
+        assertEq(uint256(tradingLimit.timestep1), 0);
+        assertEq(tradingLimit.limit1, 0);
+        assertEq(uint256(tradingLimit.lastUpdated1), 0);
+
+        assertEq(tradingLimit.limitGlobal, 0);
+        assertEq(uint256(tradingLimit.flags), uint256(L0));
+    }
+
+    function test_configure_whenL0L1On_withL1LG() public {
+        TradingLimits.Data memory config0;
+        config0.timestep0 = 500;
+        config0.limit0 = 1230;
+        config0.timestep1 = 5000;
+        config0.limit1 = 1230;
+        config0.flags = L0 | L1;
+
+        tradingLimit = tradingLimit.configure(config0);
+
+        TradingLimits.Data memory config1;
+        config1.timestep1 = 100;
+        config1.limit1 = 1000;
+        config1.limitGlobal = 10000;
+        config1.flags = L1 | LG;
+        
+        tradingLimit = tradingLimit.configure(config1);
+
+
+        assertEq(uint256(tradingLimit.timestep0), 0);
+        assertEq(tradingLimit.limit0, 0);
+        assertEq(uint256(tradingLimit.lastUpdated0), 0);
+
+        assertEq(uint256(tradingLimit.timestep1), 100);
+        assertEq(tradingLimit.limit1, 1000);
+        assertEq(uint256(tradingLimit.lastUpdated1), block.timestamp);
+
+        assertEq(tradingLimit.limitGlobal, 10000);
+        assertEq(uint256(tradingLimit.flags), uint256(L1 | LG));
+    }
+
+    function test_configure_withNetflowOnL0_isLost() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 500;
+        config.limit0 = 1230;
+        config.flags = L0;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow0 = 400;
+
+        tradingLimit = tradingLimit.configure(config);
+        assertEq(tradingLimit.netflow0, 0);
+    }
+
+    function test_configure_withNetflowOnL1_isLost() public {
+        TradingLimits.Data memory config;
+        config.timestep1 = 500;
+        config.limit1 = 1230;
+        config.flags = L1;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow1 = 400;
+
+        tradingLimit = tradingLimit.configure(config);
+        assertEq(tradingLimit.netflow1, 0);
+    }
+
+    function test_configure_withNetflowOnLG_isKept() public {
+        TradingLimits.Data memory config;
+        config.limitGlobal = 1230;
+        config.flags = LG;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflowGlobal = 400;
+
+        tradingLimit = tradingLimit.configure(config);
+        assertEq(tradingLimit.netflowGlobal, 400);
+    }
+
+    /* ==================== #configure ==================== */
+
+    function test_isValid_whenNothingOn() public view {
+        assert(tradingLimit.isValid());
+    }
+
+    function test_isValid_whenL0On_butNotMet() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 500;
+        config.limit0 = 1230;
+        config.flags = L0;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow0 = 500;
+
+        assert(tradingLimit.isValid());
+    }
+
+    function test_isValid_whenL0On_andMetPositively() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 500;
+        config.limit0 = 1230;
+        config.flags = L0;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow0 = 1231;
+
+        vm.expectRevert(bytes("L0 Exceeded"));
+        tradingLimit.isValid();
+    }
+
+    function test_isValid_whenL0On_andMetNegatively() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 500;
+        config.limit0 = 1230;
+        config.flags = L0;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow0 = -1231;
+
+        vm.expectRevert(bytes("L0 Exceeded"));
+        tradingLimit.isValid();
+    }
+
+    function test_isValid_whenL1On_butNotMet() public {
+        TradingLimits.Data memory config;
+        config.timestep0 = 500;
+        config.limit0 = 1230;
+        config.flags = L0;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow0 = 500;
+
+        assert(tradingLimit.isValid());
+    }
+
+    function test_isValid_whenL1On_andMetPositively() public {
+        TradingLimits.Data memory config;
+        config.timestep1 = 500;
+        config.limit1 = 1230;
+        config.flags = L1;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow1 = 1231;
+
+        vm.expectRevert(bytes("L1 Exceeded"));
+        tradingLimit.isValid();
+    }
+
+    function test_isValid_whenL1On_andMetNegatively() public {
+        TradingLimits.Data memory config;
+        config.timestep1 = 500;
+        config.limit1 = 1230;
+        config.flags = L1;
+
+        tradingLimit = tradingLimit.configure(config);
+        tradingLimit.netflow1 = -1231;
+
+        vm.expectRevert(bytes("L1 Exceeded"));
+        tradingLimit.isValid();
+    }
+
+
+
+    function test_whenAllLimitsAreOff_update_doesntUpdateAnything() public {
+        tradingLimit = tradingLimit.update(100 * 1e18, 18);
+        assertEq(tradingLimit.netflow0, 0);
+        assertEq(tradingLimit.netflow1, 0);
+        assertEq(tradingLimit.netflowGlobal, 0);
+    }
+
+}

--- a/test/mocks/MockExchangeProvider.sol
+++ b/test/mocks/MockExchangeProvider.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { IExchangeProvider } from "contracts/interfaces/IExchangeProvider.sol";
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+contract MockExchangeProvider is IExchangeProvider {
+  using FixidityLib for FixidityLib.Fraction;
+  mapping(bytes32 => uint256) exchangeRate;
+
+  function setRate(bytes32 exchangeId, address base, address quote, uint256 rate) external {
+    bytes32 rateId = keccak256(abi.encodePacked(exchangeId, base, quote));
+    exchangeRate[rateId] = rate;
+    rateId = keccak256(abi.encodePacked(exchangeId, quote, base));
+    exchangeRate[rateId] = FixidityLib.fixed1().divide(FixidityLib.wrap(rate)).unwrap();
+  }
+
+  function getAmountOut(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external view returns (uint256 amountOut) {
+    return _getAmountOut(exchangeId, tokenIn, tokenOut, amountIn);
+  }
+
+  function getAmountIn(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external view returns (uint256 amountIn) {
+    return _getAmountIn(exchangeId, tokenIn, tokenOut, amountOut);
+  }
+
+  function swapIn(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external returns (uint256 amountOut) {
+    return _getAmountOut(exchangeId, tokenIn, tokenOut, amountIn);
+  }
+
+  function swapOut(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external returns (uint256 amountIn) {
+    return _getAmountIn(exchangeId, tokenIn, tokenOut, amountOut);
+  }
+
+  function _getAmountOut(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) internal view returns (uint256 amountOut) {
+    bytes32 rateId = keccak256(abi.encodePacked(exchangeId, tokenOut, tokenIn));
+    return FixidityLib.newFixed(amountIn).multiply(FixidityLib.wrap(exchangeRate[rateId])).fromFixed();
+  }
+
+  function _getAmountIn(
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) internal view returns (uint256 amountIn) {
+    bytes32 rateId = keccak256(abi.encodePacked(exchangeId, tokenIn, tokenOut));
+    return FixidityLib.newFixed(amountOut).multiply(FixidityLib.wrap(exchangeRate[rateId])).fromFixed();
+  }
+
+  function getExchanges() external view returns (Exchange[] memory exchanges) {}
+}

--- a/test/utils/DummyErc20.sol
+++ b/test/utils/DummyErc20.sol
@@ -2,5 +2,10 @@
 pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 
-contract DummyERC20 is ERC20 {}
+contract DummyERC20 is ERC20, ERC20Detailed {
+    constructor(string memory name, string memory symbol, uint8 decimals) 
+        ERC20Detailed(name, symbol, decimals) 
+        public {}
+}


### PR DESCRIPTION
### Description

This PR implements trading limits for the broker via the `TradingLimits` library.
This library provides two structs:
- `TradingLimits.State` which holds the counters associated with a trading limit setup
- `TradingLimits.Config` which holds the configuration for a trading limit setup.

A trading limit is applied to an asset in a pair. For example, say we have the `cUSD/CELO` pair which has an `exchangeId`, if we want to apply a trading limit for cUSD in that pair we configure the trading limits on `limitId = exchangeId ^ cUSDTokenAddress`. Inside of a TradingLimits.Config we can enable 3 trading limits:
- L0 which is a time-window based limit, allowing a netflow of `limit0` tokens every `timespan0` seconds.
- L1 which is the same as L0 but with a different limit and timespan.
- LG which is a global limit without a timespan

### Other changes

- Create a MockExchangeProvider to simplify testing in the Broker
- Compile warning fixes

### Tested

- Library has test
- Integration with broker tested

### Related issues

- #53 

### Backwards compatibility

N/A

### Documentation

N/A
