### PR TITLE
fix: make transferCollateralAsset behaviour consistent with transferGold

### DIFF
--- a/contracts/Reserve.sol
+++ b/contracts/Reserve.sol
@@ -458,7 +458,7 @@ contract Reserve is IReserve, ICeloVersionedContract, Ownable, Initializable, Us
     uint256 value
   ) external returns (bool) {
     require(isSpender[msg.sender], "sender not allowed to transfer Reserve funds");
-    require(to != address(0), "can not transfer to 0 address");
+    require(isOtherReserveAddress[to], "can only transfer to other reserve address");
     require(
       getDailySpendingRatioForCollateralAsset(collateralAsset) > 0,
       "this asset has no spending ratio, therefore can't be transferred"


### PR DESCRIPTION
### Description

When implementing our generalized `transferGold` to `transferCollateralAsset` method we skipped a critical check which constrained the logic only to allow transfers to addresses marked as `isOtherReserveAddress`.

This PR introduces this check back and updates the tests accordingly.

### Other changes

None

### Tested

Tests are updated

### Related issues

N/A

### Backwards compatibility

No, but existing version was never released

### Documentation

N/A
