### PR TITLE
refactor: change division, multiplication order

### DIFF
--- a/contracts/StableToken.sol
+++ b/contracts/StableToken.sol
@@ -490,8 +490,9 @@ contract StableToken is
     FixidityLib.Fraction memory currentInflationFactor = FixidityLib.wrap(numerator).divide(
       FixidityLib.wrap(denominator)
     );
-    uint256 lastUpdated = inflationState.factorLastUpdated.add(inflationState.updatePeriod.mul(timesToApplyInflation));
-
+    uint256 lastUpdated = inflationState.factorLastUpdated.add(
+      inflationState.updatePeriod.mul(now.sub(inflationState.factorLastUpdated)).div(inflationState.updatePeriod)
+    );
     return (currentInflationFactor, lastUpdated);
     /* solhint-enable not-rely-on-time */
   }


### PR DESCRIPTION
### Description

- changed the order of division and multiplication for calculating the lastUpdate
- this increases precision because division gets truncated  

### Other changes

N/A

### Tested

- calculated whether the new formula is equal to the old one
- all tests still pass

### Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/150

### Backwards compatibility
N/A

### Documentation

N/A
