### PR TITLE
feat: add storage layout workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Generate matrix with all contract names from the proxy directory 
         id: set-matrix
         run: |
-          echo "::set-output name=matrix::$(ls contracts/proxies | sed 's/Proxy.sol//')"
+          echo "::set-output name=matrix::$(ls contracts/proxies | sed 's/Proxy.sol//' | jq -R -s -c 'split("\n") | map(select(length > 0))') )"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         uses: Rubilmax/foundry-storage-check@v3.2.1
         with:
           contract: ${{ matrix.contract }}
-          failOnRemoval: true 
+          workingDirectory: contracts/
   ci:
     name: Lint & Test
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           sarif_file: ${{ steps.slither.outputs.sarif }}
 
   get_proxy_names:
+    name: Get contract names
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,6 +55,7 @@ jobs:
 
   check_storage_layout:
     needs: get_proxy_names
+    name: Check storage layout
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,38 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.slither.outputs.sarif }}
+
+  get_proxy_names:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate matrix with all contract names from the proxy directory 
+        id: set-matrix
+        run: |
+          echo "::set-output name=matrix::$(ls contracts/proxies | sed 's/Proxy.sol//')"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+  check_storage_layout:
+    needs: get_proxy_names
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        contract: ${{ fromJson(needs.get_proxy_names.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Check storage layout
+        uses: Rubilmax/foundry-storage-check@v3.2.1
+        with:
+          contract: ${{ matrix.contract }}
+          failOnRemoval: true 
   ci:
     name: Lint & Test
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Check storage layout
         uses: Rubilmax/foundry-storage-check@v3.2.1
         with:
-          contract: ${{ matrix.contract }}
+          contract: ${{ matrix.contract }}.sol:${{ matrix.contract }}
           workingDirectory: contracts/
   ci:
     name: Lint & Test


### PR DESCRIPTION
### Description

- added a workflow that compares the storage layout of all proxy contract implementations and reverts PRs if they have changed
- The workflow uses  https://github.com/Rubilmax/foundry-storage-check to compare the storage between prior runs that are saved as artifacts.
- In order to perform this action on each of the proxy implementations the get_proxy_names  job creates a matrix containing all the contracts for which we want to check the storage 
- Once this branch is merged to develop it will fail on the first run since the artifacts don't exist yet and need to be built for the first time. 

### Other changes

- N/A

### Tested

- In order to test this I created the test/new-ci-job branch that branches of the feature/add-storage-layout-check branch.
- After this opened a Pr and made changes to the Reserve.sol that change the storage layout.
-  the workflow detected those changes to the storage layout correctly [Action](https://github.com/mento-protocol/mento-core/actions/runs/4253373514)
- once this branch is merged I will close the test branch again.

### Related issues

- Fixes #157 

### Backwards compatibility

- N/A

### Documentation

- N/A
