### PR TITLE
Feat: Shift locking week

### DIFF
--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -230,10 +230,10 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
 
   /**
    * @notice method returns the amount of blocks to shift locking epoch to.
-   * we move it to 00-00 UTC Friday by shifting 3564 blocks (approx) (CELO)
+   * we move it to 00-00 UTC Wednesday (approx) by shifting 89964 blocks (CELO)
    */
   function getEpochShift() internal view virtual returns (uint32) {
-    return 3564;
+    return 89964;
   }
 
   function verifyLockOwner(uint256 id) internal view returns (address account) {

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -240,20 +240,27 @@ contract Lock_Locking_Test is Locking_Test {
 
   function test_getWeek_shouldReturnCorrectWeekNo() public {
     uint32 dayInBlocks = weekInBlocks / 7;
+
     uint32 currentBlock = 21664044; // (Sep-29-2023 11:59:59 AM +UTC) Friday
-
     lockingContract.setBlock(currentBlock);
-    lockingContract.setEpochShift(3564);
 
+    // without shifting, it is week #179 with 12_204 blocks reminder
     assertEq(lockingContract.getWeek(), 179);
-    assertEq(lockingContract.blockTillNextPeriod(), 112320); // 6.5 days in blocks CELO
 
-    _incrementBlock(5 * dayInBlocks);
-    assertEq(lockingContract.getWeek(), 179);
+    lockingContract.setEpochShift(89_964);
+
+    // since we shift more than reminder(89_964 > 12_204), we are now in the previos week, #178
+    assertEq(lockingContract.getWeek(), 178);
+
+    // FRI 12:00 -> WED 00:00 = 4.5 days
+    assertEq(lockingContract.blockTillNextPeriod(), (9 * dayInBlocks) / 2);
+
+    _incrementBlock(3 * dayInBlocks);
+    assertEq(lockingContract.getWeek(), 178);
+    _incrementBlock(dayInBlocks);
+    assertEq(lockingContract.getWeek(), 178);
     _incrementBlock(dayInBlocks);
     assertEq(lockingContract.getWeek(), 179);
-    _incrementBlock(dayInBlocks);
-    assertEq(lockingContract.getWeek(), 180);
   }
 
   function test_getAvailableForWithdraw_shouldReturnCorrectAmount() public {

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -249,7 +249,7 @@ contract Lock_Locking_Test is Locking_Test {
 
     lockingContract.setEpochShift(89_964);
 
-    // since we shift more than reminder(89_964 > 12_204), we are now in the previos week, #178
+    // since we shift more than remainder(89_964 > 12_204), we are now in the previous week, #178
     assertEq(lockingContract.getWeek(), 178);
 
     // FRI 12:00 -> WED 00:00 = 4.5 days


### PR DESCRIPTION
### Description

Currently the starting point of the week is Friday 00:00 UTC. It is decided that it will be better to start the week at 00:00 Wednesday, in the middle of the week.

The PR updates the epoch shift to move the start of the week.

### Other changes

No

### Tested

Updated the current unit test

### Related issues

- Fixes #287 
