### PR TITLE
fix: outdated fork-tests after MU03

### DIFF
--- a/test/fork-tests/Utils.t.sol
+++ b/test/fork-tests/Utils.t.sol
@@ -77,6 +77,19 @@ library Utils {
     );
   }
 
+  function getContextForRateFeedID(address _t, address rateFeedID) public view returns (Context memory) {
+    BaseForkTest t = BaseForkTest(_t);
+    (address biPoolManagerAddr, ) = t.exchanges(0);
+    uint256 nOfExchanges = BiPoolManager(biPoolManagerAddr).getExchanges().length;
+    for (uint256 i = 0; i < nOfExchanges; i++) {
+      Context memory ctx = newContext(_t, i);
+      if (getReferenceRateFeedID(ctx) == rateFeedID) {
+        return ctx;
+      }
+    }
+    revert("No exchange found with that referenceRateFeedID");
+  }
+
   // ========================= Swaps =========================
 
   function swapIn(


### PR DESCRIPTION
### Description

This fixes the fork tests which were broken after the many changes done in MU03, mainly the stuff around EMA in the MedianDeltaBreaker, the constantSum pricing module, and the breakerBox refactor.

While working on this we also realized that we forgot to update the breakerBox implementation in the biPoolManager, so god bless the fork tests 🙏 

### Other changes

- Added tests for dependent rate feeds
- Small refactors/added additional comments for context here and here

### Tested

Fork tests are green

> Test result: ok. 18 passed; 0 failed; finished in 116.26s
✨  Done in 129.74s.

### Related issues

Fixes https://github.com/mento-protocol/mento-general/issues/295

### Backwards compatibility

-

### Documentation

-
