### PR TITLE
feat: add a missing same asset check in BiPoolManager

### DIFF
--- a/contracts/BiPoolManager.sol
+++ b/contracts/BiPoolManager.sol
@@ -202,6 +202,7 @@ contract BiPoolManager is IExchangeProvider, IBiPoolManager, Initializable, Owna
     require(address(exchange.pricingModule) != address(0), "pricingModule must be set");
     require(exchange.asset0 != address(0), "asset0 must be set");
     require(exchange.asset1 != address(0), "asset1 must be set");
+    require(exchange.asset0 != exchange.asset1, "exchange assets can't be identical");
 
     exchangeId = keccak256(
       abi.encodePacked(

--- a/test/BiPoolManager.t.sol
+++ b/test/BiPoolManager.t.sol
@@ -418,6 +418,11 @@ contract BiPoolManagerTest_createExchange is BiPoolManagerTest {
     createExchange(cUSD, MockERC20(address(0)));
   }
 
+  function test_createExchange_whenAssetsAreIdentical_shouldRevert() public {
+    vm.expectRevert("exchange assets can't be identical");
+    createExchange(cUSD, cUSD);
+  }
+
   function test_createExchange_whenReferenceRateFeedIDIsNotSet_shouldRevert() public {
     vm.expectRevert("referenceRateFeedID must be set");
     createExchange(cUSD, CELO, constantProduct, address(0));
@@ -462,11 +467,6 @@ contract BiPoolManagerTest_createExchange is BiPoolManagerTest {
     BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
     assertEq(exchange.bucket0, 1e24);
     assertEq(exchange.bucket1, 5e23); // exchange.bucket0 / 2
-  }
-
-  function test_createExchange_whenAssetsAreIdentical_shouldRevert() public {
-    vm.expectRevert("exchange assets can't be identical");
-    createExchange(cUSD, cUSD);
   }
 }
 

--- a/test/BiPoolManager.t.sol
+++ b/test/BiPoolManager.t.sol
@@ -463,6 +463,11 @@ contract BiPoolManagerTest_createExchange is BiPoolManagerTest {
     assertEq(exchange.bucket0, 1e24);
     assertEq(exchange.bucket1, 5e23); // exchange.bucket0 / 2
   }
+
+  function test_createExchange_whenAssetsAreIdentical_shouldRevert() public {
+    vm.expectRevert("exchange assets can't be identical");
+    createExchange(cUSD, cUSD);
+  }
 }
 
 contract BiPoolManagerTest_destroyExchange is BiPoolManagerTest {


### PR DESCRIPTION
### Description

Added a check in `BiPoolManager.sol` to verify that exchange can't be created with the same assets

### Other changes

n/a

### Tested

Unit tests 

### Related issues

- Fixes [#144](https://github.com/mento-protocol/mento-general/issues/144)

### Backwards compatibility

n/a

### Documentation

n/a
