### PR TITLE
feat(broker): add burnstabletokens method

### DIFF
--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -9,7 +9,6 @@ import { IBrokerAdmin } from "./interfaces/IBrokerAdmin.sol";
 import { IReserve } from "./interfaces/IReserve.sol";
 import { IStableToken } from "./interfaces/IStableToken.sol";
 import { IERC20Metadata } from "./common/interfaces/IERC20Metadata.sol";
-import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 import { Initializable } from "./common/Initializable.sol";
 import { TradingLimits } from "./common/TradingLimits.sol";
@@ -196,9 +195,8 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
    */
   function burnStableTokens(address token, uint256 amount) public returns (bool) {
     require(reserve.isStableAsset(token), "Token must be a reserve stable asset");
-    IERC20(token).transferFrom(msg.sender, address(this), amount);
+    IERC20Metadata(token).transferFrom(msg.sender, address(this), amount);
     IStableToken(token).burn(amount);
-    emit TokenBurned(token, amount);
     return true;
   }
 

--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -3,7 +3,6 @@ pragma experimental ABIEncoderV2;
 
 import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 import { IExchangeProvider } from "./interfaces/IExchangeProvider.sol";
 import { IBroker } from "./interfaces/IBroker.sol";
@@ -18,7 +17,6 @@ import { Initializable } from "./common/Initializable.sol";
  * @notice The broker executes swaps and keeps track of spending limits per pair.
  */
 contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
-  using SafeMath for uint256;
 
   /* ==================== State Variables ==================== */
 

--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -9,6 +9,7 @@ import { IBrokerAdmin } from "./interfaces/IBrokerAdmin.sol";
 import { IReserve } from "./interfaces/IReserve.sol";
 import { IStableToken } from "./interfaces/IStableToken.sol";
 import { IERC20Metadata } from "./common/interfaces/IERC20Metadata.sol";
+import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 import { Initializable } from "./common/Initializable.sol";
 import { TradingLimits } from "./common/TradingLimits.sol";

--- a/contracts/interfaces/IBroker.sol
+++ b/contracts/interfaces/IBroker.sol
@@ -26,6 +26,13 @@ interface IBroker {
     uint256 amountOut
   );
 
+ /**
+   * @notice Emitted when stables are burned.
+   * @param token The token getting burned.
+   * @param amount The amount of token getting burned.
+   */
+  event TokenBurned(address token, uint256 amount);
+
   /**
    * @notice Execute a token swap with fixed amountIn.
    * @param exchangeProvider the address of the exchange provider for the pair.

--- a/contracts/interfaces/IBroker.sol
+++ b/contracts/interfaces/IBroker.sol
@@ -26,13 +26,6 @@ interface IBroker {
     uint256 amountOut
   );
 
- /**
-   * @notice Emitted when stables are burned.
-   * @param token The token getting burned.
-   * @param amount The amount of token getting burned.
-   */
-  event TokenBurned(address token, uint256 amount);
-
   /**
    * @notice Execute a token swap with fixed amountIn.
    * @param exchangeProvider the address of the exchange provider for the pair.

--- a/test/Broker.t.sol
+++ b/test/Broker.t.sol
@@ -33,7 +33,6 @@ contract BrokerTest is Test {
   event ExchangeProviderAdded(address indexed exchangeProvider);
   event ExchangeProviderRemoved(address indexed exchangeProvider);
   event ReserveSet(address indexed newAddress, address indexed prevAddress);
-  event TokenBurned(address token, uint256 amount);
 
   address deployer = actor("deployer");
   address notDeployer = actor("notDeployer");
@@ -256,8 +255,6 @@ contract BrokerTest_BurnStableTokens is BrokerTest {
       abi.encodeWithSelector(IStableToken(address(stableAsset)).burn.selector, burnAmount)
     );
 
-    vm.expectEmit(true, true, true, true);
-    emit TokenBurned(address(stableAsset), 1);
     bool result = broker.burnStableTokens(address(stableAsset), 1);
 
     assertEq(result, true);

--- a/test/Broker.t.sol
+++ b/test/Broker.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
-import { Test, console2 as console } from "celo-foundry/Test.sol";
+import { Test } from "celo-foundry/Test.sol";
 import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import { Broker } from "contracts/Broker.sol";
 import { IExchangeProvider } from "contracts/interfaces/IExchangeProvider.sol";
@@ -238,7 +238,6 @@ contract BrokerTest_BurnStableTokens is BrokerTest {
 
   function test_burnStableTokens_whenTokenIsAReserveStable_shouldBurnAndEmit() public {
     stableAsset.mint(notDeployer, 2);
-    stableAsset.mint(address(broker), 2);
 
     changePrank(notDeployer);
 
@@ -263,8 +262,7 @@ contract BrokerTest_BurnStableTokens is BrokerTest {
 
     assertEq(result, true);
     assertEq(stableAsset.balanceOf(notDeployer), 1);
-    // assertion fails here
-    assertEq(stableAsset.balanceOf(address(broker)), 1);
+    assertEq(stableAsset.balanceOf(address(broker)), 0);
   }
 }
 

--- a/test/mocks/MockStableToken.sol
+++ b/test/mocks/MockStableToken.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.5.13;
 // solhint-disable no-unused-vars, const-name-snakecase
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-
 import "contracts/common/FixidityLib.sol";
 
 /**
@@ -40,6 +39,12 @@ contract MockStableToken {
 
   function burn(uint256 value) external returns (bool) {
     balances[msg.sender] = balances[msg.sender].sub(valueToUnits(value));
+    _totalSupply = _totalSupply.sub(value);
+    return true;
+  }
+
+  function burnStables(address from, uint256 value) external returns (bool) {
+    balances[from] = balances[from].sub(valueToUnits(value));
     _totalSupply = _totalSupply.sub(value);
     return true;
   }

--- a/test/mocks/MockStableToken.sol
+++ b/test/mocks/MockStableToken.sol
@@ -43,12 +43,6 @@ contract MockStableToken {
     return true;
   }
 
-  function burnStables(address from, uint256 value) external returns (bool) {
-    balances[from] = balances[from].sub(valueToUnits(value));
-    _totalSupply = _totalSupply.sub(value);
-    return true;
-  }
-
   function totalSupply() external view returns (uint256) {
     return _totalSupply;
   }


### PR DESCRIPTION
### Description

In this PR I'm introducing changes in `Broker.sol` making it possible to burn stables without permissions

### Other changes

n/a

### Tested

Unit tests to check everything works as expected

### Related issues

- Fixes #58 

### Backwards compatibility

should be backwards compatible
