### PR TITLE
feat: fuzz pricing modules

### DIFF
--- a/test/echidna/EchidnaConstantProductPricingModule.sol
+++ b/test/echidna/EchidnaConstantProductPricingModule.sol
@@ -1,3 +1,5 @@
+// solhint-disable-next-line max-line-length
+
 pragma solidity ^0.5.13;
 
 import { ConstantProductPricingModule } from "../../contracts/ConstantProductPricingModule.sol";
@@ -6,7 +8,7 @@ import { EchidnaHelpers } from "./EchidnaHelpers.sol";
 
 /**
  * @dev Command for local running:
- * echidna ./test/echidna/EchidnaConstantProductPricingModule.sol --contract EchidnaConstantProductPricingModule --config ./echidna.yaml --test-mode assertion
+ *      echidna ./test/echidna/EchidnaConstantProductPricingModule.sol --contract EchidnaConstantProductPricingModule --config ./echidna.yaml --test-mode assertion
  */
 contract EchidnaConstantProductPricingModule {
   using FixidityLib for FixidityLib.Fraction;

--- a/test/echidna/EchidnaConstantProductPricingModule.sol
+++ b/test/echidna/EchidnaConstantProductPricingModule.sol
@@ -4,6 +4,10 @@ import { ConstantProductPricingModule } from "../../contracts/ConstantProductPri
 import { FixidityLib } from "../../contracts/common/FixidityLib.sol";
 import { EchidnaHelpers } from "./EchidnaHelpers.sol";
 
+/**
+ * @dev Command for local running:
+ * echidna ./test/echidna/EchidnaConstantProductPricingModule.sol --contract EchidnaConstantProductPricingModule --config ./echidna.yaml --test-mode assertion
+ */
 contract EchidnaConstantProductPricingModule {
   using FixidityLib for FixidityLib.Fraction;
 
@@ -14,6 +18,8 @@ contract EchidnaConstantProductPricingModule {
     constantProductPricingModule = new ConstantProductPricingModule();
     helpers = new EchidnaHelpers();
   }
+
+  // TODO: Generate random inputs with constraints for these tests.
 
   /* ==================== GetAmountOut ==================== */
 

--- a/test/echidna/EchidnaConstantProductPricingModule.sol
+++ b/test/echidna/EchidnaConstantProductPricingModule.sol
@@ -19,20 +19,32 @@ contract EchidnaConstantProductPricingModule {
 
   function echidna_test_getAmountOut_zeroInputReturnsZeroOutput() public view {
     uint256 tokenOutBucketSize = 10000;
+    uint256 tokenInBucketSize = 10000;
     uint256 spread = 500;
     uint256 amountIn = 0;
 
-    uint256 amountOut = constantProductPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
+    uint256 amountOut = constantProductPricingModule.getAmountOut(
+      tokenInBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountIn
+    );
 
     assert(amountOut == 0);
   }
 
   function echidna_test_getAmountOut_outputLteTokenOutBucket() public view {
     uint256 tokenOutBucketSize = 10000;
+    uint256 tokenInBucketSize = 10000;
     uint256 spread = 500;
     uint256 amountIn = 500;
 
-    uint256 amountOut = constantProductPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
+    uint256 amountOut = constantProductPricingModule.getAmountOut(
+      tokenInBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountIn
+    );
 
     assert(amountOut <= tokenOutBucketSize);
   }
@@ -41,20 +53,32 @@ contract EchidnaConstantProductPricingModule {
 
   function echidna_test_getAmountIn_zeroOutputReturnsZeroInput() public view {
     uint256 tokenOutBucketSize = 10000;
+    uint256 tokenInBucketSize = 10000;
     uint256 spread = 500;
     uint256 amountOut = 0;
 
-    uint256 amountIn = constantProductPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
+    uint256 amountIn = constantProductPricingModule.getAmountIn(
+      tokenInBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountOut
+    );
 
     assert(amountIn == 0);
   }
 
   function echidna_test_getAmountIn_outputLteTokenOutBucket() public view {
     uint256 tokenOutBucketSize = 10000;
+    uint256 tokenInBucketSize = 10000;
     uint256 spread = 500;
     uint256 amountOut = 500;
 
-    uint256 amountIn = constantProductPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
+    uint256 amountIn = constantProductPricingModule.getAmountIn(
+      tokenInBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountOut
+    );
 
     assert(amountIn <= tokenOutBucketSize);
   }
@@ -63,10 +87,11 @@ contract EchidnaConstantProductPricingModule {
 
   function echidna_test_getAmountOut_getAmountIn_inverse() public view {
     uint256 tokenOutBucketSize = 10000;
+    uint256 tokenInBucketSize = 10000;
     uint256 spread = 500;
     uint256 amountIn = 5000;
 
-    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+    spread = helpers.between(spread, tokenInBucketSize, FixidityLib.unwrap(FixidityLib.fixed1()));
 
     uint256 amountOut = constantProductPricingModule.getAmountOut(
       tokenOutBucketSize,
@@ -86,10 +111,11 @@ contract EchidnaConstantProductPricingModule {
 
   function echidna_test_getAmountIn_getAmountOut_inverse() public view {
     uint256 tokenOutBucketSize = 10000;
+    uint256 tokenInBucketSize = 10000;
     uint256 spread = 500;
     uint256 amountOut = 5000;
 
-    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+    spread = helpers.between(spread, tokenInBucketSize, FixidityLib.unwrap(FixidityLib.fixed1()));
 
     uint256 amountIn = constantProductPricingModule.getAmountIn(
       tokenOutBucketSize,

--- a/test/echidna/EchidnaConstantProductPricingModule.sol
+++ b/test/echidna/EchidnaConstantProductPricingModule.sol
@@ -1,4 +1,4 @@
-// solhint-disable-next-line max-line-length
+// solhint-disable max-line-length
 
 pragma solidity ^0.5.13;
 

--- a/test/echidna/EchidnaConstantProductPricingModule.sol
+++ b/test/echidna/EchidnaConstantProductPricingModule.sol
@@ -26,8 +26,12 @@ contract EchidnaConstantProductPricingModule {
     uint256 tokenOutBucketSize,
     uint256 spread,
     uint256 amountIn
-  ) public view returns (bool) {
+  ) public view {
+
+    tokenInBucketSize = helpers.between(tokenInBucketSize, 1e18, uint256(-1));
+    tokenOutBucketSize = helpers.between(tokenOutBucketSize, 1e18, uint256(-1));
     spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+
     uint256 amountOut = constantProductPricingModule.getAmountOut(
       tokenInBucketSize,
       tokenOutBucketSize,
@@ -35,6 +39,8 @@ contract EchidnaConstantProductPricingModule {
       amountIn
     );
     uint256 r = constantProductPricingModule.getAmountIn(tokenInBucketSize, tokenOutBucketSize, spread, amountOut);
-    return (r == amountIn);
+    uint256 spreadFraction = FixidityLib.fixed1().subtract(FixidityLib.wrap(spread)).multiply(FixidityLib.newFixed(2)).unwrap();
+
+    assert(helpers.areClose(amountIn, r, spread));
   }
 }

--- a/test/echidna/EchidnaConstantProductPricingModule.sol
+++ b/test/echidna/EchidnaConstantProductPricingModule.sol
@@ -1,0 +1,109 @@
+pragma solidity ^0.5.13;
+
+import { ConstantProductPricingModule } from "../../contracts/ConstantProductPricingModule.sol";
+import { FixidityLib } from "../../contracts/common/FixidityLib.sol";
+import { EchidnaHelpers } from "./EchidnaHelpers.sol";
+
+contract EchidnaConstantProductPricingModule {
+  using FixidityLib for FixidityLib.Fraction;
+
+  ConstantProductPricingModule public constantProductPricingModule;
+  EchidnaHelpers private helpers;
+
+  constructor() public {
+    constantProductPricingModule = new ConstantProductPricingModule();
+    helpers = new EchidnaHelpers();
+  }
+
+  /* ==================== GetAmountOut ==================== */
+
+  function echidna_test_getAmountOut_zeroInputReturnsZeroOutput() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountIn = 0;
+
+    uint256 amountOut = constantProductPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
+
+    assert(amountOut == 0);
+  }
+
+  function echidna_test_getAmountOut_outputLteTokenOutBucket() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountIn = 500;
+
+    uint256 amountOut = constantProductPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
+
+    assert(amountOut <= tokenOutBucketSize);
+  }
+
+  /* ==================== GetAmountIn ==================== */
+
+  function echidna_test_getAmountIn_zeroOutputReturnsZeroInput() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountOut = 0;
+
+    uint256 amountIn = constantProductPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
+
+    assert(amountIn == 0);
+  }
+
+  function echidna_test_getAmountIn_outputLteTokenOutBucket() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountOut = 500;
+
+    uint256 amountIn = constantProductPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
+
+    assert(amountIn <= tokenOutBucketSize);
+  }
+
+  /* ==================== Inverse Operations ==================== */
+
+  function echidna_test_getAmountOut_getAmountIn_inverse() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountIn = 5000;
+
+    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+
+    uint256 amountOut = constantProductPricingModule.getAmountOut(
+      tokenOutBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountIn
+    );
+    uint256 amountInCalculated = constantProductPricingModule.getAmountIn(
+      tokenOutBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountOut
+    );
+
+    assert(amountInCalculated == amountIn);
+  }
+
+  function echidna_test_getAmountIn_getAmountOut_inverse() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountOut = 5000;
+
+    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+
+    uint256 amountIn = constantProductPricingModule.getAmountIn(
+      tokenOutBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountOut
+    );
+    uint256 amountOutCalculated = constantProductPricingModule.getAmountOut(
+      tokenOutBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountIn
+    );
+
+    assert(amountOutCalculated == amountOut);
+  }
+}

--- a/test/echidna/EchidnaConstantProductPricingModule.sol
+++ b/test/echidna/EchidnaConstantProductPricingModule.sol
@@ -19,123 +19,20 @@ contract EchidnaConstantProductPricingModule {
     helpers = new EchidnaHelpers();
   }
 
-  // TODO: Generate random inputs with constraints for these tests.
-
-  /* ==================== GetAmountOut ==================== */
-
-  function echidna_test_getAmountOut_zeroInputReturnsZeroOutput() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 tokenInBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountIn = 0;
-
+  function getAmounts_inverseConsistent(
+    uint256 tokenInBucketSize,
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountIn
+  ) public view returns (bool) {
+    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
     uint256 amountOut = constantProductPricingModule.getAmountOut(
       tokenInBucketSize,
       tokenOutBucketSize,
       spread,
       amountIn
     );
-
-    assert(amountOut == 0);
-  }
-
-  function echidna_test_getAmountOut_outputLteTokenOutBucket() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 tokenInBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountIn = 500;
-
-    uint256 amountOut = constantProductPricingModule.getAmountOut(
-      tokenInBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountIn
-    );
-
-    assert(amountOut <= tokenOutBucketSize);
-  }
-
-  /* ==================== GetAmountIn ==================== */
-
-  function echidna_test_getAmountIn_zeroOutputReturnsZeroInput() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 tokenInBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountOut = 0;
-
-    uint256 amountIn = constantProductPricingModule.getAmountIn(
-      tokenInBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountOut
-    );
-
-    assert(amountIn == 0);
-  }
-
-  function echidna_test_getAmountIn_outputLteTokenOutBucket() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 tokenInBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountOut = 500;
-
-    uint256 amountIn = constantProductPricingModule.getAmountIn(
-      tokenInBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountOut
-    );
-
-    assert(amountIn <= tokenOutBucketSize);
-  }
-
-  /* ==================== Inverse Operations ==================== */
-
-  function echidna_test_getAmountOut_getAmountIn_inverse() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 tokenInBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountIn = 5000;
-
-    spread = helpers.between(spread, tokenInBucketSize, FixidityLib.unwrap(FixidityLib.fixed1()));
-
-    uint256 amountOut = constantProductPricingModule.getAmountOut(
-      tokenOutBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountIn
-    );
-    uint256 amountInCalculated = constantProductPricingModule.getAmountIn(
-      tokenOutBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountOut
-    );
-
-    assert(amountInCalculated == amountIn);
-  }
-
-  function echidna_test_getAmountIn_getAmountOut_inverse() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 tokenInBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountOut = 5000;
-
-    spread = helpers.between(spread, tokenInBucketSize, FixidityLib.unwrap(FixidityLib.fixed1()));
-
-    uint256 amountIn = constantProductPricingModule.getAmountIn(
-      tokenOutBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountOut
-    );
-    uint256 amountOutCalculated = constantProductPricingModule.getAmountOut(
-      tokenOutBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountIn
-    );
-
-    assert(amountOutCalculated == amountOut);
+    uint256 r = constantProductPricingModule.getAmountIn(tokenInBucketSize, tokenOutBucketSize, spread, amountOut);
+    return (r == amountIn);
   }
 }

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -25,10 +25,12 @@ contract EchidnaConstantSumPricingModule {
     uint256 tokenOutBucketSize,
     uint256 spread,
     uint256 amountIn
-  ) public view returns (bool) {
+  ) public view {
     spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
     uint256 amountOut = constantSumPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
     uint256 r = constantSumPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
-    return (r == amountIn);
+    uint256 spreadFraction = FixidityLib.fixed1().subtract(FixidityLib.wrap(spread)).multiply(FixidityLib.newFixed(2)).unwrap();
+
+    assert(helpers.areClose(amountIn, r, spread));
   }
 }

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -1,4 +1,4 @@
-// solhint-disable-next-line max-line-length
+// solhint-disable max-line-length
 
 pragma solidity ^0.5.13;
 

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -2,14 +2,17 @@ pragma solidity ^0.5.13;
 
 import { ConstantSumPricingModule } from "../../contracts/ConstantSumPricingModule.sol";
 import { FixidityLib } from "../../contracts/common/FixidityLib.sol";
+import { EchidnaHelpers } from "./EchidnaHelpers.sol";
 
 contract EchidnaConstantSumPricingModule {
   using FixidityLib for FixidityLib.Fraction;
 
   ConstantSumPricingModule public constantSumPricingModule;
+  EchidnaHelpers private helpers;
 
   constructor() public {
     constantSumPricingModule = new ConstantSumPricingModule();
+    helpers = new EchidnaHelpers();
   }
 
   // TODO: Generate random inputs with constraints for these tests.
@@ -66,7 +69,7 @@ contract EchidnaConstantSumPricingModule {
     uint256 amountIn = 5000;
 
     // Make sure spread is between 0 and 1.
-    spread = between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
 
     uint256 amountOut = constantSumPricingModule.getAmountOut(tokenOutBucketSize, tokenOutBucketSize, spread, amountIn);
     uint256 amountInCalculated = constantSumPricingModule.getAmountIn(
@@ -85,7 +88,7 @@ contract EchidnaConstantSumPricingModule {
     uint256 amountOut = 5000;
 
     // Make sure spread is between 0 and 1.
-    spread = between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
 
     uint256 amountIn = constantSumPricingModule.getAmountIn(tokenOutBucketSize, tokenOutBucketSize, spread, amountOut);
     uint256 amountOutCalculated = constantSumPricingModule.getAmountOut(
@@ -96,24 +99,5 @@ contract EchidnaConstantSumPricingModule {
     );
 
     assert(amountOutCalculated == amountOut);
-  }
-
-  /* ==================== Helper Functions ==================== */
-
-  /**
-   * @notice Checks if a given number falls within a specified range.
-   * @param num The number to be checked.
-   * @param lower The lower boundary of the range.
-   * @param upper The upper boundary of the range.
-   * @return The number if it falls within the range, the closest boundary otherwise.
-   */
-  function between(uint256 num, uint256 lower, uint256 upper) internal pure returns (uint256) {
-    if (num < lower) {
-      return lower;
-    } else if (num > upper) {
-      return upper;
-    } else {
-      return num;
-    }
   }
 }

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -1,3 +1,5 @@
+// solhint-disable-next-line max-line-length
+
 pragma solidity ^0.5.13;
 
 import { ConstantSumPricingModule } from "../../contracts/ConstantSumPricingModule.sol";
@@ -6,7 +8,7 @@ import { EchidnaHelpers } from "./EchidnaHelpers.sol";
 
 /**
  * @dev Command for local running:
- * echidna ./test/echidna/EchidnaConstantSumPricingModule.sol --contract EchidnaConstantSumPricingModule --config ./echidna.yaml --test-mode assertion
+ *      echidna ./test/echidna/EchidnaConstantSumPricingModule.sol --contract EchidnaConstantSumPricingModule --config ./echidna.yaml --test-mode assertion
  */
 contract EchidnaConstantSumPricingModule {
   using FixidityLib for FixidityLib.Fraction;

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -1,0 +1,119 @@
+pragma solidity ^0.5.13;
+
+import { ConstantSumPricingModule } from "../../contracts/ConstantSumPricingModule.sol";
+import { FixidityLib } from "../../contracts/common/FixidityLib.sol";
+
+contract EchidnaConstantSumPricingModule {
+  using FixidityLib for FixidityLib.Fraction;
+
+  ConstantSumPricingModule public constantSumPricingModule;
+
+  constructor() public {
+    constantSumPricingModule = new ConstantSumPricingModule();
+  }
+
+  // TODO: Generate random inputs with constraints for these tests.
+
+  /* ==================== GetAmountOut ==================== */
+
+  function echidna_test_getAmountOut_zeroInputReturnsZeroOutput() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountIn = 0;
+
+    uint256 amountOut = constantSumPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
+
+    assert(amountOut == 0);
+  }
+
+  function echidna_test_getAmountOut_outputLteTokenOutBucket() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountIn = 500;
+
+    uint256 amountOut = constantSumPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
+
+    assert(amountOut <= tokenOutBucketSize);
+  }
+
+  /* ==================== GetAmountIn ==================== */
+
+  function echidna_test_getAmountIn_zeroOutputReturnsZeroInput() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountOut = 0;
+
+    uint256 amountIn = constantSumPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
+
+    assert(amountIn == 0);
+  }
+
+  function echidna_test_getAmountIn_outputLteTokenOutBucket() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountOut = 500;
+
+    uint256 amountIn = constantSumPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
+
+    assert(amountIn <= tokenOutBucketSize);
+  }
+
+  /* ==================== Inverse Operations ==================== */
+
+  function echidna_test_getAmountOut_getAmountIn_inverse() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountIn = 5000;
+
+    // Make sure spread is between 0 and 1.
+    spread = between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+
+    uint256 amountOut = constantSumPricingModule.getAmountOut(tokenOutBucketSize, tokenOutBucketSize, spread, amountIn);
+    uint256 amountInCalculated = constantSumPricingModule.getAmountIn(
+      tokenOutBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountOut
+    );
+
+    assert(amountInCalculated == amountIn);
+  }
+
+  function echidna_test_getAmountIn_getAmountOut_inverse() public view {
+    uint256 tokenOutBucketSize = 10000;
+    uint256 spread = 500;
+    uint256 amountOut = 5000;
+
+    // Make sure spread is between 0 and 1.
+    spread = between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
+
+    uint256 amountIn = constantSumPricingModule.getAmountIn(tokenOutBucketSize, tokenOutBucketSize, spread, amountOut);
+    uint256 amountOutCalculated = constantSumPricingModule.getAmountOut(
+      tokenOutBucketSize,
+      tokenOutBucketSize,
+      spread,
+      amountIn
+    );
+
+    assert(amountOutCalculated == amountOut);
+  }
+
+  /* ==================== Helper Functions ==================== */
+
+  /**
+   * @notice Checks if a given number falls within a specified range.
+   * @param num The number to be checked.
+   * @param lower The lower boundary of the range.
+   * @param upper The upper boundary of the range.
+   * @return The number if it falls within the range, the closest boundary otherwise.
+   */
+  function between(uint256 num, uint256 lower, uint256 upper) internal pure returns (uint256) {
+    if (num < lower) {
+      return lower;
+    } else if (num > upper) {
+      return upper;
+    } else {
+      return num;
+    }
+  }
+}

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -4,6 +4,10 @@ import { ConstantSumPricingModule } from "../../contracts/ConstantSumPricingModu
 import { FixidityLib } from "../../contracts/common/FixidityLib.sol";
 import { EchidnaHelpers } from "./EchidnaHelpers.sol";
 
+/**
+ * @dev Command for local running:
+ * echidna ./test/echidna/EchidnaConstantSumPricingModule.sol --contract EchidnaConstantSumPricingModule --config ./echidna.yaml --test-mode assertion
+ */
 contract EchidnaConstantSumPricingModule {
   using FixidityLib for FixidityLib.Fraction;
 
@@ -63,10 +67,18 @@ contract EchidnaConstantSumPricingModule {
 
   /* ==================== Inverse Operations ==================== */
 
-  function echidna_test_getAmountOut_getAmountIn_inverse() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountIn = 5000;
+  function echidna_test_getAmountOut_getAmountIn_inverse(
+    uint256 tokenOutBucketSize,
+    uint256 spread,
+    uint256 amountIn
+  ) public view {
+    // uint256 tokenOutBucketSize = 10000;
+    // uint256 spread = 500;
+    // uint256 amountIn = 5000;
+
+    tokenOutBucketSize = (tokenOutBucketSize % 10000) + 1;
+    spread = spread % 1000;
+    amountIn = (amountIn % 10000) + 1;
 
     // Make sure spread is between 0 and 1.
     spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -25,8 +25,8 @@ contract EchidnaConstantSumPricingModule {
     uint256 amountIn
   ) public view returns (bool) {
     spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
-    uint256 amountOut = constantSumPricingModule.getAmountOut(tokenOutBucketSize, tokenOutBucketSize, spread, amountIn);
-    uint256 r = constantSumPricingModule.getAmountIn(tokenOutBucketSize, tokenOutBucketSize, spread, amountOut);
+    uint256 amountOut = constantSumPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
+    uint256 r = constantSumPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
     return (r == amountIn);
   }
 }

--- a/test/echidna/EchidnaConstantSumPricingModule.sol
+++ b/test/echidna/EchidnaConstantSumPricingModule.sol
@@ -19,97 +19,14 @@ contract EchidnaConstantSumPricingModule {
     helpers = new EchidnaHelpers();
   }
 
-  // TODO: Generate random inputs with constraints for these tests.
-
-  /* ==================== GetAmountOut ==================== */
-
-  function echidna_test_getAmountOut_zeroInputReturnsZeroOutput() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountIn = 0;
-
-    uint256 amountOut = constantSumPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
-
-    assert(amountOut == 0);
-  }
-
-  function echidna_test_getAmountOut_outputLteTokenOutBucket() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountIn = 500;
-
-    uint256 amountOut = constantSumPricingModule.getAmountOut(0, tokenOutBucketSize, spread, amountIn);
-
-    assert(amountOut <= tokenOutBucketSize);
-  }
-
-  /* ==================== GetAmountIn ==================== */
-
-  function echidna_test_getAmountIn_zeroOutputReturnsZeroInput() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountOut = 0;
-
-    uint256 amountIn = constantSumPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
-
-    assert(amountIn == 0);
-  }
-
-  function echidna_test_getAmountIn_outputLteTokenOutBucket() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountOut = 500;
-
-    uint256 amountIn = constantSumPricingModule.getAmountIn(0, tokenOutBucketSize, spread, amountOut);
-
-    assert(amountIn <= tokenOutBucketSize);
-  }
-
-  /* ==================== Inverse Operations ==================== */
-
-  function echidna_test_getAmountOut_getAmountIn_inverse(
+  function getAmounts_inverseConsistent(
     uint256 tokenOutBucketSize,
     uint256 spread,
     uint256 amountIn
-  ) public view {
-    // uint256 tokenOutBucketSize = 10000;
-    // uint256 spread = 500;
-    // uint256 amountIn = 5000;
-
-    tokenOutBucketSize = (tokenOutBucketSize % 10000) + 1;
-    spread = spread % 1000;
-    amountIn = (amountIn % 10000) + 1;
-
-    // Make sure spread is between 0 and 1.
+  ) public view returns (bool) {
     spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
-
     uint256 amountOut = constantSumPricingModule.getAmountOut(tokenOutBucketSize, tokenOutBucketSize, spread, amountIn);
-    uint256 amountInCalculated = constantSumPricingModule.getAmountIn(
-      tokenOutBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountOut
-    );
-
-    assert(amountInCalculated == amountIn);
-  }
-
-  function echidna_test_getAmountIn_getAmountOut_inverse() public view {
-    uint256 tokenOutBucketSize = 10000;
-    uint256 spread = 500;
-    uint256 amountOut = 5000;
-
-    // Make sure spread is between 0 and 1.
-    spread = helpers.between(spread, 0, FixidityLib.unwrap(FixidityLib.fixed1()));
-
-    uint256 amountIn = constantSumPricingModule.getAmountIn(tokenOutBucketSize, tokenOutBucketSize, spread, amountOut);
-    uint256 amountOutCalculated = constantSumPricingModule.getAmountOut(
-      tokenOutBucketSize,
-      tokenOutBucketSize,
-      spread,
-      amountIn
-    );
-
-    assert(amountOutCalculated == amountOut);
+    uint256 r = constantSumPricingModule.getAmountIn(tokenOutBucketSize, tokenOutBucketSize, spread, amountOut);
+    return (r == amountIn);
   }
 }

--- a/test/echidna/EchidnaHelpers.sol
+++ b/test/echidna/EchidnaHelpers.sol
@@ -11,12 +11,16 @@ contract EchidnaHelpers {
    * @return The number if it falls within the range, the closest boundary otherwise.
    */
   function between(uint256 num, uint256 lower, uint256 upper) public pure returns (uint256) {
-    if (num < lower) {
-      return lower;
-    } else if (num > upper) {
-      return upper;
+    num = lower + (num % (upper - lower));
+    return num;
+  }
+
+
+  function areClose(uint256 num1, uint256 num2, uint256 precision) public view returns (bool) {
+    if(num1 >= num2) {
+      return num1 - num2 <= precision;
     } else {
-      return num;
+      return num2 - num1 <= precision;
     }
   }
 }

--- a/test/echidna/EchidnaHelpers.sol
+++ b/test/echidna/EchidnaHelpers.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.5.13;
+
+contract EchidnaHelpers {
+  /* ==================== Helper Functions ==================== */
+
+  /**
+   * @notice Checks if a given number falls within a specified range.
+   * @param num The number to be checked.
+   * @param lower The lower boundary of the range.
+   * @param upper The upper boundary of the range.
+   * @return The number if it falls within the range, the closest boundary otherwise.
+   */
+  function between(uint256 num, uint256 lower, uint256 upper) public pure returns (uint256) {
+    if (num < lower) {
+      return lower;
+    } else if (num > upper) {
+      return upper;
+    } else {
+      return num;
+    }
+  }
+}


### PR DESCRIPTION
### Description

This pull request adds fuzz tests for the pricing module contracts as defined in the [Verilog review](https://github.com/Verilog-Solutions/review-mento#automated-testing). The tests verify the consistency and inverse relationship of the getAmountOut and getAmountIn functions in each of the pricing modules.

### Other changes

- N/A

### Tested

These changes have been tested locally using Echidna. Each test checks the inverse relationship between the getAmountOut and getAmountIn functions under a range of different input conditions.

### Related issues

- Closes #188 

### Backwards compatibility

Fully backwards compatible as the changes only involve the addition of tests and do not alter any existing functionality in the smart contracts.

### Documentation

- N/A
