### PR TITLE
fix: update fork-tests after MU04

### DIFF
--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -128,8 +128,8 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     // XXX: The number of collateral assets 3 is hardcoded here [CELO, USDC, EUROC]
     for (uint256 i = 0; i < 3; i++) {
       address collateralAsset = reserve.collateralAssets(i);
-      mint(collateralAsset, address(reserve), Utils.toSubunits(10_000_000, collateralAsset));
-      console.log("Minting 10mil %s to reserve", IERC20Metadata(collateralAsset).symbol());
+      mint(collateralAsset, address(reserve), Utils.toSubunits(25_000_000, collateralAsset));
+      console.log("Minting 25mil %s to reserve", IERC20Metadata(collateralAsset).symbol());
     }
 
     console.log("Exchanges(%d): ", exchanges.length);

--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -179,13 +179,13 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     IStableTokenV2 stableTokenEUR = IStableTokenV2(registry.getAddressForStringOrDie("StableTokenEUR"));
     IStableTokenV2 stableTokenBRL = IStableTokenV2(registry.getAddressForStringOrDie("StableTokenBRL"));
 
-    vm.expectRevert("contract already initialized");
+    vm.expectRevert("Initializable: contract is already initialized");
     stableToken.initialize("", "", 8, address(10), 0, 0, new address[](0), new uint256[](0), "");
 
-    vm.expectRevert("contract already initialized");
+    vm.expectRevert("Initializable: contract is already initialized");
     stableTokenEUR.initialize("", "", 8, address(10), 0, 0, new address[](0), new uint256[](0), "");
 
-    vm.expectRevert("contract already initialized");
+    vm.expectRevert("Initializable: contract is already initialized");
     stableTokenBRL.initialize("", "", 8, address(10), 0, 0, new address[](0), new uint256[](0), "");
   }
 

--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -178,6 +178,7 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     IStableTokenV2 stableToken = IStableTokenV2(registry.getAddressForStringOrDie("StableToken"));
     IStableTokenV2 stableTokenEUR = IStableTokenV2(registry.getAddressForStringOrDie("StableTokenEUR"));
     IStableTokenV2 stableTokenBRL = IStableTokenV2(registry.getAddressForStringOrDie("StableTokenBRL"));
+    IStableTokenV2 stableTokenXOF = IStableTokenV2(registry.getAddressForStringOrDie("StableTokenXOF"));
 
     vm.expectRevert("Initializable: contract is already initialized");
     stableToken.initialize("", "", 8, address(10), 0, 0, new address[](0), new uint256[](0), "");
@@ -187,6 +188,9 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
 
     vm.expectRevert("Initializable: contract is already initialized");
     stableTokenBRL.initialize("", "", 8, address(10), 0, 0, new address[](0), new uint256[](0), "");
+
+    vm.expectRevert("Initializable: contract is already initialized");
+    stableTokenXOF.initialize("", "", 8, address(10), 0, 0, new address[](0), new uint256[](0), "");
   }
 
   function test_swapsHappenInBothDirections() public {

--- a/test/gas/ExchangeGas.t.sol
+++ b/test/gas/ExchangeGas.t.sol
@@ -5,9 +5,10 @@ pragma experimental ABIEncoderV2;
 
 import { Test, console2 as console } from "celo-foundry/Test.sol";
 import { TokenHelpers } from "../utils/TokenHelpers.t.sol";
+import { StableToken } from "contracts/legacy/StableToken.sol";
+import { StableTokenEUR } from "contracts/legacy/StableTokenEUR.sol";
 import { GoldToken } from "contracts/common/GoldToken.sol";
 import { IExchange } from "contracts/legacy/interfaces/IExchange.sol";
-import "contracts/interfaces/IStableTokenV2.sol";
 
 import { FixidityLib } from "contracts/common/FixidityLib.sol";
 
@@ -18,8 +19,8 @@ contract ExchangeGasTest is Test, TokenHelpers {
   IExchange exchangeCUSD;
   IExchange exchangeCEUR;
 
-  IStableTokenV2 cUSDToken;
-  IStableTokenV2 cEURToken;
+  StableToken cUSDToken;
+  StableTokenEUR cEURToken;
   GoldToken celoToken;
 
   function setUp() public {
@@ -30,8 +31,9 @@ contract ExchangeGasTest is Test, TokenHelpers {
     exchangeCUSD = IExchange(0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275);
     exchangeCEUR = IExchange(0xE383394B913d7302c49F794C7d3243c429d53D1d);
 
-    cUSDToken = IStableTokenV2(0x765DE816845861e75A25fCA122bb6898B8B1282a);
-    cEURToken = IStableTokenV2(0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73);
+    // TODO: convert to StableTokenV2 after mainnet migration
+    cUSDToken = StableToken(0x765DE816845861e75A25fCA122bb6898B8B1282a);
+    cEURToken = StableTokenEUR(0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73);
     celoToken = GoldToken(0x471EcE3750Da237f93B8E339c536989b8978a438);
 
     trader = actor("trader");

--- a/test/gas/ExchangeGas.t.sol
+++ b/test/gas/ExchangeGas.t.sol
@@ -5,10 +5,9 @@ pragma experimental ABIEncoderV2;
 
 import { Test, console2 as console } from "celo-foundry/Test.sol";
 import { TokenHelpers } from "../utils/TokenHelpers.t.sol";
-import { StableToken } from "contracts/legacy/StableToken.sol";
-import { StableTokenEUR } from "contracts/legacy/StableTokenEUR.sol";
 import { GoldToken } from "contracts/common/GoldToken.sol";
 import { IExchange } from "contracts/legacy/interfaces/IExchange.sol";
+import "contracts/interfaces/IStableTokenV2.sol";
 
 import { FixidityLib } from "contracts/common/FixidityLib.sol";
 
@@ -19,8 +18,8 @@ contract ExchangeGasTest is Test, TokenHelpers {
   IExchange exchangeCUSD;
   IExchange exchangeCEUR;
 
-  StableToken cUSDToken;
-  StableTokenEUR cEURToken;
+  IStableTokenV2 cUSDToken;
+  IStableTokenV2 cEURToken;
   GoldToken celoToken;
 
   function setUp() public {
@@ -31,8 +30,8 @@ contract ExchangeGasTest is Test, TokenHelpers {
     exchangeCUSD = IExchange(0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275);
     exchangeCEUR = IExchange(0xE383394B913d7302c49F794C7d3243c429d53D1d);
 
-    cUSDToken = StableToken(0x765DE816845861e75A25fCA122bb6898B8B1282a);
-    cEURToken = StableTokenEUR(0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73);
+    cUSDToken = IStableTokenV2(0x765DE816845861e75A25fCA122bb6898B8B1282a);
+    cEURToken = IStableTokenV2(0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73);
     celoToken = GoldToken(0x471EcE3750Da237f93B8E339c536989b8978a438);
 
     trader = actor("trader");

--- a/test/utils/TokenHelpers.t.sol
+++ b/test/utils/TokenHelpers.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.13;
 
 import "celo-foundry/Test.sol";
 
+import "contracts/legacy/StableToken.sol";
 import "contracts/common/GoldToken.sol";
 import "contracts/common/interfaces/IRegistry.sol";
 import "contracts/interfaces/IStableTokenV2.sol";
@@ -43,6 +44,18 @@ contract TokenHelpers is Test {
     address pranker = currentPrank;
     changePrank(address(0));
     celoToken.mint(to, amount);
+    changePrank(pranker);
+  }
+
+  // TODO: delete after the migration to StableTokenV2 is done on mainnet
+  function mint(
+    StableToken stableToken,
+    address to,
+    uint256 amount
+  ) internal {
+    address pranker = currentPrank;
+    changePrank(stableToken.registry().getAddressForString("Broker"));
+    stableToken.mint(to, amount);
     changePrank(pranker);
   }
 

--- a/test/utils/TokenHelpers.t.sol
+++ b/test/utils/TokenHelpers.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.5.13;
 
 import "celo-foundry/Test.sol";
 
-import "contracts/legacy/StableToken.sol";
 import "contracts/common/GoldToken.sol";
 import "contracts/common/interfaces/IRegistry.sol";
 import "contracts/interfaces/IStableTokenV2.sol";
@@ -20,13 +19,13 @@ contract TokenHelpers is Test {
     if (token == registry.getAddressForString("GoldToken")) {
       mint(GoldToken(token), to, amount);
     } else if (token == registry.getAddressForStringOrDie("StableToken")) {
-      mint(StableToken(token), to, amount);
+      mint(IStableTokenV2(token), to, amount);
     } else if (token == registry.getAddressForStringOrDie("StableTokenEUR")) {
-      mint(StableToken(token), to, amount);
+      mint(IStableTokenV2(token), to, amount);
     } else if (token == registry.getAddressForStringOrDie("StableTokenBRL")) {
-      mint(StableToken(token), to, amount);
+      mint(IStableTokenV2(token), to, amount);
     } else if (token == registry.getAddressForStringOrDie("StableTokenXOF")) {
-      mint(StableToken(token), to, amount);
+      mint(IStableTokenV2(token), to, amount);
     } else {
       deal(token, to, amount);
     }
@@ -44,17 +43,6 @@ contract TokenHelpers is Test {
     address pranker = currentPrank;
     changePrank(address(0));
     celoToken.mint(to, amount);
-    changePrank(pranker);
-  }
-
-  function mint(
-    StableToken stableToken,
-    address to,
-    uint256 amount
-  ) internal {
-    address pranker = currentPrank;
-    changePrank(stableToken.registry().getAddressForString("GrandaMento"));
-    stableToken.mint(to, amount);
     changePrank(pranker);
   }
 


### PR DESCRIPTION
### Description

This updates the fork-tests to work post MU04 execution on Baklava. It did required a bit but debugging the overall changes ended up being quite small:

- Minting more collateral to the Reserve address (since trading limits will be higher)
- Update the contract already initialized message for StableTokenV2
- ~Remove the old mint functions for the v1 stable tokens~ 
update: ended up bringing it back as it's needed for a gas test that runs on mainnet

### Tested

Fork tests are green on Baklava ✅
```
Running 18 tests for test/fork-tests/EnvForkTest.t.sol:BaklavaForkTest
[PASS] test_biPoolManagerCanNotBeReinitialized() (gas: 38850)
[PASS] test_brokerCanNotBeReinitialized() (gas: 19360)
[PASS] test_circuitBreaker_breaks() (gas: 72145240)
[PASS] test_circuitBreaker_haltsTrading() (gas: 77095231)
[PASS] test_circuitBreaker_rateFeedsAreProtected() (gas: 761903)
[PASS] test_circuitBreaker_recovers() (gas: 26192048)
[PASS] test_rateFeedDependencies_haltsDependantTrading() (gas: 32748025)
[PASS] test_reserveCanNotBeReinitialized() (gas: 19309)
[PASS] test_sortedOraclesCanNotBeReinitialized() (gas: 16489)
[PASS] test_stableTokensCanNotBeReinitialized() (gas: 69512)
[PASS] test_swapsHappenInBothDirections() (gas: 5307611)
[PASS] test_tradingLimitsAreConfigured() (gas: 540654)
[PASS] test_tradingLimitsAreEnforced_0to1_L0() (gas: 5047372)
[PASS] test_tradingLimitsAreEnforced_0to1_L1() (gas: 40787988)
[PASS] test_tradingLimitsAreEnforced_0to1_LG() (gas: 73835760)
[PASS] test_tradingLimitsAreEnforced_1to0_L0() (gas: 4715844)
[PASS] test_tradingLimitsAreEnforced_1to0_L1() (gas: 39125830)
[PASS] test_tradingLimitsAreEnforced_1to0_LG() (gas: 52951100)
Test result: ok. 18 passed; 0 failed; 0 skipped; finished in 119.54s
Ran 1 test suites: 18 tests passed, 0 failed, 0 skipped (18 total tests)
✨  Done in 137.99s.
```

### Related issues

- https://github.com/mento-protocol/mento-deployment/issues/116
