### PR TITLE
Fix comment typo in StableTokenRegistry.sol

### DIFF
--- a/contracts/SortedOracles.sol
+++ b/contracts/SortedOracles.sol
@@ -116,6 +116,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @param newBreakerBox The new BreakerBox address.
    */
   function setBreakerBox(IBreakerBox newBreakerBox) public onlyOwner {
+    require(address(newBreakerBox) != address(0), "BreakerBox address must be set");
     breakerBox = newBreakerBox;
     emit BreakerBoxUpdated(address(newBreakerBox));
   }

--- a/contracts/StableTokenRegistry.sol
+++ b/contracts/StableTokenRegistry.sol
@@ -79,7 +79,7 @@ contract StableTokenRegistry is Initializable, Ownable {
   }
 
   /**
-   * @notice Removes unwamted token instances.
+   * @notice Removes unwanted token instances.
    * @param fiatTicker The currency that is no longer supported.
    * @param index The index in fiatTickers of fiatTicker.
    */

--- a/test/SortedOracles.t.sol
+++ b/test/SortedOracles.t.sol
@@ -181,6 +181,11 @@ contract SortedOracles_breakerBox is SortedOraclesTest {
     sortedOracles.setBreakerBox(MockBreakerBox(address(0)));
   }
 
+  function test_setBreakerBox_whenGivenAddressIsNull_shouldRevert() public {
+    vm.expectRevert("BreakerBox address must be set");
+    sortedOracles.setBreakerBox(MockBreakerBox(address(0)));
+  }
+
   function test_setBreakerBox_shouldUpdateAndEmit() public {
     sortedOracles = new SortedOracles(true);
     assertEq(address(sortedOracles.breakerBox()), address(0));


### PR DESCRIPTION
### Description

Typo fix 

### Other changes

No

### Tested

Forge tests pass

### Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/152

### Backwards compatibility

Fully just comment change

### Documentation

no docs