### PR TITLE
Fix/correct breaker descriptions

### DIFF
--- a/contracts/MedianDeltaBreaker.sol
+++ b/contracts/MedianDeltaBreaker.sol
@@ -125,7 +125,7 @@ contract MedianDeltaBreaker is IBreaker, Ownable {
 
   /**
    * @notice  Check if the current median report rate for a rate feed change, relative
-   *          to the last median report, is greater than configured threshold.
+   *          to the last median report, is greater than the configured threshold.
    *          If the change is greater than the threshold the breaker will trip.
    * @param   rateFeedID The rate feed to be checked.
    * @return  triggerBreaker  A bool indicating whether or not this breaker

--- a/contracts/MedianDeltaBreaker.sol
+++ b/contracts/MedianDeltaBreaker.sol
@@ -12,8 +12,8 @@ import { FixidityLib } from "./common/FixidityLib.sol";
 
 /**
  * @title   Median Delta Breaker
- * @notice  Breaker contract that will trigger when the current oracle median rate change
- *          relative to the last is greater than a calculated threshold. If this
+ * @notice  Breaker contract that will trigger when an updated oracle median rate changes
+ *          more than a configured relative threshold from the previous one. If this
  *          breaker is triggered for a rate feed it should be set to no trading mode.
  */
 contract MedianDeltaBreaker is IBreaker, Ownable {
@@ -124,8 +124,8 @@ contract MedianDeltaBreaker is IBreaker, Ownable {
   }
 
   /**
-   * @notice  Check if the current median report rate change, for a rate feed, relative
-   *          to the last median report is greater than a calculated threshold.
+   * @notice  Check if the current median report rate for a rate feed change, relative
+   *          to the last median report, is greater than configured threshold.
    *          If the change is greater than the threshold the breaker will trip.
    * @param   rateFeedID The rate feed to be checked.
    * @return  triggerBreaker  A bool indicating whether or not this breaker


### PR DESCRIPTION
### Description

The `MedianDeltaBreaker.sol` description says it triggers at a 'calculated threshold', which implies there is some time series analysis going on. What actually happens is that the relative thresholds are configured per rate. This PR changes the documentation to correct descriptions. 

### Other changes

No

### Tested

No, only doc changes

### Related issues

No issue

### Backwards compatibility

Yup fully

### Documentation

No
