### PR TITLE
fix: add null addresses checks in creditGasFees

### DIFF
--- a/contracts/tokens/StableTokenV2.sol
+++ b/contracts/tokens/StableTokenV2.sol
@@ -291,9 +291,29 @@ contract StableTokenV2 is ERC20PermitUpgradeable, IStableTokenV2, CalledByVm {
     uint256 gatewayFee,
     uint256 baseTxFee
   ) external onlyVm {
+    uint256 amountToBurn = 0;
     _mint(from, refund + tipTxFee + gatewayFee + baseTxFee);
-    _transfer(from, feeRecipient, tipTxFee);
-    _transfer(from, gatewayFeeRecipient, gatewayFee);
-    _transfer(from, communityFund, baseTxFee);
+
+    if (feeRecipient != address(0)) {
+      _transfer(from, feeRecipient, tipTxFee);
+    } else if (tipTxFee > 0) {
+      amountToBurn += tipTxFee;
+    }
+
+    if (gatewayFeeRecipient != address(0)) {
+      _transfer(from, gatewayFeeRecipient, gatewayFee);
+    } else if (gatewayFee > 0) {
+      amountToBurn += gatewayFee;
+    }
+
+    if (communityFund != address(0)) {
+      _transfer(from, communityFund, baseTxFee);
+    } else if (baseTxFee > 0) {
+      amountToBurn += baseTxFee;
+    }
+
+    if (amountToBurn > 0) {
+      _burn(from, amountToBurn);
+    }
   }
 }

--- a/contracts/tokens/StableTokenV2.sol
+++ b/contracts/tokens/StableTokenV2.sol
@@ -258,8 +258,7 @@ contract StableTokenV2 is ERC20PermitUpgradeable, IStableTokenV2, CalledByVm {
    * @param value The amount of balance to reserve
    * @dev Note that this function is called by the protocol when paying for tx fees in this
    * currency. After the tx is executed, gas is refunded to the sender and credited to the
-   * various tx fee recipients via a call to `creditGasFees`. Note too that the events emitted
-   * by `creditGasFees` reflect the *net* gas fee payments for the transaction.
+   * various tx fee recipients via a call to `creditGasFees`.
    */
   function debitGasFees(address from, uint256 value) external onlyVm {
     _burn(from, value);
@@ -278,8 +277,7 @@ contract StableTokenV2 is ERC20PermitUpgradeable, IStableTokenV2, CalledByVm {
    * @param gatewayFee Gateway fee
    * @dev Note that this function is called by the protocol when paying for tx fees in this
    * currency. Before the tx is executed, gas is debited from the sender via a call to
-   * `debitGasFees`. Note too that the events emitted by `creditGasFees` reflect the *net* gas fee
-   * payments for the transaction.
+   * `debitGasFees`.
    */
   function creditGasFees(
     address from,

--- a/contracts/tokens/StableTokenV2.sol
+++ b/contracts/tokens/StableTokenV2.sol
@@ -291,7 +291,7 @@ contract StableTokenV2 is ERC20PermitUpgradeable, IStableTokenV2, CalledByVm {
     uint256 gatewayFee,
     uint256 baseTxFee
   ) external onlyVm {
-    uint256 amountToBurn = 0;
+    uint256 amountToBurn;
     _mint(from, refund + tipTxFee + gatewayFee + baseTxFee);
 
     if (feeRecipient != address(0)) {

--- a/test/tokens/StableTokenV2.t.sol
+++ b/test/tokens/StableTokenV2.t.sol
@@ -172,6 +172,7 @@ contract StableTokenV2Test is BaseTest {
     uint256 tipTxFee = 30;
     uint256 gatewayFee = 10;
     uint256 baseTxFee = 40;
+    uint256 tokenSupplyBefore = token.totalSupply();
 
     vm.prank(address(0));
     token.creditGasFees(
@@ -189,6 +190,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFee);
     assertEq(token.balanceOf(communityFund), baseTxFee);
+    assertEq(token.totalSupply(), tokenSupplyBefore + refund + tipTxFee + gatewayFee + baseTxFee);
   }
 
   function test_creditGasFees_whenCalledByVm_with0xFeeRecipient_shouldBurnTipTxFee() public {
@@ -197,6 +199,8 @@ contract StableTokenV2Test is BaseTest {
     uint256 gatewayFee = 10;
     uint256 baseTxFee = 40;
     uint256 holder0InitialBalance = token.balanceOf(holder0);
+    uint256 tokenSupplyBefore = token.totalSupply();
+    uint256 newlyMinted = refund + tipTxFee + gatewayFee + baseTxFee;
 
     vm.prank(address(0));
     token.creditGasFees(
@@ -214,6 +218,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(feeRecipient), 0);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFee);
     assertEq(token.balanceOf(communityFund), baseTxFee);
+    assertEq(token.totalSupply(), tokenSupplyBefore + newlyMinted - tipTxFee);
   }
 
   function test_creditGasFees_whenCalledByVm_with0xGatewayFeeRecipient_shouldBurnGateWayFee() public {
@@ -222,6 +227,8 @@ contract StableTokenV2Test is BaseTest {
     uint256 gatewayFee = 10;
     uint256 baseTxFee = 40;
     uint256 holder0InitialBalance = token.balanceOf(holder0);
+    uint256 tokenSupplyBefore = token.totalSupply();
+    uint256 newlyMinted = refund + tipTxFee + gatewayFee + baseTxFee;
 
     vm.prank(address(0));
     token.creditGasFees(holder0, feeRecipient, address(0), communityFund, refund, tipTxFee, gatewayFee, baseTxFee);
@@ -230,6 +237,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), 0);
     assertEq(token.balanceOf(communityFund), baseTxFee);
+    assertEq(token.totalSupply(), tokenSupplyBefore + newlyMinted - gatewayFee);
   }
 
   function test_creditGasFees_whenCalledByVm_with0xCommunityFund_shouldBurnBaseTxFee() public {
@@ -238,6 +246,8 @@ contract StableTokenV2Test is BaseTest {
     uint256 gatewayFee = 10;
     uint256 baseTxFee = 40;
     uint256 holder0InitialBalance = token.balanceOf(holder0);
+    uint256 tokenSupplyBefore = token.totalSupply();
+    uint256 newlyMinted = refund + tipTxFee + gatewayFee + baseTxFee;
 
     vm.prank(address(0));
     token.creditGasFees(
@@ -255,6 +265,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFee);
     assertEq(token.balanceOf(communityFund), 0);
+    assertEq(token.totalSupply(), tokenSupplyBefore + newlyMinted - baseTxFee);
   }
 
   function test_creditGasFees_whenCalledByVm_withMultiple0xRecipients_shouldBurnTheirRespectiveFees() public {
@@ -263,6 +274,8 @@ contract StableTokenV2Test is BaseTest {
     uint256 gatewayFee = 10;
     uint256 baseTxFee = 40;
     uint256 holder0InitialBalance = token.balanceOf(holder0);
+    uint256 tokenSupplyBefore0 = token.totalSupply();
+    uint256 newlyMinted0 = refund + tipTxFee + gatewayFee + baseTxFee;
 
     vm.prank(address(0));
     // gateWayFeeRecipient and communityFund both 0x
@@ -272,12 +285,15 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), 0);
     assertEq(token.balanceOf(communityFund), 0);
+    assertEq(token.totalSupply(), tokenSupplyBefore0 + newlyMinted0 - gatewayFee - baseTxFee);
 
     // case with both feeRecipient and communityFund both 0x
     uint256 holder1InitialBalance = token.balanceOf(holder1);
     uint256 feeRecipientBalance = token.balanceOf(feeRecipient);
     uint256 gatewayFeeRecipientBalance = token.balanceOf(gatewayFeeRecipient);
     uint256 communityFundBalance = token.balanceOf(communityFund);
+    uint256 tokenSupplyBefore1 = token.totalSupply();
+    uint256 newlyMinted1 = refund + tipTxFee + gatewayFee + baseTxFee;
     vm.prank(address(0));
     token.creditGasFees(holder1, address(0), gatewayFeeRecipient, address(0), refund, tipTxFee, gatewayFee, baseTxFee);
 
@@ -285,6 +301,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(feeRecipient), feeRecipientBalance);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFeeRecipientBalance + gatewayFee);
     assertEq(token.balanceOf(communityFund), communityFundBalance);
+    assertEq(token.totalSupply(), tokenSupplyBefore1 + newlyMinted1 - tipTxFee - baseTxFee);
   }
 
   function buildTypedDataHash(

--- a/test/tokens/StableTokenV2.t.sol
+++ b/test/tokens/StableTokenV2.t.sol
@@ -31,7 +31,7 @@ contract StableTokenV2Test is BaseTest {
 
   address feeRecipient = address(0x3001);
   address gatewayFeeRecipient = address(0x3002);
-  address conmunityFund = address(0x3003);
+  address communityFund = address(0x3003);
 
   StableTokenV2 private token;
 
@@ -164,7 +164,7 @@ contract StableTokenV2Test is BaseTest {
 
   function test_creditGasFees_whenCallerNotVM_shouldRevert() public {
     vm.expectRevert("Only VM can call");
-    token.creditGasFees(holder0, feeRecipient, gatewayFeeRecipient, conmunityFund, 25, 25, 25, 25);
+    token.creditGasFees(holder0, feeRecipient, gatewayFeeRecipient, communityFund, 25, 25, 25, 25);
   }
 
   function test_creditGasFees_whenCalledByVm_shouldCreditFees() public {
@@ -178,7 +178,7 @@ contract StableTokenV2Test is BaseTest {
       holder0,
       feeRecipient,
       gatewayFeeRecipient,
-      conmunityFund,
+      communityFund,
       refund,
       tipTxFee,
       gatewayFee,
@@ -188,7 +188,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(holder0), 1000 + refund);
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFee);
-    assertEq(token.balanceOf(conmunityFund), baseTxFee);
+    assertEq(token.balanceOf(communityFund), baseTxFee);
   }
 
   function test_creditGasFees_whenCalledByVm_with0xFeeRecipient_shouldBurnTipTxFee() public {
@@ -203,7 +203,7 @@ contract StableTokenV2Test is BaseTest {
       holder0,
       address(0),
       gatewayFeeRecipient,
-      conmunityFund,
+      communityFund,
       refund,
       tipTxFee,
       gatewayFee,
@@ -213,7 +213,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(holder0), holder0InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), 0);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFee);
-    assertEq(token.balanceOf(conmunityFund), baseTxFee);
+    assertEq(token.balanceOf(communityFund), baseTxFee);
   }
 
   function test_creditGasFees_whenCalledByVm_with0xGatewayFeeRecipient_shouldBurnGateWayFee() public {
@@ -228,7 +228,7 @@ contract StableTokenV2Test is BaseTest {
       holder0,
       feeRecipient,
       address(0),
-      conmunityFund,
+      communityFund,
       refund,
       tipTxFee,
       gatewayFee,
@@ -238,7 +238,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(holder0), holder0InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), 0);
-    assertEq(token.balanceOf(conmunityFund), baseTxFee);
+    assertEq(token.balanceOf(communityFund), baseTxFee);
   }
 
   function test_creditGasFees_whenCalledByVm_with0xCommunityFund_shouldBurnBaseTxFee() public {
@@ -263,7 +263,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(holder0), holder0InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFee);
-    assertEq(token.balanceOf(conmunityFund), 0);
+    assertEq(token.balanceOf(communityFund), 0);
   }
 
   function test_creditGasFees_whenCalledByVm_withMultiple0xRecipients_shouldBurnTheirRespectiveFees() public {
@@ -274,7 +274,7 @@ contract StableTokenV2Test is BaseTest {
     uint256 holder0InitialBalance = token.balanceOf(holder0);
 
     vm.prank(address(0));
-    // gateWayFeeRecipient and conmunityFund both 0x
+    // gateWayFeeRecipient and communityFund both 0x
     token.creditGasFees(
       holder0,
       feeRecipient,
@@ -289,13 +289,13 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(holder0), holder0InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
     assertEq(token.balanceOf(gatewayFeeRecipient), 0);
-    assertEq(token.balanceOf(conmunityFund), 0);
+    assertEq(token.balanceOf(communityFund), 0);
 
-    // case with both feeRecipient and conmunityFund both 0x
+    // case with both feeRecipient and communityFund both 0x
     uint256 holder1InitialBalance = token.balanceOf(holder1);
     uint256 feeRecipientBalance = token.balanceOf(feeRecipient);
     uint256 gatewayFeeRecipientBalance = token.balanceOf(gatewayFeeRecipient);
-    uint256 conmunityFundBalance = token.balanceOf(conmunityFund);
+    uint256 communityFundBalance = token.balanceOf(communityFund);
     vm.prank(address(0));
     token.creditGasFees(
       holder1,
@@ -311,7 +311,7 @@ contract StableTokenV2Test is BaseTest {
     assertEq(token.balanceOf(holder1), holder1InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), feeRecipientBalance);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFeeRecipientBalance + gatewayFee);
-    assertEq(token.balanceOf(conmunityFund), conmunityFundBalance);
+    assertEq(token.balanceOf(communityFund), communityFundBalance);
 
   }
 

--- a/test/tokens/StableTokenV2.t.sol
+++ b/test/tokens/StableTokenV2.t.sol
@@ -224,16 +224,7 @@ contract StableTokenV2Test is BaseTest {
     uint256 holder0InitialBalance = token.balanceOf(holder0);
 
     vm.prank(address(0));
-    token.creditGasFees(
-      holder0,
-      feeRecipient,
-      address(0),
-      communityFund,
-      refund,
-      tipTxFee,
-      gatewayFee,
-      baseTxFee
-    );
+    token.creditGasFees(holder0, feeRecipient, address(0), communityFund, refund, tipTxFee, gatewayFee, baseTxFee);
 
     assertEq(token.balanceOf(holder0), holder0InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
@@ -275,16 +266,7 @@ contract StableTokenV2Test is BaseTest {
 
     vm.prank(address(0));
     // gateWayFeeRecipient and communityFund both 0x
-    token.creditGasFees(
-      holder0,
-      feeRecipient,
-      address(0),
-      address(0),
-      refund,
-      tipTxFee,
-      gatewayFee,
-      baseTxFee
-    );
+    token.creditGasFees(holder0, feeRecipient, address(0), address(0), refund, tipTxFee, gatewayFee, baseTxFee);
 
     assertEq(token.balanceOf(holder0), holder0InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), tipTxFee);
@@ -297,22 +279,12 @@ contract StableTokenV2Test is BaseTest {
     uint256 gatewayFeeRecipientBalance = token.balanceOf(gatewayFeeRecipient);
     uint256 communityFundBalance = token.balanceOf(communityFund);
     vm.prank(address(0));
-    token.creditGasFees(
-      holder1,
-      address(0),
-      gatewayFeeRecipient,
-      address(0),
-      refund,
-      tipTxFee,
-      gatewayFee,
-      baseTxFee
-    );
+    token.creditGasFees(holder1, address(0), gatewayFeeRecipient, address(0), refund, tipTxFee, gatewayFee, baseTxFee);
 
     assertEq(token.balanceOf(holder1), holder1InitialBalance + refund);
     assertEq(token.balanceOf(feeRecipient), feeRecipientBalance);
     assertEq(token.balanceOf(gatewayFeeRecipient), gatewayFeeRecipientBalance + gatewayFee);
     assertEq(token.balanceOf(communityFund), communityFundBalance);
-
   }
 
   function buildTypedDataHash(


### PR DESCRIPTION
### Description

While testing MU04 on Baklava we noticed that gas payment with stables was broken and after some digging we realized that this is due to a slight change in the implementation details of the `creditGasFees` function after switching to the StableTokenV2 implementation. 

TL;DR is that there were checks for the null address in the v1 implementation that were removed in v2, which makes the tx fail when the node attempts to include it in a block due to the `gatewayFeeRecipient` address being `0x` and the underlying call to `_transfer(from, 0x, amount)` failing. 

This change adds a null address check for each recipient addresses and it also keeps track of any amount that can't be transferred to recipients so that it's burned at the end of the function for proper accounting purposes.

### Other changes

Fixed a slight typo of `conmunityFund` which was repeated throughout the code.

### Tested

- Wrote unit tests passing null addresses for each recipient
- Existing tests pass as expected

### Backwards compatibility

This is actually backwards compatible with the original V1 implementation that has proper null checks before the balances of the different accounts are manipulated https://github.com/mento-protocol/mento-core/blob/develop/contracts/legacy/StableToken.sol#L581-L587
