### PR TITLE
Update fork tests to work with eXOF

### DIFF
--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -115,7 +115,6 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     for (uint256 i = 0; i < exchangeProviders.length; i++) {
       IExchangeProvider.Exchange[] memory _exchanges = IExchangeProvider(exchangeProviders[i]).getExchanges();
       for (uint256 j = 0; j < _exchanges.length; j++) {
-
         // bytes32 celoXOF = 0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07;
         // bytes32 EUROCXOF = 0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe;
         // if (_exchanges[j].exchangeId != celoXOF && _exchanges[j].exchangeId != EUROCXOF) continue;
@@ -398,7 +397,7 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
 
       This can be generalized once we add the getter to breakerBox.
     */
-    uint256[] memory exchangesIndexesWithDependencies = Arrays.uints(4,5,7,8);
+    uint256[] memory exchangesIndexesWithDependencies = Arrays.uints(4, 5, 7, 8);
     for (uint256 i = 0; i < exchangesIndexesWithDependencies.length; i++) {
       console.log("\n\n");
       Utils.Context memory ctx = Utils.newContext(address(this), exchangesIndexesWithDependencies[i]);

--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -378,6 +378,7 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
   }
 
   mapping(address => uint256) depsCount;
+
   function test_rateFeedDependencies_haltsDependantTrading() public {
     // Hardcoded number of dependencies for each ratefeed
     depsCount[registry.getAddressForStringOrDie("StableToken")] = 0;
@@ -395,7 +396,7 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
       console.log("\n\nexchangeIndex: %d [%d]", i, gasleft());
       Utils.Context memory ctx = Utils.newContext(address(this), i);
       address[] memory dependencies = new address[](depsCount[ctx.getReferenceRateFeedID()]);
-      for(uint d = 0; d < dependencies.length; d++) {
+      for (uint256 d = 0; d < dependencies.length; d++) {
         dependencies[d] = ctx.breakerBox.rateFeedDependencies(ctx.getReferenceRateFeedID(), d);
       }
       if (dependencies.length == 0) {
@@ -413,7 +414,8 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
 
         for (uint256 j = 0; j < breakers.length; j++) {
           console.log("\t\t\t checking breaker with index %d", j);
-          if (breakerBox.isBreakerEnabled(breakers[j], dependencies[k])) { console.log("\t\t\t\t enabled!!");
+          if (breakerBox.isBreakerEnabled(breakers[j], dependencies[k])) {
+            console.log("\t\t\t\t enabled!!");
             assert_breakerBreaks(dependencyContext, breakers[j], j);
             console.log("\t\t\t\t\t 🙏🏽 done with breakerBreaks");
 

--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -115,10 +115,6 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     for (uint256 i = 0; i < exchangeProviders.length; i++) {
       IExchangeProvider.Exchange[] memory _exchanges = IExchangeProvider(exchangeProviders[i]).getExchanges();
       for (uint256 j = 0; j < _exchanges.length; j++) {
-        // bytes32 celoXOF = 0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07;
-        // bytes32 EUROCXOF = 0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe;
-        // if (_exchanges[j].exchangeId != celoXOF && _exchanges[j].exchangeId != EUROCXOF) continue;
-
         if (exchangeIdFilter != bytes32(0) && _exchanges[j].exchangeId != exchangeIdFilter) continue;
         exchanges.push(ExchangeWithProvider(exchangeProviders[i], _exchanges[j]));
         exchangeMap[exchangeProviders[i]][_exchanges[j].exchangeId] = ExchangeWithProvider(

--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -385,10 +385,10 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     depsCount[registry.getAddressForStringOrDie("StableTokenEUR")] = 0;
     depsCount[registry.getAddressForStringOrDie("StableTokenBRL")] = 0;
     depsCount[registry.getAddressForStringOrDie("StableTokenXOF")] = 2;
-    depsCount[0xA1A8003936862E7a15092A91898D69fa8bCE290c] = 0;
-    depsCount[0x206B25Ea01E188Ee243131aFdE526bA6E131a016] = 1;
-    depsCount[0x25F21A1f97607Edf6852339fad709728cffb9a9d] = 1;
-    depsCount[0x26076B9702885d475ac8c3dB3Bd9F250Dc5A318B] = 0;
+    depsCount[0xA1A8003936862E7a15092A91898D69fa8bCE290c] = 0; // USDC/USD
+    depsCount[0x206B25Ea01E188Ee243131aFdE526bA6E131a016] = 1; // USDC/EUR
+    depsCount[0x25F21A1f97607Edf6852339fad709728cffb9a9d] = 1; // USDC/BRL
+    depsCount[0x26076B9702885d475ac8c3dB3Bd9F250Dc5A318B] = 0; // EUROC/EUR
 
     address[] memory breakers = breakerBox.getBreakers();
 

--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -393,7 +393,6 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     address[] memory breakers = breakerBox.getBreakers();
 
     for (uint256 i = 0; i < exchanges.length; i++) {
-      console.log("\n\nexchangeIndex: %d [%d]", i, gasleft());
       Utils.Context memory ctx = Utils.newContext(address(this), i);
       address[] memory dependencies = new address[](depsCount[ctx.getReferenceRateFeedID()]);
       for (uint256 d = 0; d < dependencies.length; d++) {
@@ -408,16 +407,11 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
       console.log("\t exchangeIndex: %d | rateFeedId: %s | %s dependencies", i, rateFeedID, dependencies.length);
 
       for (uint256 k = 0; k < dependencies.length; k++) {
-        console.log("\t\t\t dependency %d: %s", k, dependencies[k]);
         Utils.Context memory dependencyContext = Utils.getContextForRateFeedID(address(this), dependencies[k]);
-        Utils.logPool(dependencyContext);
 
         for (uint256 j = 0; j < breakers.length; j++) {
-          console.log("\t\t\t checking breaker with index %d", j);
           if (breakerBox.isBreakerEnabled(breakers[j], dependencies[k])) {
-            console.log("\t\t\t\t enabled!!");
             assert_breakerBreaks(dependencyContext, breakers[j], j);
-            console.log("\t\t\t\t\t 🙏🏽 done with breakerBreaks");
 
             assert_swapInFails(
               ctx,
@@ -427,10 +421,7 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
               "Trading is suspended for this reference rate"
             );
 
-            console.log("\t\t\t\t\t 🎉done with swapInFails");
-            console.log("\t\t\t\t\t attempt recover for index %d", j);
             assert_breakerRecovers(dependencyContext, breakers[j], j);
-            console.log("\t\t\t\t\t 🤡 done with breakrecovers");
           }
         }
       }

--- a/test/fork-tests/TestAsserts.t.sol
+++ b/test/fork-tests/TestAsserts.t.sol
@@ -396,22 +396,17 @@ contract TestAsserts is Test {
       assert_medianDeltaBreakerBreaks_onDecrease(ctx, breaker);
     } else if (isValueDeltaBreaker) {
       assert_valueDeltaBreakerBreaks_onIncrease(ctx, breaker);
-      console.log("\t\t\t\t\t done with onIncrease in normalValueDeltaBreaker");
       assert_valueDeltaBreakerBreaks_onDecrease(ctx, breaker);
-      console.log("\t\t\t\t\t done with onDecrease in normalValueDeltaBreaker");
     } else if (isNonRecoverableValueDeltaBreaker) {
       // non recoverable
       assert_valueDeltaBreakerBreaks_onIncrease(ctx, breaker);
-      console.log("\t\t\t\t\t done with onIncrease in NonRecoverableValueDeltaBreaker");
       assert_valueDeltaBreakerBreaks_onDecrease(ctx, breaker);
-      console.log("\t\t\t\t\t done with onDecrease in NonRecoverableValueDeltaBreaker");
     } else {
       revert("Unknown trading mode, can't infer breaker type");
     }
   }
 
   function assert_medianDeltaBreakerBreaks_onIncrease(Utils.Context memory ctx, address _breaker) public {
-    console.log("MedianDeltaBreaker breaks on price increase");
     uint256 currentMedian = ensureRateActive(ctx); // ensure trading mode is 0
 
     // trigger breaker by setting new median to ema - (threshold + 0.001% buffer)
@@ -428,7 +423,6 @@ contract TestAsserts is Test {
   }
 
   function assert_medianDeltaBreakerBreaks_onDecrease(Utils.Context memory ctx, address _breaker) public {
-    console.log("MedianDeltaBreaker breaks on price decrease");
     uint256 currentMedian = ensureRateActive(ctx); // ensure trading mode is 0
 
     // trigger breaker by setting new median to ema + (threshold + 0.001% buffer)
@@ -445,7 +439,6 @@ contract TestAsserts is Test {
   }
 
   function assert_valueDeltaBreakerBreaks_onIncrease(Utils.Context memory ctx, address _breaker) public {
-    console.log("ValueDeltaBreaker breaks on price increase");
     uint256 currentMedian = ensureRateActive(ctx); // ensure trading mode is 0
 
     // trigger breaker by setting new median to reference value + threshold + 1
@@ -462,7 +455,6 @@ contract TestAsserts is Test {
   }
 
   function assert_valueDeltaBreakerBreaks_onDecrease(Utils.Context memory ctx, address _breaker) public {
-    console.log("ValueDeltaBreaker breaks on price decrease");
     uint256 currentMedian = ensureRateActive(ctx); // ensure trading mode is 0
 
     // trigger breaker by setting new median to reference value - threshold - 1
@@ -498,7 +490,6 @@ contract TestAsserts is Test {
   }
 
   function assert_medianDeltaBreakerRecovers(Utils.Context memory ctx, address _breaker) internal {
-    console.log("MedianDeltaBreaker recovers");
     uint256 currentMedian = ensureRateActive(ctx); // ensure trading mode is 0
 
     // trigger breaker by setting new median to ema + threshold + 0.001%
@@ -525,7 +516,6 @@ contract TestAsserts is Test {
   }
 
   function assert_valueDeltaBreakerRecovers(Utils.Context memory ctx, address _breaker) internal {
-    console.log("ValueDeltaBreaker recovers");
     uint256 currentMedian = ensureRateActive(ctx); // ensure trading mode is 0
 
     // trigger breaker by setting new median to reference value + threshold + 1

--- a/test/fork-tests/TestAsserts.t.sol
+++ b/test/fork-tests/TestAsserts.t.sol
@@ -115,7 +115,6 @@ contract TestAsserts is Test {
     );
     console.log("========================================");
 
-
     if (limitConfigFrom.isLimitEnabled(limit) && limitConfigTo.isLimitEnabled(limit)) {
       console.log("Both Limits enabled");
       FixidityLib.Fraction memory rate = ctx.getReferenceRateFraction(to);
@@ -161,7 +160,7 @@ contract TestAsserts is Test {
         assert_swapOverLimitFails_onOutflow(ctx, from, to, limit);
       }
       // If both limits are enabled we choose the one that is more restrictive
-    }  else if (limitConfigFrom.isLimitEnabled(limit)) {
+    } else if (limitConfigFrom.isLimitEnabled(limit)) {
       assert_swapOverLimitFails_onInflow(ctx, from, to, limit);
     } else if (limitConfigTo.isLimitEnabled(limit)) {
       assert_swapOverLimitFails_onOutflow(ctx, from, to, limit);

--- a/test/fork-tests/TestAsserts.t.sol
+++ b/test/fork-tests/TestAsserts.t.sol
@@ -390,15 +390,10 @@ contract TestAsserts is Test {
     // where the medianDeltaBreaker gets deployed first and the valueDeltaBreaker second.
     bool isMedianDeltaBreaker = breakerIndex == 0;
     bool isValueDeltaBreaker = breakerIndex == 1;
-    bool isNonRecoverableValueDeltaBreaker = breakerIndex == 2;
     if (isMedianDeltaBreaker) {
       assert_medianDeltaBreakerBreaks_onIncrease(ctx, breaker);
       assert_medianDeltaBreakerBreaks_onDecrease(ctx, breaker);
     } else if (isValueDeltaBreaker) {
-      assert_valueDeltaBreakerBreaks_onIncrease(ctx, breaker);
-      assert_valueDeltaBreakerBreaks_onDecrease(ctx, breaker);
-    } else if (isNonRecoverableValueDeltaBreaker) {
-      // non recoverable
       assert_valueDeltaBreakerBreaks_onIncrease(ctx, breaker);
       assert_valueDeltaBreakerBreaks_onDecrease(ctx, breaker);
     } else {
@@ -613,11 +608,10 @@ contract TestAsserts is Test {
     address[] memory _breakers = ctx.breakerBox.getBreakers();
     bool isMedianDeltaBreaker = breakerIndex == 0;
     bool isValueDeltaBreaker = breakerIndex == 1;
-    bool isNonRecoverableValueDeltaBreaker = breakerIndex == 2;
     if (isMedianDeltaBreaker) {
       uint256 currentEMA = MedianDeltaBreaker(_breakers[breakerIndex]).medianRatesEMA(ctx.getReferenceRateFeedID());
       return currentEMA;
-    } else if (isValueDeltaBreaker || isNonRecoverableValueDeltaBreaker) {
+    } else if (isValueDeltaBreaker) {
       return ctx.getValueDeltaBreakerReferenceValue(_breakers[breakerIndex]);
     } else {
       revert("can't infer corresponding breaker");

--- a/test/fork-tests/TestAsserts.t.sol
+++ b/test/fork-tests/TestAsserts.t.sol
@@ -106,8 +106,8 @@ contract TestAsserts is Test {
     address to,
     uint8 limit
   ) internal {
-    TradingLimits.Config memory limitConfigFrom = ctx.tradingLimitsConfig(from);
-    TradingLimits.Config memory limitConfigTo = ctx.tradingLimitsConfig(to);
+    TradingLimits.Config memory fromLimitConfig = ctx.tradingLimitsConfig(from);
+    TradingLimits.Config memory toLimitConfig = ctx.tradingLimitsConfig(to);
     console.log(
       string(abi.encodePacked("Swapping ", IERC20Metadata(from).symbol(), " -> ", IERC20Metadata(to).symbol())),
       "with limit",
@@ -115,54 +115,13 @@ contract TestAsserts is Test {
     );
     console.log("========================================");
 
-    if (limitConfigFrom.isLimitEnabled(limit) && limitConfigTo.isLimitEnabled(limit)) {
-      console.log("Both Limits enabled");
-      FixidityLib.Fraction memory rate = ctx.getReferenceRateFraction(to);
-      TradingLimits.Config memory toLimitConfig = ctx.tradingLimitsConfig(to);
-      TradingLimits.Config memory fromLimitConfig = ctx.tradingLimitsConfig(from);
-      skip(toLimitConfig.timestep1 + fromLimitConfig.timestep1 + 1);
-      ensureRateActive(ctx);
-      TradingLimits.State memory toLimitState = ctx.refreshedTradingLimitsState(to);
-      TradingLimits.State memory fromLimitState = ctx.refreshedTradingLimitsState(from);
-
-      uint256 toLimit;
-      uint256 fromLimit;
-      int256 toNetflow;
-      int256 fromNetflow;
-
-      if (limit == L0) {
-        toLimit = uint256(toLimitConfig.limit0);
-        fromLimit = uint256(fromLimitConfig.limit0);
-        toNetflow = int256(toLimitState.netflow0);
-        fromNetflow = int256(fromLimitState.netflow0);
-      } else if (limit == L1) {
-        toLimit = uint256(toLimitConfig.limit1);
-        fromLimit = uint256(fromLimitConfig.limit1);
-        toNetflow = int256(toLimitState.netflow1);
-        fromNetflow = int256(fromLimitState.netflow1);
-      } else if (limit == LG) {
-        toLimit = uint256(toLimitConfig.limitGlobal);
-        fromLimit = uint256(fromLimitConfig.limitGlobal);
-        toNetflow = int256(toLimitState.netflowGlobal);
-        fromNetflow = int256(fromLimitState.netflowGlobal);
-      }
-
-      console.log("toLimit: %d fromLimit: %d", toLimit, fromLimit);
-      console.logInt(toNetflow);
-      console.logInt(fromNetflow);
-
-      fromLimit = rate.multiply(FixidityLib.newFixed(uint256(fromLimit))).fromFixed();
-
-      console.log("toLimit: %d fromLimit: %d", toLimit, fromLimit);
-      if (toLimit > fromLimit) {
-        assert_swapOverLimitFails_onInflow(ctx, from, to, limit);
-      } else {
-        assert_swapOverLimitFails_onOutflow(ctx, from, to, limit);
-      }
-      // If both limits are enabled we choose the one that is more restrictive
-    } else if (limitConfigFrom.isLimitEnabled(limit)) {
+    if (fromLimitConfig.isLimitEnabled(limit) && toLimitConfig.isLimitEnabled(limit)) {
+      // TODO: Figure out best way to implement fork tests
+      // when two limits are configured.
+      console.log("Both Limits enabled skipping for now");
+    } else if (fromLimitConfig.isLimitEnabled(limit)) {
       assert_swapOverLimitFails_onInflow(ctx, from, to, limit);
-    } else if (limitConfigTo.isLimitEnabled(limit)) {
+    } else if (toLimitConfig.isLimitEnabled(limit)) {
       assert_swapOverLimitFails_onOutflow(ctx, from, to, limit);
     }
   }

--- a/test/fork-tests/Utils.t.sol
+++ b/test/fork-tests/Utils.t.sol
@@ -182,13 +182,13 @@ library Utils {
     BiPoolManager biPoolManager = BiPoolManager(ctx.exchangeProvider);
     BiPoolManager.PoolExchange memory pool = biPoolManager.getPoolExchange(ctx.exchangeId);
     (bool timePassed, bool enoughReports, bool medianReportRecent, bool isReportExpired, ) = shouldUpdateBuckets(ctx);
-    logPool(ctx);
+    // logPool(ctx);
     if (timePassed && (!medianReportRecent || isReportExpired || !enoughReports)) {
       (uint256 newMedian, ) = ctx.sortedOracles.medianRate(pool.config.referenceRateFeedID);
       (timePassed, enoughReports, medianReportRecent, isReportExpired, ) = shouldUpdateBuckets(ctx);
       updateOracleMedianRate(ctx, newMedian.mul(1_000_001).div(1_000_000));
 
-      logPool(ctx);
+      // logPool(ctx);
       return;
     }
   }
@@ -301,8 +301,11 @@ library Utils {
       }
 
       changePrank(oracle);
+      console.log("🔮 going to do prank report: ");
       ctx.sortedOracles.report(rateFeedID, newMedian, lesserKey, greaterKey);
+      console.log("🔮 done with prank report");
     }
+    console.log("done with updateOracleMedianRate");
     changePrank(ctx.trader);
   }
 

--- a/test/fork-tests/Utils.t.sol
+++ b/test/fork-tests/Utils.t.sol
@@ -513,7 +513,7 @@ library Utils {
     if (ctx.exchangeId == 0) {
       console.log("🎱 RateFeed: %s", ctx.rateFeedID);
       return;
-    }     
+    }
     BiPoolManager biPoolManager = BiPoolManager(ctx.exchangeProvider);
     BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(ctx.exchangeId);
 

--- a/test/fork-tests/Utils.t.sol
+++ b/test/fork-tests/Utils.t.sol
@@ -166,8 +166,6 @@ library Utils {
     BiPoolManager biPoolManager = BiPoolManager(ctx.exchangeProvider);
     BiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(ctx.exchangeId);
 
-    console.log(exchange.config.referenceRateFeedID);
-    console.log(ctx.sortedOracles.numRates(exchange.config.referenceRateFeedID));
     (bool isReportExpired, ) = ctx.sortedOracles.isOldestReportExpired(exchange.config.referenceRateFeedID);
     // solhint-disable-next-line not-rely-on-time
     bool timePassed = now >= exchange.lastBucketUpdate.add(exchange.config.referenceRateResetFrequency);

--- a/test/utils/TokenHelpers.t.sol
+++ b/test/utils/TokenHelpers.t.sol
@@ -25,6 +25,8 @@ contract TokenHelpers is Test {
       mint(StableToken(token), to, amount);
     } else if (token == registry.getAddressForStringOrDie("StableTokenBRL")) {
       mint(StableToken(token), to, amount);
+    } else if (token == registry.getAddressForStringOrDie("StableTokenXOF")) {
+      mint(StableToken(token), to, amount);
     } else {
       deal(token, to, amount);
     }


### PR DESCRIPTION
### Description

Fork tests weren't passing on `baklava` after the eXOF update because:
1. We have an unrecoverable breaker
2. We have trading limits on both assets in a pool
3. We have multiple dependencies on a single rate

The approaches I took to fix were:
1. Include manual reset logic to our helper functions that used to reset breakers just by altering the median
2. Check if both assets have limits and in that case choose to test the limit that is more restrictive
3. Slightly alter the logic for rate feed dependencies to test when there are multiple dependencies for a rate feed.

For (3) I initially tried an approach where I was using low-level `call` to figure out how many dependencies a rate feed has but that threw me into a rabbit hole of weird foundry behaviour because catching those `call` reverts ended up consuming a lot of gas and finally the function ended with out-of-gas errors. This was in an attempt to remove the hardcoded elements from the test, but I think we need to live with them for now.

### Other changes

N/A

### Tested

Test run

### Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/302

### Backwards compatibility

Yes

### Documentation

N/A

┆Issue is synchronized with this [Jira Story](https://mentolabs.atlassian.net/browse/MC-12) by [Unito](https://www.unito.io)
