### PR TITLE
feat: store airgrabEnds in factory

### DIFF
--- a/contracts/common/ICeloGovernance.sol
+++ b/contracts/common/ICeloGovernance.sol
@@ -10,6 +10,10 @@ interface ICeloGovernance {
 
   function minDeposit() external view returns (uint256);
 
+  function dequeued(uint256 index) external view returns (uint256);
+
+  function execute(uint256 proposalId, uint256 index) external;
+
   function propose(
     uint256[] calldata values,
     address[] calldata destinations,

--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -64,6 +64,7 @@ contract GovernanceFactory is Ownable {
   uint32 public constant AIRGRAB_LOCK_CLIFF = 0; // Cliff duration for the airgrabbed tokens in weeks
   uint256 public constant AIRGRAB_DURATION = 365 days;
   uint256 public constant FRACTAL_MAX_AGE = 180 days; // Maximum age of the kyc for the airgrab
+  uint256 public airgrabEnds;
 
   // Governance Timelock configuration
   uint256 public constant GOVERNANCE_TIMELOCK_DELAY = 2 days;
@@ -148,7 +149,7 @@ contract GovernanceFactory is Ownable {
     // ========================================
     // ========== Deploy 4: Airgrab ===========
     // ========================================
-    uint256 airgrabEnds = block.timestamp + AIRGRAB_DURATION;
+    airgrabEnds = block.timestamp + AIRGRAB_DURATION;
     airgrab = AirgrabDeployerLib.deploy( // NONCE:4
       airgrabRoot,
       fractalSigner,


### PR DESCRIPTION
### Description

Small changes required for governance deployment:

1- Adding `execute` and `dequeued` to Celo Governance interface because we need to execute the proposal manually with a custom gas limit. 
2- Storing `airgrabEnds` value in the factory contract because that value is required to verify airgrab contract.

### Other changes

No

### Tested

Previous tests still pass
