### PR TITLE
Feature/refactor breaker box

### DIFF
--- a/contracts/interfaces/IBreakerBox.sol
+++ b/contracts/interfaces/IBreakerBox.sol
@@ -8,19 +8,15 @@ pragma solidity ^0.5.13;
 interface IBreakerBox {
   /**
    * @dev Used to track additional info about
-   *      the current trading mode a specific rate feed ID is in.
+   *      the current trading mode a specific breaker of a rate feed ID is in.
+   *      TradingMode is used to determine if a breaker is tripped.
    *      LastUpdatedTime helps to check cooldown.
-   *      LastUpdatedBlock helps to determine if check should be executed.
+   *      Enabled is used to enable/disable breaker for a rate feed.
    */
   struct BreakerStatus {
     uint8 tradingMode;
     uint64 lastUpdatedTime;
     bool enabled;
-  }
-  struct TradingModeInfo {
-    uint64 tradingMode;
-    uint64 lastUpdatedTime;
-    uint128 lastUpdatedBlock;
   }
 
   /**

--- a/contracts/interfaces/IBreakerBox.sol
+++ b/contracts/interfaces/IBreakerBox.sol
@@ -12,6 +12,11 @@ interface IBreakerBox {
    *      LastUpdatedTime helps to check cooldown.
    *      LastUpdatedBlock helps to determine if check should be executed.
    */
+  struct BreakerStatus {
+    uint8 tradingMode;
+    uint64 lastUpdatedTime;
+    bool enabled;
+  }
   struct TradingModeInfo {
     uint64 tradingMode;
     uint64 lastUpdatedTime;
@@ -115,5 +120,5 @@ interface IBreakerBox {
    * @notice Gets the trading mode for the specified rateFeedID.
    * @param rateFeedID The address of the rateFeedID to retrieve the trading mode for.
    */
-  function getRateFeedTradingMode(address rateFeedID) external view returns (uint256 tradingMode);
+  function getRateFeedTradingMode(address rateFeedID) external view returns (uint8 tradingMode);
 }

--- a/test/mocks/MockBreaker.sol
+++ b/test/mocks/MockBreaker.sol
@@ -20,17 +20,23 @@ contract MockBreaker {
     return cooldown;
   }
 
-  function setCooldown(uint256) external {}
+  function setCooldown(uint256 _cooldown) external {
+    cooldown = _cooldown;
+  }
 
   function shouldTrigger(address) external view returns (bool) {
     return trigger;
   }
 
-  function setTrigger(bool) external {}
+  function setTrigger(bool _trigger) external {
+    trigger = _trigger;
+  }
 
   function shouldReset(address) external view returns (bool) {
     return reset;
   }
 
-  function setReset(bool) external {}
+  function setReset(bool _reset) external {
+    reset = _reset;
+  }
 }

--- a/test/mocks/MockBreakerBox.sol
+++ b/test/mocks/MockBreakerBox.sol
@@ -18,7 +18,7 @@ contract MockBreakerBox is IBreakerBox {
     return true;
   }
 
-  function getRateFeedTradingMode(address) external view returns (uint256) {
+  function getRateFeedTradingMode(address) external view returns (uint8) {
     return 0;
   }
 


### PR DESCRIPTION
### Description

- This pr refactors the BreakerBox to support multiple dependent breakers for a rate feed.
- in addition to those changes mentioned in the acceptance criteria I also removed the breakerEnabled mapping since it follows the structure of the new breakerStatus mapping and therefore can be added to the breaker Status struct.
- I use the address(0) breaker to quickly and efficiently track whether a rateFeed is included in the breakerStatus mapping.

### Other changes

- had to update the testAssert as it was dependent on the old mappings in order to get everything to compile
- the only problem with this is that the fork tests fail since the old version is deployed/ used 


### Tested

- updated the BreakerBox tests and added new tests for the changed logic 

### Related issues

- Fixes #196

### Backwards compatibility

- N/A

### Documentation

- N/A
