### PR TITLE
Make Broker quote functions external view

### DIFF
--- a/contracts/Broker.sol
+++ b/contracts/Broker.sol
@@ -108,7 +108,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
     address tokenIn,
     address tokenOut,
     uint256 amountOut
-  ) external returns (uint256 amountIn) {
+  ) external view returns (uint256 amountIn) {
     require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
     amountIn = IExchangeProvider(exchangeProvider).getAmountIn(exchangeId, tokenIn, tokenOut, amountOut);
   }
@@ -128,7 +128,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable {
     address tokenIn,
     address tokenOut,
     uint256 amountIn
-  ) external returns (uint256 amountOut) {
+  ) external view returns (uint256 amountOut) {
     require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
     amountOut = IExchangeProvider(exchangeProvider).getAmountOut(exchangeId, tokenIn, tokenOut, amountIn);
   }

--- a/contracts/interfaces/IBroker.sol
+++ b/contracts/interfaces/IBroker.sol
@@ -79,7 +79,7 @@ interface IBroker {
     address tokenIn,
     address tokenOut,
     uint256 amountIn
-  ) external returns (uint256 amountOut);
+  ) external view returns (uint256 amountOut);
 
   /**
    * @notice Calculate amountIn of tokenIn needed for a given amountOut of tokenOut.
@@ -96,7 +96,7 @@ interface IBroker {
     address tokenIn,
     address tokenOut,
     uint256 amountOut
-  ) external returns (uint256 amountIn);
+  ) external view returns (uint256 amountIn);
 
   /**
    * @notice Get the list of registered exchange providers.


### PR DESCRIPTION
### Description

I noticed while working in the SDK that the getAmountOut and getAmountIn functions in the broker can only be called as a transaction due to their visibility, even though they don't modify any state. Instead they should be callable as a contract read call as this is obviously the intended way to be used by consumers (getting a quote -> executing a swap).

### Other changes

N/A

### Tested

No additional testing aside from the existing foundry tests. 

### Related issues

- Fixes #92 

### Backwards compatibility

Not sure if this will require a full redeploy or just a broker upgrade?