### PR TITLE
feat(reserve): allow limitless transfer of collateral assets

### DIFF
--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -240,7 +240,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
     if (reserve.isStableAsset(token)) {
       IStableToken(token).mint(to, amount);
     } else if (reserve.isCollateralAsset(token)) {
-      reserve.transferCollateralAsset(token, to, amount);
+      reserve.transferExchangeCollateralAsset(token, to, amount);
     } else {
       revert("Token must be stable or collateral assert");
     }

--- a/contracts/Reserve.sol
+++ b/contracts/Reserve.sol
@@ -492,6 +492,23 @@ contract Reserve is IReserve, ICeloVersionedContract, Ownable, Initializable, Us
   }
 
   /**
+   * @notice Transfer collateral asset to any address.
+   * @dev Transfers are not subject to a daily spending limit.
+   * @param collateralAsset The address of collateral asset being transferred.
+   * @param to The address that will receive the collateral asset.
+   * @param value The amount of collateral asset to transfer.
+   * @return Returns true if the transaction succeeds.
+   */
+  function transferExchangeCollateralAsset(
+    address collateralAsset,
+    address payable to,
+    uint256 value
+  ) external returns (bool) {
+    require(isExchangeSpender[msg.sender], "Address is not allowed to spend");
+    return _transferCollateralAsset(collateralAsset, to, value);
+  }
+
+  /**
    * @notice Transfer unfrozen gold to any address.
    * @param to The address that will receive the gold.
    * @param value The amount of gold to transfer.

--- a/contracts/Reserve.sol
+++ b/contracts/Reserve.sol
@@ -504,7 +504,7 @@ contract Reserve is IReserve, ICeloVersionedContract, Ownable, Initializable, Us
     address payable to,
     uint256 value
   ) external returns (bool) {
-    require(isExchangeSpender[msg.sender], "Address is not allowed to spend");
+    require(isExchangeSpender[msg.sender], "Address not allowed to spend");
     return _transferCollateralAsset(collateralAsset, to, value);
   }
 

--- a/contracts/interfaces/IReserve.sol
+++ b/contracts/interfaces/IReserve.sol
@@ -42,4 +42,10 @@ interface IReserve {
   function getDailySpendingRatioForCollateralAsset(address collateralAsset) external view returns (uint256);
 
   function isExchangeSpender(address exchange) external view returns (bool);
+
+  function transferExchangeCollateralAsset(
+    address collateralAsset,
+    address payable to,
+    uint256 value
+  ) external returns (bool);
 }

--- a/test/Reserve.t.sol
+++ b/test/Reserve.t.sol
@@ -505,21 +505,6 @@ contract ReserveTest_transfers is ReserveTest {
     reserve.transferExchangeCollateralAsset(address(dummyToken1), trader, 1000);
   }
 
-  function transferExchangeCollateralAssetSpecs(address caller) public {
-    changePrank(caller);
-    address payable dest = address(0x1111);
-    reserve.transferExchangeCollateralAsset(address(dummyToken1), dest, 1000);
-    assertEq(dummyToken1.balanceOf(dest), 1000);
-
-    changePrank(spender);
-    vm.expectRevert("Address not allowed to spend");
-    reserve.transferExchangeCollateralAsset(address(dummyToken1), dest, 1000);
-
-    changePrank(notDeployer);
-    vm.expectRevert("Address not allowed to spend");
-    reserve.transferExchangeCollateralAsset(address(dummyToken1), dest, 1000);
-  }
-
   function test_addExchangeSpender() public {
     address exchangeSpender0 = address(0x22222);
     address exchangeSpender1 = address(0x33333);

--- a/test/Reserve.t.sol
+++ b/test/Reserve.t.sol
@@ -4,18 +4,18 @@
 pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { Test } from "celo-foundry/Test.sol";
 
-import "./utils/WithRegistry.sol";
-import "./utils/TokenHelpers.sol";
-import "./utils/DummyErc20.sol";
+import { WithRegistry } from "./utils/WithRegistry.sol";
+import { TokenHelpers } from "./utils/TokenHelpers.sol";
+import { DummyERC20 } from "./utils/DummyErc20.sol";
 
-import "./mocks/MockSortedOracles.sol";
-import "./mocks/MockStableToken.sol";
+import { MockSortedOracles } from "./mocks/MockSortedOracles.sol";
+import { MockStableToken } from "./mocks/MockStableToken.sol";
 
-import "contracts/Reserve.sol";
-import "contracts/common/FixidityLib.sol";
+import { Reserve } from "contracts/Reserve.sol";
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
 
 contract ReserveTest is Test, WithRegistry, TokenHelpers {
   using SafeMath for uint256;
@@ -47,19 +47,21 @@ contract ReserveTest is Test, WithRegistry, TokenHelpers {
   uint256 tobinTaxReserveRatio = FixidityLib.newFixedFraction(2, 1).unwrap();
 
   address deployer;
-  address rando;
+  address notDeployer;
 
+  address broker;
   Reserve reserve;
   MockSortedOracles sortedOracles;
   DummyERC20 dummyToken1 = new DummyERC20("DummyToken1", "DT1", 18);
   DummyERC20 dummyToken2 = new DummyERC20("DummyToken2", "DT2", 18);
 
   function setUp() public {
-    rando = actor("rando");
+    notDeployer = actor("notDeployer");
     deployer = actor("deployer");
     changePrank(deployer);
     reserve = new Reserve(true);
     sortedOracles = new MockSortedOracles();
+    broker = actor("broker");
 
     registry.setAddressFor("SortedOracles", address(sortedOracles));
     registry.setAddressFor("Exchange", exchangeAddress);
@@ -122,7 +124,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     vm.expectRevert("tobin tax cannot be larger than 1");
     reserve.setTobinTax(FixidityLib.newFixed(1).unwrap().add(1));
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.setTobinTax(100);
   }
@@ -134,7 +136,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     reserve.setTobinTaxReserveRatio(newValue);
     assertEq(reserve.tobinTaxReserveRatio(), newValue);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.setTobinTaxReserveRatio(100);
   }
@@ -149,7 +151,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     vm.expectRevert("spending ratio cannot be larger than 1");
     reserve.setDailySpendingRatio(FixidityLib.newFixed(1).unwrap().add(1));
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.setDailySpendingRatio(100);
   }
@@ -200,7 +202,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
   }
 
   function test_setDailySpendingRatioForCollateralAssets_whenSenderIsNotOwner_shouldRevert() public {
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.setDailySpendingRatioForCollateralAssets(new address[](0), new uint256[](0));
   }
@@ -225,7 +227,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
   }
 
   function test_addCollateralAsset_whenNotOwner_shouldRevert() public {
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.addCollateralAsset(address(0x1234));
   }
@@ -248,7 +250,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
   }
 
   function test_removeCollateralAsset_whenNotOwner_shouldRevert() public {
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.removeCollateralAsset(address(dummyToken1), 0);
   }
@@ -258,7 +260,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     reserve.setRegistry(newValue);
     assertEq(address(reserve.registry()), newValue);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.setRegistry(address(0x1234));
   }
@@ -273,7 +275,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     vm.expectRevert("token addr already registered");
     reserve.addToken(token);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.addToken(address(0x1234));
   }
@@ -291,7 +293,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     emit TokenRemoved(token, 0);
     reserve.removeToken(token, 0);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.removeToken(address(0x1234), 0);
   }
@@ -303,7 +305,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     reserve.setTobinTaxStalenessThreshold(newThreshold);
     assertEq(reserve.tobinTaxStalenessThreshold(), newThreshold);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.setTobinTaxStalenessThreshold(newThreshold);
   }
@@ -320,7 +322,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     vm.expectRevert("reserve addr already added");
     reserve.addOtherReserveAddress(otherReserveAddresses[0]);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.addOtherReserveAddress(otherReserveAddresses[1]);
     changePrank(deployer);
@@ -349,7 +351,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     reserve.addOtherReserveAddress(otherReserveAddresses[0]);
     reserve.addOtherReserveAddress(otherReserveAddresses[1]);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.removeOtherReserveAddress(otherReserveAddresses[0], 0);
     changePrank(deployer);
@@ -378,7 +380,7 @@ contract ReserveTest_initAndSetters is ReserveTest {
     assertEq(reserve.getAssetAllocationSymbols(), assetAllocationSymbols);
     assertEq(reserve.getAssetAllocationWeights(), assetAllocationWeights);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.setAssetAllocations(assetAllocationSymbols, assetAllocationWeights);
     changePrank(deployer);
@@ -490,11 +492,39 @@ contract ReserveTest_transfers is ReserveTest {
     reserve.transferCollateralAsset(address(dummyToken1), address(0x234), reserveDummyToken1Balance);
   }
 
+  function test_transferExchangeCollateralAsset_whenSenderIsBroker_shouldTransfer() public {
+    reserve.addExchangeSpender(broker);
+    changePrank(broker);
+    reserve.transferExchangeCollateralAsset(address(dummyToken1), trader, 1000);
+    assertEq(dummyToken1.balanceOf(trader), 1000);
+  }
+
+  function test_transferExchangeCollateralAsset_notExchangeSender_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Address not allowed to spend");
+    reserve.transferExchangeCollateralAsset(address(dummyToken1), trader, 1000);
+  }
+
+  function transferExchangeCollateralAssetSpecs(address caller) public {
+    changePrank(caller);
+    address payable dest = address(0x1111);
+    reserve.transferExchangeCollateralAsset(address(dummyToken1), dest, 1000);
+    assertEq(dummyToken1.balanceOf(dest), 1000);
+
+    changePrank(spender);
+    vm.expectRevert("Address not allowed to spend");
+    reserve.transferExchangeCollateralAsset(address(dummyToken1), dest, 1000);
+
+    changePrank(notDeployer);
+    vm.expectRevert("Address not allowed to spend");
+    reserve.transferExchangeCollateralAsset(address(dummyToken1), dest, 1000);
+  }
+
   function test_addExchangeSpender() public {
     address exchangeSpender0 = address(0x22222);
     address exchangeSpender1 = address(0x33333);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.addExchangeSpender(exchangeSpender0);
 
@@ -517,7 +547,7 @@ contract ReserveTest_transfers is ReserveTest {
     address exchangeSpender1 = address(0x33333);
     reserve.addExchangeSpender(exchangeSpender0);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.removeExchangeSpender(exchangeSpender0, 0);
 
@@ -545,7 +575,7 @@ contract ReserveTest_transfers is ReserveTest {
   function test_addSpender() public {
     address _spender = address(0x4444);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.addSpender(_spender);
 
@@ -563,7 +593,7 @@ contract ReserveTest_transfers is ReserveTest {
 
     reserve.addSpender(_spender);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     reserve.removeSpender(_spender);
 
@@ -600,7 +630,7 @@ contract ReserveTest_transfers is ReserveTest {
     vm.expectRevert("Address not allowed to spend");
     reserve.transferExchangeGold(dest, 1000);
 
-    changePrank(rando);
+    changePrank(notDeployer);
     vm.expectRevert("Address not allowed to spend");
     reserve.transferExchangeGold(dest, 1000);
   }

--- a/test/mocks/MockReserve.sol
+++ b/test/mocks/MockReserve.sol
@@ -40,6 +40,13 @@ contract MockReserve {
     return true;
   }
 
+  function transferExchangeCollateralAsset( address tokenAddress,
+    address payable to,
+    uint256 amount) external returns (bool) {
+    require(IERC20(tokenAddress).transfer(to, amount), "asset transfer failed");
+    return true;
+  }
+
   function addToken(address token) external returns (bool) {
     tokens[token] = true;
     return true;

--- a/test/utils/IntegrationSetup.sol
+++ b/test/utils/IntegrationSetup.sol
@@ -25,7 +25,7 @@ import { TradingLimits } from "contracts/common/TradingLimits.sol";
 
 import { FixidityLib } from "contracts/common/FixidityLib.sol";
 import { Freezer } from "contracts/common/Freezer.sol";
-import { AddressSortedLinkedListWithMedian } from "contracts//common/linkedlists/AddressSortedLinkedListWithMedian.sol";
+import { AddressSortedLinkedListWithMedian } from "contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol";
 import { SortedLinkedListWithMedian } from "contracts/common/linkedlists/SortedLinkedListWithMedian.sol";
 
 import { WithRegistry } from "./WithRegistry.sol";
@@ -265,7 +265,6 @@ contract IntegrationSetup is Test, WithRegistry {
     broker.initialize(exchangeProviders, address(reserve));
     registry.setAddressFor("Broker", address(broker));
     reserve.addExchangeSpender(address(broker));
-    reserve.addSpender(address(broker));
 
     /* ====== Create pairs for all asset combinations ======= */
 


### PR DESCRIPTION
### Description

In this pr, I'm updating a missing functionality in reserve, which will enable the broker to transfer collateral assets without being an object to spending limits

### Tested

unit tests

### Related issues

- Fixes #79 

### Backwards compatibility

n/a

### Documentation

n/a
