### PR TITLE
feat(breaker): make breakers configurable for specific ratefeeds

### DIFF
--- a/contracts/BreakerBox.sol
+++ b/contracts/BreakerBox.sol
@@ -32,7 +32,7 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
   // Ordered list of breakers to be checked.
   LinkedList.List private breakers;
   // Maps a breaker with rate feed id and bool to check if it's enabled.
-  mapping(address => mapping(address => bool)) breakerEnabled;
+  mapping(address => mapping(address => bool)) public breakerEnabled;
 
   // Address of the Mento SortedOracles contract
   ISortedOracles public sortedOracles;
@@ -140,7 +140,11 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
     emit BreakerRemoved(breaker);
   }
 
-  // todo write natspec to describe the changes
+  /**
+   * @notice Sets a breaker that is enabled for the specified rate feed.
+   * @param breaker The address of the breaker to be enabled.
+   * @param rateFeedID The address of the rate feed.
+   */
   function setBreakerEnabled(address breaker, address rateFeedID) public onlyOwner {
     TradingModeInfo memory info = rateFeedTradingModes[rateFeedID];
     require(info.lastUpdatedTime != 0, "this rate feed has not been registered");
@@ -261,6 +265,15 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
     return info.tradingMode;
   }
 
+  /**
+   * @notice Checks if a breaker is enabled for a specific rate feed.
+   * @param breaker The address of the breaker we're checking for.
+   * @param rateFeedID The address of the rateFeedID.
+   */
+  function isBreakerEnabled(address breaker, address rateFeedID) external view returns (bool) {
+    return breakerEnabled[breaker][rateFeedID];
+  }
+
   /* ==================== Check Breakers ==================== */
 
   /**
@@ -309,7 +322,7 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
 
     // Check all breakers.
     for (uint256 i = 0; i < _breakers.length; i++) {
-      if (breakerEnabled[_breakers[i]][rateFeedID]) {
+      if (isBreakerEnabled(_breakers[i], rateFeedID)) {
         IBreaker breaker = IBreaker(_breakers[i]);
         bool tripBreaker = breaker.shouldTrigger(rateFeedID);
         if (tripBreaker) {

--- a/contracts/BreakerBox.sol
+++ b/contracts/BreakerBox.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.5.13;
 import { IBreakerBox } from "./interfaces/IBreakerBox.sol";
 import { IBreaker } from "./interfaces/IBreaker.sol";
 import { ISortedOracles } from "./interfaces/ISortedOracles.sol";
-import { Test, console2 as console } from "celo-foundry/Test.sol";
 
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { AddressLinkedList, LinkedList } from "./common/linkedlists/AddressLinkedList.sol";
@@ -145,12 +144,12 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
   }
 
   /**
-   * @notice Enables a breaker for the specified rate feed.
-   * @param breaker The address of the breaker to be enabled.
+   * @notice Enables or disables a breaker for the specified rate feed.
+   * @param breaker The address of the breaker.
    * @param rateFeedID The address of the rate feed.
    * @param status Bool indicating the the status.
    */
-  function setBreakerEnabled(
+  function toggleBreaker(
     address breaker,
     address rateFeedID,
     bool status
@@ -158,24 +157,10 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
     TradingModeInfo memory info = rateFeedTradingModes[rateFeedID];
     require(info.lastUpdatedTime != 0, "this rate feed has not been registered");
     require(isBreaker(breaker), "this breaker has not been registered in the breakers list");
-    breakerEnabled[breaker][rateFeedID] = status;
-    emit BreakerStatusUpdated(breaker, rateFeedID, status);
-  }
-
-  /**
-   * @notice Disables a breaker for the specified rate feed.
-   * @param breaker The address of the breaker to be disabled.
-   * @param rateFeedID The address of the rate feed.
-   * @param status Bool indicating the the status.
-   */
-  function disableBreaker(
-    address breaker,
-    address rateFeedID,
-    bool status
-  ) public onlyOwner {
-    TradingModeInfo memory info = rateFeedTradingModes[rateFeedID];
-    require(info.lastUpdatedTime != 0, "this rate feed has not been registered");
-    require(isBreaker(breaker), "this breaker has not been registered in the breakers list");
+    if (!status && tradingModeBreaker[info.tradingMode] == breaker) {
+      tradingModeBreaker[info.tradingMode] = address(0);
+      breakerTradingMode[breaker] = 0;
+    }
     breakerEnabled[breaker][rateFeedID] = status;
     emit BreakerStatusUpdated(breaker, rateFeedID, status);
   }

--- a/contracts/BreakerBox.sol
+++ b/contracts/BreakerBox.sol
@@ -158,8 +158,7 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
     require(info.lastUpdatedTime != 0, "this rate feed has not been registered");
     require(isBreaker(breaker), "this breaker has not been registered in the breakers list");
     if (!status && tradingModeBreaker[info.tradingMode] == breaker) {
-      tradingModeBreaker[info.tradingMode] = address(0);
-      breakerTradingMode[breaker] = 0;
+      setRateFeedTradingMode(rateFeedID, 0);
     }
     breakerEnabled[breaker][rateFeedID] = status;
     emit BreakerStatusUpdated(breaker, rateFeedID, status);

--- a/contracts/BreakerBox.sol
+++ b/contracts/BreakerBox.sol
@@ -303,10 +303,7 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
           info.lastUpdatedTime = uint64(block.timestamp);
           info.lastUpdatedBlock = uint128(block.number);
           rateFeedTradingModes[rateFeedID] = info;
-          // todo teat the edge case when we're disabling a breaker for a rate feed if that breaker is already tripped.
           breakerEnabled[address(breaker)][rateFeedID] = false;
-          // todo We should reset the trading mode of the rate feed to the default.
-          setRateFeedTradingMode(rateFeedID, 0);
           emit ResetSuccessful(rateFeedID, address(breaker));
         } else {
           emit ResetAttemptCriteriaFail(rateFeedID, address(breaker));
@@ -322,7 +319,7 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
 
     // Check all breakers.
     for (uint256 i = 0; i < _breakers.length; i++) {
-      if (isBreakerEnabled(_breakers[i], rateFeedID)) {
+      if (breakerEnabled[_breakers[i]][rateFeedID]) {
         IBreaker breaker = IBreaker(_breakers[i]);
         bool tripBreaker = breaker.shouldTrigger(rateFeedID);
         if (tripBreaker) {

--- a/contracts/BreakerBox.sol
+++ b/contracts/BreakerBox.sol
@@ -123,6 +123,7 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
     uint64 tradingMode = breakerTradingMode[breaker];
 
     // Set any refenceRateIDs using this breakers trading mode to the default mode.
+    // Disable a breaker on this address
     address[] memory activeRateFeeds = rateFeedIDs;
     TradingModeInfo memory tradingModeInfo;
 
@@ -131,8 +132,10 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
       if (tradingModeInfo.tradingMode == tradingMode) {
         setRateFeedTradingMode(activeRateFeeds[i], 0);
       }
+      if (breakerEnabled[breaker][activeRateFeeds[i]]) {
+        breakerEnabled[breaker][activeRateFeeds[i]] = false;
+      }
     }
-
     delete tradingModeBreaker[tradingMode];
     delete breakerTradingMode[breaker];
     breakers.remove(breaker);
@@ -141,7 +144,7 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
   }
 
   /**
-   * @notice Sets a breaker that is enabled for the specified rate feed.
+   * @notice Enables a breaker for the specified rate feed.
    * @param breaker The address of the breaker to be enabled.
    * @param rateFeedID The address of the rate feed.
    */
@@ -207,6 +210,15 @@ contract BreakerBox is IBreakerBox, Initializable, Ownable {
     rateFeedIDs.pop();
 
     delete rateFeedTradingModes[rateFeedID];
+
+    address[] memory _breakers = breakers.getKeys();
+
+    // remove configured rate feed for the breaker
+    for (uint256 i = 0; i < _breakers.length; i++) {
+      if (breakerEnabled[_breakers[i]][rateFeedID]) {
+        breakerEnabled[_breakers[i]][rateFeedID] = false;
+      }
+    }
     emit RateFeedRemoved(rateFeedID);
   }
 

--- a/contracts/MedianDeltaBreaker.sol
+++ b/contracts/MedianDeltaBreaker.sol
@@ -171,7 +171,7 @@ contract MedianDeltaBreaker is IBreaker, Ownable {
 
     uint256 rateSpecificThreshold = rateChangeThreshold[rateFeedID].unwrap();
 
-    // checks if a given rate feed id has a threshold set
+    // checks if a given rate feed id has a threshold set and reassignes it
     if (rateSpecificThreshold != 0) allowedThreshold = rateSpecificThreshold;
 
     uint256 fixed1 = FixidityLib.fixed1().unwrap();

--- a/contracts/MedianDeltaBreaker.sol
+++ b/contracts/MedianDeltaBreaker.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.5.13;
 import { IBreaker } from "./interfaces/IBreaker.sol";
 import { ISortedOracles } from "./interfaces/ISortedOracles.sol";
 
-import { UsingRegistry } from "./common/UsingRegistry.sol";
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -30,7 +29,7 @@ contract MedianDeltaBreaker is IBreaker, Ownable {
   FixidityLib.Fraction public defaultRateChangeThreshold;
 
   // Maps rate feed to a threshold.
-  mapping(address => FixidityLib.Fraction) rateChangeThreshold;
+  mapping(address => FixidityLib.Fraction) public rateChangeThreshold;
 
   // Address of the Mento SortedOracles contract
   ISortedOracles public sortedOracles;
@@ -47,8 +46,8 @@ contract MedianDeltaBreaker is IBreaker, Ownable {
     _transferOwnership(msg.sender);
     setCooldownTime(_cooldownTime);
     setDefaultRateChangeThreshold(_defaultRateChangeThreshold);
-    setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
     setSortedOracles(_sortedOracles);
+    setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
   }
 
   /* ==================== Restricted Functions ==================== */
@@ -84,7 +83,7 @@ contract MedianDeltaBreaker is IBreaker, Ownable {
   {
     require(
       rateFeedIDs.length == rateChangeThresholds.length,
-      "Rate feeds and rate change thresholds have to be the same length"
+      "rate feeds and rate change thresholds have to be the same length"
     );
     for (uint256 i = 0; i < rateFeedIDs.length; i++) {
       if (rateFeedIDs[i] != address(0) && rateChangeThresholds[i] != 0) {
@@ -162,13 +161,14 @@ contract MedianDeltaBreaker is IBreaker, Ownable {
     address rateFeedID
   ) public view returns (bool) {
     uint256 allowedThreshold;
+
     uint256 rateSpecificThreshold = rateChangeThreshold[rateFeedID].unwrap();
 
     // checks if a given rate feed id has a threshold set
     if (rateSpecificThreshold != 0) {
       allowedThreshold = rateSpecificThreshold;
     }
-
+   
     // otherwise just uses a default threshold
     allowedThreshold = defaultRateChangeThreshold.unwrap();
     uint256 fixed1 = FixidityLib.fixed1().unwrap();

--- a/contracts/interfaces/IBreaker.sol
+++ b/contracts/interfaces/IBreaker.sol
@@ -26,7 +26,7 @@ interface IBreaker {
 
   /**
    * @notice Emitted when the rate feed is configured to a rate threshold.
-   * @param defaultRateChangeThreshold The threshold of the rate feed.
+   * @param rateChangeThreshold The threshold of the rate feed.
    */
   event RateChangeThresholdForRateFeedUpdated(address rateFeedID, uint256 rateChangeThreshold);
 

--- a/contracts/interfaces/IBreaker.sol
+++ b/contracts/interfaces/IBreaker.sol
@@ -19,18 +19,6 @@ interface IBreaker {
   event SortedOraclesUpdated(address newSortedOracles);
 
   /**
-   * @notice Emitted when the default rate threshold is updated.
-   * @param defaultRateChangeThreshold The value of the new threshold.
-   */
-  event DefaultRateChangeThresholdUpdated(uint256 defaultRateChangeThreshold);
-
-  /**
-   * @notice Emitted when the rate feed is configured to a rate threshold.
-   * @param rateChangeThreshold The threshold of the rate feed.
-   */
-  event RateChangeThresholdForRateFeedUpdated(address rateFeedID, uint256 rateChangeThreshold);
-
-  /**
    * @notice Retrieve the cooldown time for the breaker.
    * @return cooldown The amount of time that must pass before the breaker can reset.
    * @dev when cooldown is 0 auto reset will not be attempted.

--- a/contracts/interfaces/IBreaker.sol
+++ b/contracts/interfaces/IBreaker.sol
@@ -19,6 +19,18 @@ interface IBreaker {
   event SortedOraclesUpdated(address newSortedOracles);
 
   /**
+   * @notice Emitted when the default rate threshold is updated.
+   * @param defaultRateChangeThreshold The value of the new threshold.
+   */
+  event DefaultRateChangeThresholdUpdated(uint256 defaultRateChangeThreshold);
+
+  /**
+   * @notice Emitted when the rate feed is configured to a rate threshold.
+   * @param defaultRateChangeThreshold The threshold of the rate feed.
+   */
+  event RateChangeThresholdForRateFeedUpdated(address rateFeedID, uint256 rateChangeThreshold);
+
+  /**
    * @notice Retrieve the cooldown time for the breaker.
    * @return cooldown The amount of time that must pass before the breaker can reset.
    * @dev when cooldown is 0 auto reset will not be attempted.

--- a/contracts/interfaces/IBreakerBox.sol
+++ b/contracts/interfaces/IBreakerBox.sol
@@ -30,49 +30,49 @@ interface IBreakerBox {
   event BreakerRemoved(address indexed breaker);
 
   /**
-   * @notice Emitted when a breaker is tripped by a rateFeedID.
+   * @notice Emitted when a breaker is tripped by a rate feed.
    * @param breaker The address of the breaker that was tripped.
-   * @param rateFeedID The address of the rateFeedID.
+   * @param rateFeedID The address of the rate feed.
    */
   event BreakerTripped(address indexed breaker, address indexed rateFeedID);
 
   /**
-   * @notice Emitted when a new rateFeedID is added to the breaker box.
-   * @param rateFeedID The address of the rateFeedID that was added.
+   * @notice Emitted when a new rate feed is added to the breaker box.
+   * @param rateFeedID The address of the rate feed that was added.
    */
   event RateFeedAdded(address indexed rateFeedID);
 
   /**
-   * @notice Emitted when a rateFeedID is removed from the breaker box.
-   * @param rateFeedID The rateFeedID that was removed.
+   * @notice Emitted when a rate feed is removed from the breaker box.
+   * @param rateFeedID The rate feed that was removed.
    */
   event RateFeedRemoved(address indexed rateFeedID);
 
   /**
-   * @notice Emitted when the trading mode for a rateFeedID is updated
+   * @notice Emitted when the trading mode for a rate feed is updated
    * @param rateFeedID The address of the rataFeedID.
-   * @param tradingMode The new trading mode of the rateFeedID.
+   * @param tradingMode The new trading mode of the rate feed.
    */
   event TradingModeUpdated(address indexed rateFeedID, uint256 tradingMode);
 
   /**
    * @notice Emitted after a reset attempt is successful.
-   * @param rateFeedID The address of the rateFeedID.
+   * @param rateFeedID The address of the rate feed.
    * @param breaker The address of the breaker.
    */
   event ResetSuccessful(address indexed rateFeedID, address indexed breaker);
 
   /**
    * @notice  Emitted after a reset attempt fails when the
-   *          rateFeedID fails the breakers reset criteria.
-   * @param rateFeedID The address of the rateFeedID.
+   *          rate feed fails the breakers reset criteria.
+   * @param rateFeedID The address of the rate feed.
    * @param breaker The address of the breaker.
    */
   event ResetAttemptCriteriaFail(address indexed rateFeedID, address indexed breaker);
 
   /**
    * @notice Emitted after a reset attempt fails when cooldown time has not elapsed.
-   * @param rateFeedID The address of the rateFeedID.
+   * @param rateFeedID The address of the rate feed.
    * @param breaker The address of the breaker.
    */
   event ResetAttemptNotCool(address indexed rateFeedID, address indexed breaker);
@@ -82,6 +82,13 @@ interface IBreakerBox {
    * @param newSortedOracles The address of the new sortedOracles.
    */
   event SortedOraclesUpdated(address indexed newSortedOracles);
+
+   /**
+   * @notice Emitted when the breaker is enabled for a rate feed.
+   * @param breaker The address of the breaker.
+   * @param rateFeedID The address of the rate feed.
+   */
+  event BreakerEnabled(address breaker, address rateFeedID);
 
   /**
    * @notice Retrives an ordered array of all breaker addresses.

--- a/contracts/interfaces/IBreakerBox.sol
+++ b/contracts/interfaces/IBreakerBox.sol
@@ -84,11 +84,12 @@ interface IBreakerBox {
   event SortedOraclesUpdated(address indexed newSortedOracles);
 
    /**
-   * @notice Emitted when the breaker is enabled for a rate feed.
+   * @notice Emitted when the breaker is enabled or disabled for a rate feed.
    * @param breaker The address of the breaker.
    * @param rateFeedID The address of the rate feed.
+   * @param status Indicating the status.
    */
-  event BreakerEnabled(address breaker, address rateFeedID);
+  event BreakerStatusUpdated(address breaker, address rateFeedID, bool status);
 
   /**
    * @notice Retrives an ordered array of all breaker addresses.

--- a/test/BreakerBox.t.sol
+++ b/test/BreakerBox.t.sol
@@ -294,8 +294,7 @@ contract BreakerBoxTest_constructorAndSetters is BreakerBoxTest {
     toggleAndAssertBreaker(address(mockBreaker1), rateFeedID1, true);
     toggleAndAssertBreaker(address(mockBreaker1), rateFeedID1, false);
 
-    assert(breakerBox.breakerTradingMode(address(mockBreaker1)) == 0);
-    assert(breakerBox.tradingModeBreaker(1) == address(0));
+    assertEq(breakerBox.getRateFeedTradingMode(rateFeedID1), 0);
   }
 
   /* ---------- Rate Feed IDs ---------- */

--- a/test/BreakerBox.t.sol
+++ b/test/BreakerBox.t.sol
@@ -202,12 +202,15 @@ contract BreakerBoxTest_constructorAndSetters is BreakerBoxTest {
   }
 
   function test_removeBreaker_shouldUpdateStorageAndEmit() public {
+    breakerBox.setBreakerEnabled(address(mockBreaker1), rateFeedID1);
+
     vm.expectEmit(true, false, false, false);
     emit BreakerRemoved(address(mockBreaker1));
 
     assert(breakerBox.tradingModeBreaker(1) == address(mockBreaker1));
     assert(breakerBox.breakerTradingMode(address(mockBreaker1)) == 1);
     assert(breakerBox.isBreaker(address(mockBreaker1)));
+    assertEq(breakerBox.isBreakerEnabled(address(mockBreaker1), rateFeedID3), false);
 
     breakerBox.removeBreaker(address(mockBreaker1));
 
@@ -298,7 +301,6 @@ contract BreakerBoxTest_constructorAndSetters is BreakerBoxTest {
     sortedOracles.addOracle(rateFeedID3, actor("oracleAddress"));
     vm.expectEmit(true, true, true, true);
     emit RateFeedAdded(rateFeedID3);
-
     (uint256 tradingModeBefore, uint256 lastUpdatedTimeBefore, uint256 lastUpdatedBlockBefore) = breakerBox
       .rateFeedTradingModes(rateFeedID3);
 
@@ -330,6 +332,8 @@ contract BreakerBoxTest_constructorAndSetters is BreakerBoxTest {
   }
 
   function test_removeRateFeed_shouldResetTradingModeInfoAndEmit() public {
+    breakerBox.setBreakerEnabled(address(mockBreaker1), rateFeedID1);
+
     breakerBox.setRateFeedTradingMode(rateFeedID1, 1);
     vm.expectEmit(true, true, true, true);
     emit RateFeedRemoved(rateFeedID1);
@@ -347,6 +351,7 @@ contract BreakerBoxTest_constructorAndSetters is BreakerBoxTest {
     assert(tradingModeAfter == 0);
     assert(lastUpdatedTimeAfter == 0);
     assert(lastUpdatedBlockAfter == 0);
+    assertEq(breakerBox.isBreakerEnabled(address(mockBreaker1), rateFeedID3), false);
   }
 
   function test_setRateFeedTradingMode_whenRateFeedHasNotBeenAdded_ShouldRevert() public {

--- a/test/MedianDeltaBreaker.t.sol
+++ b/test/MedianDeltaBreaker.t.sol
@@ -28,7 +28,7 @@ contract MedianDeltaBreakerTest is Test, WithRegistry {
   event BreakerTriggered(address indexed rateFeedID);
   event BreakerReset(address indexed rateFeedID);
   event CooldownTimeUpdated(uint256 newCooldownTime);
-  event PriceChangeThresholdUpdated(uint256 newMinPriceChangeThreshold);
+  event RateChangeThresholdUpdated(uint256 newMinRateChangeThreshold);
   event SortedOraclesUpdated(address newSortedOracles);
 
   function setUp() public {
@@ -69,8 +69,8 @@ contract MedianDeltaBreakerTest_constructorAndSetters is MedianDeltaBreakerTest 
     assertEq(breaker.cooldownTime(), coolDownTime);
   }
 
-  function test_constructor_shouldSetPriceChangeThreshold() public {
-    assertEq(breaker.priceChangeThreshold(), threshold);
+  function test_constructor_shouldSetRateChangeThreshold() public {
+    assertEq(breaker.rateChangeThreshold(), threshold);
   }
 
   function test_constructor_shouldSetSortedOracles() public {
@@ -95,26 +95,26 @@ contract MedianDeltaBreakerTest_constructorAndSetters is MedianDeltaBreakerTest 
     assertEq(breaker.cooldownTime(), testCooldown);
   }
 
-  function test_setPriceChangeThreshold_whenCallerIsNotOwner_shouldRevert() public {
+  function test_setRateChangeThreshold_whenCallerIsNotOwner_shouldRevert() public {
     vm.expectRevert("Ownable: caller is not the owner");
     changePrank(nonDeployer);
 
-    breaker.setPriceChangeThreshold(123456);
+    breaker.setRateChangeThreshold(123456);
   }
 
-  function test_setPriceChangeThreshold_whenValueGreaterThanOne_shouldRevert() public {
-    vm.expectRevert("price change threshold must be less than 1");
-    breaker.setPriceChangeThreshold(1 * 10**24);
+  function test_setRateChangeThreshold_whenValueGreaterThanOne_shouldRevert() public {
+    vm.expectRevert("rate change threshold must be less than 1");
+    breaker.setRateChangeThreshold(1 * 10**24);
   }
 
-  function test_setPriceChangeThreshold_whenCallerIsOwner_shouldUpdateAndEmit() public {
+  function test_setRateChangeThreshold_whenCallerIsOwner_shouldUpdateAndEmit() public {
     uint256 testThreshold = 0.1 * 10**24;
     vm.expectEmit(false, false, false, true);
-    emit PriceChangeThresholdUpdated(testThreshold);
+    emit RateChangeThresholdUpdated(testThreshold);
 
-    breaker.setPriceChangeThreshold(testThreshold);
+    breaker.setRateChangeThreshold(testThreshold);
 
-    assertEq(breaker.priceChangeThreshold(), testThreshold);
+    assertEq(breaker.rateChangeThreshold(), testThreshold);
   }
 
   function test_setSortedOracles_whenSenderIsNotOwner_shouldRevert() public {

--- a/test/MedianDeltaBreaker.t.sol
+++ b/test/MedianDeltaBreaker.t.sol
@@ -34,7 +34,7 @@ contract MedianDeltaBreakerTest is Test, WithRegistry {
   event CooldownTimeUpdated(uint256 newCooldownTime);
   event DefaultRateChangeThresholdUpdated(uint256 newMinRateChangeThreshold);
   event SortedOraclesUpdated(address newSortedOracles);
-  event RateChangeThresholdForRateFeedUpdated(address rateFeedID, uint256 rateChangeThreshold);
+  event RateChangeThresholdUpdated(address rateFeedID, uint256 rateChangeThreshold);
 
   function setUp() public {
     deployer = actor("deployer");
@@ -188,9 +188,9 @@ contract MedianDeltaBreakerTest_constructorAndSetters is MedianDeltaBreakerTest 
 
   function test_setRateChangeThreshold_whenSenderIsOwner_shouldUpdateAndEmit() public {
     vm.expectEmit(true, true, true, true);
-    emit RateChangeThresholdForRateFeedUpdated(rateFeedIDs[0], rateChangeThresholds[0]);
+    emit RateChangeThresholdUpdated(rateFeedIDs[0], rateChangeThresholds[0]);
     vm.expectEmit(true, true, true, true);
-    emit RateChangeThresholdForRateFeedUpdated(rateFeedIDs[1], rateChangeThresholds[1]);
+    emit RateChangeThresholdUpdated(rateFeedIDs[1], rateChangeThresholds[1]);
     breaker.setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
     assertEq(breaker.rateChangeThreshold(rateFeedIDs[0]), rateChangeThresholds[0]);
     assertEq(breaker.rateChangeThreshold(rateFeedIDs[1]), rateChangeThresholds[1]);

--- a/test/MedianDeltaBreaker.t.sol
+++ b/test/MedianDeltaBreaker.t.sol
@@ -2,6 +2,7 @@
 // solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
 // solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
 pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
 
 import { Test, console2 as console } from "celo-foundry/Test.sol";
 import { ISortedOracles } from "contracts/interfaces/ISortedOracles.sol";
@@ -16,7 +17,7 @@ import { MockSortedOracles } from "./mocks/MockSortedOracles.sol";
 
 contract MedianDeltaBreakerTest is Test, WithRegistry {
   address deployer;
-  address nonDeployer;
+  address notDeployer;
 
   address rateFeedID;
   MockSortedOracles sortedOracles;
@@ -25,22 +26,39 @@ contract MedianDeltaBreakerTest is Test, WithRegistry {
   uint256 threshold = 0.15 * 10**24; // 15%
   uint256 coolDownTime = 5 minutes;
 
+  address[] rateFeedIDs = new address[](2);
+  uint256[] rateChangeThresholds = new uint256[](2);
+
   event BreakerTriggered(address indexed rateFeedID);
   event BreakerReset(address indexed rateFeedID);
   event CooldownTimeUpdated(uint256 newCooldownTime);
-  event RateChangeThresholdUpdated(uint256 newMinRateChangeThreshold);
+  event DefaultRateChangeThresholdUpdated(uint256 newMinRateChangeThreshold);
   event SortedOraclesUpdated(address newSortedOracles);
+  event RateChangeThresholdForRateFeedUpdated(address rateFeedID, uint256 rateChangeThreshold);
 
   function setUp() public {
     deployer = actor("deployer");
-    nonDeployer = actor("nonDeployer");
+    notDeployer = actor("notDeployer");
     rateFeedID = actor("rateFeedID");
 
-    changePrank(deployer);
+    rateFeedIDs[0] = actor("rateFeedId0");
+    rateFeedIDs[1] = actor("rateFeedId1");
+    rateChangeThresholds[0] = 0.14 * 10**24;
+    rateChangeThresholds[1] = 0.13 * 10**24;
 
+    changePrank(deployer);
     sortedOracles = new MockSortedOracles();
 
-    breaker = new MedianDeltaBreaker(coolDownTime, threshold, ISortedOracles(address(sortedOracles)));
+    sortedOracles.addOracle(rateFeedIDs[0], actor("oracleClient"));
+    sortedOracles.addOracle(rateFeedIDs[1], actor("oracleClient1"));
+
+    breaker = new MedianDeltaBreaker(
+      coolDownTime,
+      threshold,
+      rateFeedIDs,
+      rateChangeThresholds,
+      ISortedOracles(address(sortedOracles))
+    );
   }
 
   function setupSortedOracles(uint256 currentMedianRate, uint256 previousMedianRate) public {
@@ -70,18 +88,23 @@ contract MedianDeltaBreakerTest_constructorAndSetters is MedianDeltaBreakerTest 
   }
 
   function test_constructor_shouldSetRateChangeThreshold() public {
-    assertEq(breaker.rateChangeThreshold(), threshold);
+    assertEq(breaker.defaultRateChangeThreshold(), threshold);
   }
 
   function test_constructor_shouldSetSortedOracles() public {
     assertEq(address(breaker.sortedOracles()), address(sortedOracles));
   }
 
+  function test_constructor_shouldSetRateChangeThresholds() public {
+    assertEq(breaker.rateChangeThreshold(rateFeedIDs[0]), rateChangeThresholds[0]);
+    assertEq(breaker.rateChangeThreshold(rateFeedIDs[1]), rateChangeThresholds[1]);
+  }
+
   /* ---------- Setters ---------- */
 
   function test_setCooldownTime_whenCallerIsNotOwner_shouldRevert() public {
     vm.expectRevert("Ownable: caller is not the owner");
-    changePrank(nonDeployer);
+    changePrank(notDeployer);
     breaker.setCooldownTime(2 minutes);
   }
 
@@ -97,28 +120,28 @@ contract MedianDeltaBreakerTest_constructorAndSetters is MedianDeltaBreakerTest 
 
   function test_setRateChangeThreshold_whenCallerIsNotOwner_shouldRevert() public {
     vm.expectRevert("Ownable: caller is not the owner");
-    changePrank(nonDeployer);
+    changePrank(notDeployer);
 
-    breaker.setRateChangeThreshold(123456);
+    breaker.setDefaultRateChangeThreshold(123456);
   }
 
   function test_setRateChangeThreshold_whenValueGreaterThanOne_shouldRevert() public {
     vm.expectRevert("rate change threshold must be less than 1");
-    breaker.setRateChangeThreshold(1 * 10**24);
+    breaker.setDefaultRateChangeThreshold(1 * 10**24);
   }
 
   function test_setRateChangeThreshold_whenCallerIsOwner_shouldUpdateAndEmit() public {
     uint256 testThreshold = 0.1 * 10**24;
     vm.expectEmit(false, false, false, true);
-    emit RateChangeThresholdUpdated(testThreshold);
+    emit DefaultRateChangeThresholdUpdated(testThreshold);
 
-    breaker.setRateChangeThreshold(testThreshold);
+    breaker.setDefaultRateChangeThreshold(testThreshold);
 
-    assertEq(breaker.rateChangeThreshold(), testThreshold);
+    assertEq(breaker.defaultRateChangeThreshold(), testThreshold);
   }
 
   function test_setSortedOracles_whenSenderIsNotOwner_shouldRevert() public {
-    changePrank(nonDeployer);
+    changePrank(notDeployer);
     vm.expectRevert("Ownable: caller is not the owner");
     breaker.setSortedOracles(ISortedOracles(address(0)));
   }
@@ -138,6 +161,41 @@ contract MedianDeltaBreakerTest_constructorAndSetters is MedianDeltaBreakerTest 
     assertEq(address(breaker.sortedOracles()), newSortedOracles);
   }
 
+  function test_setRateChangeThreshold_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    breaker.setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
+  }
+
+  function test_setRateChangeThreshold_whenValuesAreDifferentLengths_shouldRevert() public {
+    address[] memory rateFeedIDs2 = new address[](1);
+    rateFeedIDs2[0] = actor("randomRateFeed");
+    vm.expectRevert("rate feeds and rate change thresholds have to be the same length");
+    breaker.setRateChangeThresholds(rateFeedIDs2, rateChangeThresholds);
+  }
+
+  function test_setRateChangeThreshold_whenThresholdIsMoreThan0_shouldRevert() public {
+    rateChangeThresholds[0] = 1 * 10**24;
+    vm.expectRevert("rate change threshold must be less than 1");
+    breaker.setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
+  }
+
+  function test_setRateChangeThreshold_whenRateFeedIdDoesNotExist_shouldRevert() public {
+    rateFeedIDs[0] = actor("randomRateFeed");
+    vm.expectRevert("rate feed ID does not exist as it has 0 oracles");
+    breaker.setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
+  }
+
+  function test_setRateChangeThreshold_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    vm.expectEmit(true, true, true, true);
+    emit RateChangeThresholdForRateFeedUpdated(rateFeedIDs[0], rateChangeThresholds[0]);
+    vm.expectEmit(true, true, true, true);
+    emit RateChangeThresholdForRateFeedUpdated(rateFeedIDs[1], rateChangeThresholds[1]);
+    breaker.setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
+    assertEq(breaker.rateChangeThreshold(rateFeedIDs[0]), rateChangeThresholds[0]);
+    assertEq(breaker.rateChangeThreshold(rateFeedIDs[1]), rateChangeThresholds[1]);
+  }
+
   /* ---------- Getters ---------- */
   function test_getCooldown_shouldReturnCooldown() public {
     assertEq(breaker.getCooldown(), coolDownTime);
@@ -145,35 +203,55 @@ contract MedianDeltaBreakerTest_constructorAndSetters is MedianDeltaBreakerTest 
 }
 
 contract MedianDeltaBreakerTest_shouldTrigger is MedianDeltaBreakerTest {
-  function updateMedianByPercent(uint256 medianChangeScaleFactor) public {
+  function updateMedianByPercent(uint256 medianChangeScaleFactor, address _rateFeedID) public {
     uint256 previousMedianRate = 0.98 * 10**24;
     uint256 currentMedianRate = (previousMedianRate * medianChangeScaleFactor) / 10**24;
     setupSortedOracles(currentMedianRate, previousMedianRate);
 
     vm.expectCall(
       address(sortedOracles),
-      abi.encodeWithSelector(sortedOracles.previousMedianRate.selector, rateFeedID)
+      abi.encodeWithSelector(sortedOracles.previousMedianRate.selector, _rateFeedID)
     );
-    vm.expectCall(address(sortedOracles), abi.encodeWithSelector(sortedOracles.medianRate.selector, rateFeedID));
+    vm.expectCall(address(sortedOracles), abi.encodeWithSelector(sortedOracles.medianRate.selector, _rateFeedID));
   }
 
   function test_shouldTrigger_whenMedianDrops30Percent_shouldReturnTrue() public {
-    updateMedianByPercent(0.7 * 10**24);
-    assertTrue(breaker.shouldTrigger(address(rateFeedID)));
+    // rateChangeThreshold not configured
+    updateMedianByPercent(0.7 * 10**24, rateFeedID);
+    assertTrue(breaker.shouldTrigger(rateFeedID));
+
+    // rateChangeThreshold 14 %
+    updateMedianByPercent(0.7 * 10**24, rateFeedIDs[0]);
+    assertTrue(breaker.shouldTrigger(rateFeedIDs[0]));
   }
 
   function test_shouldTrigger_whenMedianDrops10Percent_shouldReturnFalse() public {
-    updateMedianByPercent(0.9 * 10**24);
-    assertFalse(breaker.shouldTrigger(address(rateFeedID)));
+    // rateChangeThreshold not configured
+    updateMedianByPercent(0.9 * 10**24, rateFeedID);
+    assertFalse(breaker.shouldTrigger(rateFeedID));
+
+    // rateChangeThreshold 14 %
+    updateMedianByPercent(0.9 * 10**24, rateFeedIDs[0]);
+    assertFalse(breaker.shouldTrigger(rateFeedIDs[0]));
   }
 
   function test_shouldTrigger_whenMedianIncreases10Percent_shouldReturnFalse() public {
-    updateMedianByPercent(1.1 * 10**24);
-    assertFalse(breaker.shouldTrigger(address(rateFeedID)));
+    // rateChangeThreshold not configured
+    updateMedianByPercent(1.1 * 10**24, rateFeedID);
+    assertFalse(breaker.shouldTrigger(rateFeedID));
+
+    // rateChangeThreshold 13 %
+    updateMedianByPercent(1.1 * 10**24, rateFeedIDs[1]);
+    assertFalse(breaker.shouldTrigger(rateFeedIDs[1]));
   }
 
   function test_shouldTrigger_whenMedianIncreases20Percent_shouldReturnTrue() public {
-    updateMedianByPercent(1.2 * 10**24);
-    assertTrue(breaker.shouldTrigger(address(rateFeedID)));
+    // rateChangeThreshold not configured
+    updateMedianByPercent(1.2 * 10**24, rateFeedID);
+    assertTrue(breaker.shouldTrigger(rateFeedID));
+
+    // rateChangeThreshold 13 %
+    updateMedianByPercent(1.2 * 10**24, rateFeedIDs[1]);
+    assertTrue(breaker.shouldTrigger(rateFeedIDs[1]));
   }
 }

--- a/test/utils/IntegrationSetup.sol
+++ b/test/utils/IntegrationSetup.sol
@@ -239,6 +239,27 @@ contract IntegrationSetup is Test, WithRegistry {
 
     /* ========== Deploy Median Delta Breaker =============== */
 
+    // todo change these to correct values
+    uint256[] memory rateChangeThresholds = new uint256[](5);
+    
+    rateChangeThresholds[0] = 0.15 * 10**24;
+    rateChangeThresholds[1] = 0.14 * 10**24;
+    rateChangeThresholds[2] = 0.13 * 10**24;
+    rateChangeThresholds[3] = 0.12 * 10**24;
+    rateChangeThresholds[4] = 0.11 * 10**24;
+
+    uint256 threshold = 0.15 * 10**24; // 15%
+    uint256 coolDownTime = 5 minutes;
+
+    medianDeltaBreaker = new MedianDeltaBreaker(
+      coolDownTime,
+      threshold,
+      rateFeedIDs,
+      rateChangeThresholds,
+      ISortedOracles(address(sortedOracles))
+    );
+
+
     breakerBox.addBreaker(address(medianDeltaBreaker), 1);
     sortedOracles.setBreakerBox(breakerBox);
   }

--- a/test/utils/IntegrationSetup.sol
+++ b/test/utils/IntegrationSetup.sol
@@ -263,11 +263,11 @@ contract IntegrationSetup is Test, WithRegistry {
     sortedOracles.setBreakerBox(breakerBox);
 
     // enable breakers
-    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cUSD_CELO_referenceRateFeedID, true);
-    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cEUR_CELO_referenceRateFeedID, true);
-    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cUSD_USDCet_referenceRateFeedID, true);
-    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cUSD_cEUR_referenceRateFeedID, true);
-    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cEUR_USDCet_referenceRateFeedID, true);
+    breakerBox.toggleBreaker(address(medianDeltaBreaker), cUSD_CELO_referenceRateFeedID, true);
+    breakerBox.toggleBreaker(address(medianDeltaBreaker), cEUR_CELO_referenceRateFeedID, true);
+    breakerBox.toggleBreaker(address(medianDeltaBreaker), cUSD_USDCet_referenceRateFeedID, true);
+    breakerBox.toggleBreaker(address(medianDeltaBreaker), cUSD_cEUR_referenceRateFeedID, true);
+    breakerBox.toggleBreaker(address(medianDeltaBreaker), cEUR_USDCet_referenceRateFeedID, true);
   }
 
   function setUp_broker() internal {

--- a/test/utils/IntegrationSetup.sol
+++ b/test/utils/IntegrationSetup.sol
@@ -25,7 +25,7 @@ import { TradingLimits } from "contracts/common/TradingLimits.sol";
 
 import { FixidityLib } from "contracts/common/FixidityLib.sol";
 import { Freezer } from "contracts/common/Freezer.sol";
-import { AddressSortedLinkedListWithMedian } from "contracts//common/linkedlists/AddressSortedLinkedListWithMedian.sol";
+import { AddressSortedLinkedListWithMedian } from "contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol";
 import { SortedLinkedListWithMedian } from "contracts/common/linkedlists/SortedLinkedListWithMedian.sol";
 
 import { WithRegistry } from "./WithRegistry.sol";
@@ -239,9 +239,6 @@ contract IntegrationSetup is Test, WithRegistry {
 
     /* ========== Deploy Median Delta Breaker =============== */
 
-    uint256 threshold = 0.15 * 10**24; // 15%
-    uint256 coolDownTime = 5 minutes;
-    medianDeltaBreaker = new MedianDeltaBreaker(coolDownTime, threshold, ISortedOracles(address(sortedOracles)));
     breakerBox.addBreaker(address(medianDeltaBreaker), 1);
     sortedOracles.setBreakerBox(breakerBox);
   }

--- a/test/utils/IntegrationSetup.sol
+++ b/test/utils/IntegrationSetup.sol
@@ -241,7 +241,7 @@ contract IntegrationSetup is Test, WithRegistry {
 
     // todo change these to correct values
     uint256[] memory rateChangeThresholds = new uint256[](5);
-    
+
     rateChangeThresholds[0] = 0.15 * 10**24;
     rateChangeThresholds[1] = 0.14 * 10**24;
     rateChangeThresholds[2] = 0.13 * 10**24;
@@ -259,9 +259,15 @@ contract IntegrationSetup is Test, WithRegistry {
       ISortedOracles(address(sortedOracles))
     );
 
-
     breakerBox.addBreaker(address(medianDeltaBreaker), 1);
     sortedOracles.setBreakerBox(breakerBox);
+
+    // enable breakers
+    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cUSD_CELO_referenceRateFeedID, true);
+    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cEUR_CELO_referenceRateFeedID, true);
+    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cUSD_USDCet_referenceRateFeedID, true);
+    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cUSD_cEUR_referenceRateFeedID, true);
+    breakerBox.setBreakerEnabled(address(medianDeltaBreaker), cEUR_USDCet_referenceRateFeedID, true);
   }
 
   function setUp_broker() internal {


### PR DESCRIPTION
### Description

Currently, the BreakerBox has an array of registered breakers. When a new price is reported, the breaker iterates through the list and checks each breaker for the rateFeedID. This means that there is no way to configure a breaker that's only checked for one rateFeed. At the same time, the existing MedianDeltaBreaker has a global priceChangeThreshold which is checked for all rates. The goal of this pr is to make this system more configurable.

### Other changes

Renamed priceChange to rateChange in the MedianDeltaBreaker and tests to keep things consistent.

### Tested

Unit tests

### Related issues

- Fixes #81 

### Backwards compatibility

n/a
