### PR TITLE
feat: gas comparison

### DIFF
--- a/test/gas/BrokerGas.t.sol
+++ b/test/gas/BrokerGas.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility, const-name-snakecase, max-states-count
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+import { McMintIntegration } from "../utils/McMintIntegration.sol";
+import { TokenHelpers } from "../utils/TokenHelpers.sol";
+
+// forge test --match-contract BrokerIntegration -vvv
+contract BrokerGasTest is Test, McMintIntegration, TokenHelpers {
+  address trader;
+
+  function setUp() public {
+    setUp_mcMint();
+
+    trader = actor("trader");
+
+    mint(cUSDToken, trader, 10**22); // Mint 10k to trader
+    mint(cEURToken, trader, 10**22); // Mint 10k to trader
+
+    deal(address(celoToken), trader, 1000 * 10**18); // Gift 10k to trader
+
+    deal(address(celoToken), address(reserve), 10**24); // Gift 1Mil to reserve
+    deal(address(usdcToken), address(reserve), 10**24); // Gift 1Mil to reserve
+  }
+
+  /**
+   * @notice Test helper function to do swap in
+   */
+  function doSwapIn(
+    bytes32 poolId,
+    uint256 amountIn,
+    address tokenIn,
+    address tokenOut
+  ) public {
+    // Get exchange provider from broker
+    address[] memory exchangeProviders = broker.getExchangeProviders();
+    assertEq(exchangeProviders.length, 1);
+    changePrank(trader);
+    IERC20(tokenIn).approve(address(broker), amountIn);
+
+    broker.swapIn(address(exchangeProviders[0]), poolId, tokenIn, tokenOut, 1000 * 10**18, 0);
+  }
+
+  function test_gas_swapIn_cUSDToUSDCet() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = cUSDToken;
+    IERC20 tokenOut = usdcToken;
+    bytes32 poolId = pair_cUSD_USDCet_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+
+  function test_gas_swapIn_cEURToUSDCet() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = cEURToken;
+    IERC20 tokenOut = usdcToken;
+    bytes32 poolId = pair_cEUR_USDCet_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+
+  function test_gas_swapIn_cEURTocUSD() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = cEURToken;
+    IERC20 tokenOut = cUSDToken;
+    bytes32 poolId = pair_cUSD_cEUR_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+
+  function test_gas_swapIn_cUSDTocEUR() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = cUSDToken;
+    IERC20 tokenOut = cEURToken;
+    bytes32 poolId = pair_cUSD_cEUR_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+
+  function test_gas_swapIn_CELOTocEUR() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = celoToken;
+    IERC20 tokenOut = cEURToken;
+    bytes32 poolId = pair_cEUR_CELO_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+
+  function test_gas_swapIn_CELOTocUSD() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = celoToken;
+    IERC20 tokenOut = cUSDToken;
+    bytes32 poolId = pair_cUSD_CELO_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+
+  function test_gas_swapIn_CUSDToCelo() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = cUSDToken;
+    IERC20 tokenOut = celoToken;
+    bytes32 poolId = pair_cUSD_CELO_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+
+  function test_gas_swapIn_CEURToCelo() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    IERC20 tokenIn = cEURToken;
+    IERC20 tokenOut = celoToken;
+    bytes32 poolId = pair_cEUR_CELO_ID;
+
+    doSwapIn(poolId, amountIn, address(tokenIn), address(tokenOut));
+  }
+}

--- a/test/gas/ExchangeGas.t.sol
+++ b/test/gas/ExchangeGas.t.sol
@@ -39,14 +39,6 @@ contract ExchangeGasTest is Test, TokenHelpers {
 
     mint(cUSDToken, trader, 10**22);
     mint(cEURToken, trader, 10**22);
-
-    console.log("trader CELO balance", celoToken.balanceOf(trader)); // 0, should be 10**22
-    console.log(
-      "governance proxy CELO balance after tansfer",
-      celoToken.balanceOf(0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972)
-    );
-    console.log("trader cUSD balance", cUSDToken.balanceOf(trader)); // 10**22
-    console.log("trader cEUR balance", cEURToken.balanceOf(trader)); // 10**22
   }
 
   function test_gas_sell_CELO_for_cUSD() public {

--- a/test/gas/ExchangeGas.t.sol
+++ b/test/gas/ExchangeGas.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: UNLICENSED
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility, const-name-snakecase, max-states-count
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { TokenHelpers } from "../utils/TokenHelpers.sol";
+import { StableToken } from "contracts/StableToken.sol";
+import { StableTokenEUR } from "contracts/StableTokenEUR.sol";
+import { GoldToken } from "contracts/common/GoldToken.sol";
+import { IExchange } from "contracts/interfaces/IExchange.sol";
+
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+contract ExchangeGasTest is Test, TokenHelpers {
+  address trader;
+  uint256 celoMainnetFork;
+
+  IExchange exchangeCUSD;
+  IExchange exchangeCEUR;
+
+  StableToken cUSDToken;
+  StableTokenEUR cEURToken;
+  GoldToken celoToken;
+
+  function setUp() public {
+    celoMainnetFork = vm.createFork("https://forno.celo.org");
+    vm.selectFork(celoMainnetFork);
+
+    // https://docs.mento.org/mento-protocol/core/deployment-addresses
+    exchangeCUSD = IExchange(0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275);
+    exchangeCEUR = IExchange(0xE383394B913d7302c49F794C7d3243c429d53D1d);
+
+    cUSDToken = StableToken(0x765DE816845861e75A25fCA122bb6898B8B1282a);
+    cEURToken = StableTokenEUR(0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73);
+    celoToken = GoldToken(0x471EcE3750Da237f93B8E339c536989b8978a438);
+
+    trader = actor("trader");
+
+    mint(cUSDToken, trader, 10**22);
+    mint(cEURToken, trader, 10**22);
+
+    console.log("trader CELO balance", celoToken.balanceOf(trader)); // 0, should be 10**22
+    console.log(
+      "governance proxy CELO balance after tansfer",
+      celoToken.balanceOf(0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972)
+    );
+    console.log("trader cUSD balance", cUSDToken.balanceOf(trader)); // 10**22
+    console.log("trader cEUR balance", cEURToken.balanceOf(trader)); // 10**22
+  }
+
+  function test_gas_sell_CELO_for_cUSD() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    uint256 minBuyAmount = 1 * 10**18; // 1
+    bool sellGold = true;
+
+    changePrank(0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972); //governance proxy
+    celoToken.approve(address(exchangeCUSD), amountIn);
+
+    exchangeCUSD.sell(amountIn, minBuyAmount, sellGold);
+  }
+
+  function test_gas_sell_CELO_for_cEUR() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    uint256 minBuyAmount = 1 * 10**18; // 1
+    bool sellGold = true;
+
+    changePrank(0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972); //governance proxy
+    celoToken.approve(address(exchangeCEUR), amountIn);
+
+    exchangeCEUR.sell(amountIn, minBuyAmount, sellGold);
+  }
+
+  function test_gas_sell_cUSD_for_CELO() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    uint256 minBuyAmount = 1 * 10**18; // 1
+    bool sellGold = false;
+
+    changePrank(trader);
+    cUSDToken.approve(address(exchangeCUSD), amountIn);
+
+    exchangeCUSD.sell(amountIn, minBuyAmount, sellGold);
+  }
+
+  function test_gas_sell_cEUR_for_CELO() public {
+    uint256 amountIn = 1000 * 10**18; // 1k
+    uint256 minBuyAmount = 1 * 10**18; // 1
+    bool sellGold = false;
+
+    changePrank(trader);
+    cEURToken.approve(address(exchangeCEUR), amountIn);
+
+    exchangeCEUR.sell(amountIn, minBuyAmount, sellGold);
+  }
+}

--- a/test/gas/GasComparison.md
+++ b/test/gas/GasComparison.md
@@ -1,0 +1,43 @@
+##### Gas Comparison
+
+`/test/gas/BrokerGas.t.sol` contains simple swap tests to estimate gas usage. You can get an overview with
+
+`forge test --match-contract BrokerGasTest` and
+`forge test --match-contract BrokerGasTest --gas-report`
+
+or a more detailed view of gas usage by function call with
+
+`forge test --match-contract BrokerGasTest -vvvv` or for single tests
+`forge test --match-test ${TEST_NAME} -vvvvv`.
+
+##### How to compare gas usage
+
+To compare feature additions and code changes, you can run `/test/gas/BrokerGas.t.sol` on different branches and compare the gas estimates manually.
+
+##### Historical Exchange Gas usage
+
+Mento V1 contracts take around 25% more gas for simple swaps from a Stable to CELO. You can run the gas estimation by
+`forge test --match-contract ExchangeGasTest -vvvv` or for single tests
+`forge test --match-test ${TEST_NAME} -vvvvv`.
+
+###### 2022/11/21 gas report
+
+Broker.sol
+[PASS] test_gas_swapIn_CELOTocEUR() (gas: 170792)
+[PASS] test_gas_swapIn_CELOTocUSD() (gas: 170790)
+[PASS] test_gas_swapIn_CEURToCelo() (gas: 229310)
+[PASS] test_gas_swapIn_CUSDToCelo() (gas: 229311)
+[PASS] test_gas_swapIn_cUSDTocEUR() (gas: 200882)
+[PASS] test_gas_swapIn_cEURTocUSD() (gas: 200965)
+[PASS] test_gas_swapIn_cUSDToUSDCet() (gas: 246431)
+[PASS] test_gas_swapIn_cEURToUSDCet() (gas: 246410)
+
+- test_gas_swapIn_CELOTocUSD: [112366] Broker::swapIn
+
+Exchange.sol
+[PASS] test_gas_sell_CELO_for_cEUR() (gas: 207711)
+[PASS] test_gas_sell_CELO_for_cUSD() (gas: 207752)
+[PASS] test_gas_sell_cEUR_for_CELO() (gas: 257494)
+[PASS] test_gas_sell_cUSD_for_CELO() (gas: 261958)
+
+- test_gas_sell_CELO_for_cUSD: [140569] 0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275::sell

--- a/test/integration/BrokerIntegration.t.sol
+++ b/test/integration/BrokerIntegration.t.sol
@@ -49,20 +49,6 @@ contract BrokerIntegrationTest is Test, McMintIntegration, TokenHelpers {
     address[] memory exchangeProviders = broker.getExchangeProviders();
     assertEq(exchangeProviders.length, 1);
 
-    // Get exchange from provider
-    IBiPoolManager.PoolExchange memory exchange = IBiPoolManager(exchangeProviders[0]).getPoolExchange(poolId);
-
-    uint256 bucketIn;
-    uint256 bucketOut;
-
-    if (tokenIn == exchange.asset0) {
-      bucketIn = exchange.bucket0;
-      bucketOut = exchange.bucket1;
-    } else {
-      bucketIn = exchange.bucket1;
-      bucketOut = exchange.bucket0;
-    }
-
     expectedOut = broker.getAmountOut(exchangeProviders[0], poolId, tokenIn, tokenOut, amountIn);
 
     changePrank(trader);


### PR DESCRIPTION
### Description

This PR adds a gas comparison between Exchange.sol and Broker.sol common single swaps. Broker.sol gas usage is estimated locally with foundry building on the integration tests. Exchange.sol gas usage is estimated with fork testing from Celo mainnet. 

I created a Markdown file as a runbook on how to compare gas usage for future feature additions.

### Other changes

-

### Tested

All tests pass.

### Related issues

- Fixes #33 

### Backwards compatibility

Fully

### Documentation

`GasComparison.md` in `/test/gas/`
