### PR TITLE
refactor: add zero address check

### DIFF
--- a/contracts/SortedOracles.sol
+++ b/contracts/SortedOracles.sol
@@ -116,6 +116,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @param newBreakerBox The new BreakerBox address.
    */
   function setBreakerBox(IBreakerBox newBreakerBox) public onlyOwner {
+    require(address(newBreakerBox) != address(0), "BreakerBox address must be set");
     breakerBox = newBreakerBox;
     emit BreakerBoxUpdated(address(newBreakerBox));
   }

--- a/test/SortedOracles.t.sol
+++ b/test/SortedOracles.t.sol
@@ -181,6 +181,11 @@ contract SortedOracles_breakerBox is SortedOraclesTest {
     sortedOracles.setBreakerBox(MockBreakerBox(address(0)));
   }
 
+  function test_setBreakerBox_whenGivenAddressIsNull_shouldRevert() public {
+    vm.expectRevert("BreakerBox address must be set");
+    sortedOracles.setBreakerBox(MockBreakerBox(address(0)));
+  }
+
   function test_setBreakerBox_shouldUpdateAndEmit() public {
     sortedOracles = new SortedOracles(true);
     assertEq(address(sortedOracles.breakerBox()), address(0));


### PR DESCRIPTION
### Description

- This change adds a zero address check when setting the breaker box

### Other changes

N/A

### Tested

- Added test to verify check works

### Related issues

- Closes https://github.com/mento-protocol/mento-general/issues/146

### Backwards compatibility

N/A

### Documentation

N/A
