### PR TITLE
fix: function type minDeposit

### DIFF
--- a/contracts/common/ICeloGovernance.sol
+++ b/contracts/common/ICeloGovernance.sol
@@ -8,7 +8,7 @@ interface ICeloGovernance {
     bytes data;
   }
 
-  function minDeposit() external returns (uint256);
+  function minDeposit() external view returns (uint256);
 
   function propose(
     uint256[] calldata values,


### PR DESCRIPTION
### Description

function type is wrong for the interface and causes to send a tx instead of a view call

### Other changes

none

