### PR TITLE
feat(test): update integration tests to config and use trading limits

### DIFF
--- a/test/gas/GasComparison.md
+++ b/test/gas/GasComparison.md
@@ -23,21 +23,17 @@ Mento V1 contracts take around 25% more gas for simple swaps from a Stable to CE
 ###### 2022/11/21 gas report
 
 Broker.sol
-[PASS] test_gas_swapIn_CELOTocEUR() (gas: 170792)
-[PASS] test_gas_swapIn_CELOTocUSD() (gas: 170790)
-[PASS] test_gas_swapIn_CEURToCelo() (gas: 229310)
-[PASS] test_gas_swapIn_CUSDToCelo() (gas: 229311)
-[PASS] test_gas_swapIn_cUSDTocEUR() (gas: 200882)
-[PASS] test_gas_swapIn_cEURTocUSD() (gas: 200965)
-[PASS] test_gas_swapIn_cUSDToUSDCet() (gas: 246431)
-[PASS] test_gas_swapIn_cEURToUSDCet() (gas: 246410)
-
-- test_gas_swapIn_CELOTocUSD: [112366] Broker::swapIn
+[PASS] test_gas_swapIn_CELOTocEUR() (gas: 237016)
+[PASS] test_gas_swapIn_CELOTocUSD() (gas: 237014)
+[PASS] test_gas_swapIn_CEURToCelo() (gas: 292394)
+[PASS] test_gas_swapIn_CUSDToCelo() (gas: 292395)
+[PASS] test_gas_swapIn_cEURToUSDCet() (gas: 309449)
+[PASS] test_gas_swapIn_cEURTocUSD() (gas: 269525)
+[PASS] test_gas_swapIn_cUSDToUSDCet() (gas: 309470)
+[PASS] test_gas_swapIn_cUSDTocEUR() (gas: 269442)
 
 Exchange.sol
 [PASS] test_gas_sell_CELO_for_cEUR() (gas: 207711)
 [PASS] test_gas_sell_CELO_for_cUSD() (gas: 207752)
 [PASS] test_gas_sell_cEUR_for_CELO() (gas: 257494)
 [PASS] test_gas_sell_cUSD_for_CELO() (gas: 261958)
-
-- test_gas_sell_CELO_for_cUSD: [140569] 0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275::sell

--- a/test/utils/IntegrationSetup.sol
+++ b/test/utils/IntegrationSetup.sol
@@ -344,12 +344,8 @@ contract IntegrationSetup is Test, WithRegistry {
 
   function setUp_tradingLimits() internal {
     /* ========== Config Trading Limits =============== */
-    uint8 L0 = 1; // 0b001
-    uint8 L1 = 2; // 0b010
-    uint8 LG = 4; // 0b100
-
     TradingLimits.Config memory config = configL0L1LG(100, 10000, 1000, 100000, 1000000);
-    broker.configureTradingLimit(pair_cUSD_CELO_ID, address(cUSDToken), config);    
+    broker.configureTradingLimit(pair_cUSD_CELO_ID, address(cUSDToken), config);
     broker.configureTradingLimit(pair_cEUR_CELO_ID, address(cEURToken), config);
     broker.configureTradingLimit(pair_cUSD_USDCet_ID, address(usdcToken), config);
     broker.configureTradingLimit(pair_cEUR_USDCet_ID, address(usdcToken), config);

--- a/test/utils/IntegrationSetup.sol
+++ b/test/utils/IntegrationSetup.sol
@@ -21,6 +21,7 @@ import { SortedOracles } from "contracts/SortedOracles.sol";
 import { Reserve } from "contracts/Reserve.sol";
 import { BreakerBox } from "contracts/BreakerBox.sol";
 import { MedianDeltaBreaker } from "contracts/MedianDeltaBreaker.sol";
+import { TradingLimits } from "contracts/common/TradingLimits.sol";
 
 import { FixidityLib } from "contracts/common/FixidityLib.sol";
 import { Freezer } from "contracts/common/Freezer.sol";
@@ -33,6 +34,7 @@ import { Token } from "./Token.sol";
 contract IntegrationSetup is Test, WithRegistry {
   using FixidityLib for FixidityLib.Fraction;
   using AddressSortedLinkedListWithMedian for SortedLinkedListWithMedian.List;
+  using TradingLimits for TradingLimits.Config;
 
   uint256 constant tobinTaxStalenessThreshold = 600;
   uint256 constant dailySpendingRatio = 1000000000000000000000000;
@@ -84,6 +86,7 @@ contract IntegrationSetup is Test, WithRegistry {
     setUp_breakers();
     setUp_broker();
     setUp_freezer();
+    setUp_tradingLimits();
   }
 
   function setUp_assets() internal {
@@ -337,5 +340,34 @@ contract IntegrationSetup is Test, WithRegistry {
 
     freezer = new Freezer(true);
     registry.setAddressFor("Freezer", address(freezer));
+  }
+
+  function setUp_tradingLimits() internal {
+    /* ========== Config Trading Limits =============== */
+    uint8 L0 = 1; // 0b001
+    uint8 L1 = 2; // 0b010
+    uint8 LG = 4; // 0b100
+
+    TradingLimits.Config memory config = configL0L1LG(100, 10000, 1000, 100000, 1000000);
+    broker.configureTradingLimit(pair_cUSD_CELO_ID, address(cUSDToken), config);    
+    broker.configureTradingLimit(pair_cEUR_CELO_ID, address(cEURToken), config);
+    broker.configureTradingLimit(pair_cUSD_USDCet_ID, address(usdcToken), config);
+    broker.configureTradingLimit(pair_cEUR_USDCet_ID, address(usdcToken), config);
+    broker.configureTradingLimit(pair_cUSD_cEUR_ID, address(cUSDToken), config);
+  }
+
+  function configL0L1LG(
+    uint32 timestep0,
+    int48 limit0,
+    uint32 timestep1,
+    int48 limit1,
+    int48 limitGlobal
+  ) internal pure returns (TradingLimits.Config memory config) {
+    config.timestep0 = timestep0;
+    config.limit0 = limit0;
+    config.timestep1 = timestep1;
+    config.limit1 = limit1;
+    config.limitGlobal = limitGlobal;
+    config.flags = 1 | 2 | 4; //L0, L1, and LG
   }
 }


### PR DESCRIPTION
### Description

Adding trading limits to Broker integration tests and gas estimation

### Other changes

None

### Tested

Yup all tests pass

### Related issues

- Fixes #33 

### Backwards compatibility

Fully

### Documentation

Nope
