### PR TITLE
feat: verify that spender exists before removing and refactor test

### DIFF
--- a/contracts/Reserve.sol
+++ b/contracts/Reserve.sol
@@ -360,6 +360,7 @@ contract Reserve is IReserve, ICeloVersionedContract, Ownable, Initializable, Us
    * @param spender The address that is to be no longer allowed to spend Reserve funds.
    */
   function removeSpender(address spender) external onlyOwner {
+    require(isSpender[spender], "Spender hasn't been added");
     isSpender[spender] = false;
     emit SpenderRemoved(spender);
   }

--- a/test/Reserve.t.sol
+++ b/test/Reserve.t.sol
@@ -573,19 +573,24 @@ contract ReserveTest_transfers is ReserveTest {
     reserve.addSpender(address(0x0));
   }
 
-  function test_removeSpender() public {
-    address _spender = address(0x4444);
+  function test_removeSpender_whenCallerIsOwner_shouldRemove() public {
+    address _spender = actor("_spender");
 
     reserve.addSpender(_spender);
-
-    changePrank(notDeployer);
-    vm.expectRevert("Ownable: caller is not the owner");
-    reserve.removeSpender(_spender);
-
-    changePrank(deployer);
     vm.expectEmit(true, true, true, true, address(reserve));
     emit SpenderRemoved(_spender);
     reserve.removeSpender(_spender);
+  }
+
+  function test_removeSpender_whenCallerIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    reserve.removeSpender(spender);
+  }
+
+  function test_removeSpender_whenSpenderDoesNotExist_shouldRevert() public {
+    vm.expectRevert("Spender hasn't been added");
+    reserve.removeSpender(notDeployer);
   }
 
   function test_transferExchangeGold_asExchangeFromRegistry() public {


### PR DESCRIPTION
### Description
In this pr, I've added a check in `removeSpender()` to verify that the spender exists before proceeding to try and remove it  in order to avoid unnecessary gas costs. 

### Other changes

Refactored existing `removeSpender()` test 

### Tested

Unit test added

### Related issues

- Fixes [#143](https://github.com/mento-protocol/mento-general/issues/143)

### Backwards compatibility

Should be backwards compatible

### Documentation

n/a
