### PR TITLE
Feat/vesting work

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "lib/safe-contracts"]
 	path = lib/safe-contracts
 	url = https://github.com/safe-global/safe-contracts
-[submodule "lib/Locked_VestingTokenPlans"]
-	path = lib/Locked_VestingTokenPlans
-	url = https://github.com/hedgey-finance/Locked_VestingTokenPlans

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/safe-contracts"]
 	path = lib/safe-contracts
 	url = https://github.com/safe-global/safe-contracts
+[submodule "lib/Locked_VestingTokenPlans"]
+	path = lib/Locked_VestingTokenPlans
+	url = https://github.com/hedgey-finance/Locked_VestingTokenPlans

--- a/contracts/governance/locking/interfaces/ILocking.sol
+++ b/contracts/governance/locking/interfaces/ILocking.sol
@@ -2,6 +2,15 @@
 pragma solidity 0.8.18;
 
 interface ILocking {
+  /**
+   * @notice locks tokens in veMentoLocking contract.
+   * @param account address of the owner of lock
+   * @param delegate new delegate address
+   * @param amount amount to lock
+   * @param slope slope period in weeks
+   * @param cliff cliff period in weeks
+   * @return lockId lock id
+   */
   function lock(
     address account,
     address delegate,
@@ -12,6 +21,15 @@ interface ILocking {
 }
 
 interface ILockingExtended {
+  /**
+   * @notice locks tokens in veMentoLocking contract.
+   * @param account address of the owner of lock
+   * @param delegate new delegate address
+   * @param amount amount to lock
+   * @param slope slope period in weeks
+   * @param cliff cliff period in weeks
+   * @return lockId lock id
+   */
   function lock(
     address account,
     address delegate,
@@ -20,19 +38,44 @@ interface ILockingExtended {
     uint32 cliff
   ) external returns (uint256);
 
+  /**
+   * @notice returns current week number.
+   * @return current week number
+   */
   function getWeek() external view returns (uint256);
 
+  /**
+   * @notice returns remaining locked amount.
+   * @return remaining locked amount of tokens
+   */
   function locked(address account) external view returns (uint96);
 
+  /**
+   * @notice relocks tokens in veMentoLocking contract.
+   * @param lockId lockId
+   * @param newDelegate new delegate address
+   * @param newAmount amount to lock
+   * @param newSlope slope period in weeks
+   * @param newCliff cliff period in weeks
+   * @return lockId lock id
+   */
   function relock(
-    uint256 id,
+    uint256 lockId,
     address newDelegate,
     uint96 newAmount,
     uint32 newSlope,
     uint32 newCliff
   ) external returns (uint256);
 
+  /**
+   * @notice withdraws redeemable tokens from veMentoLocking contract.
+   */
   function withdraw() external;
 
+  /**
+   * @notice returns the amount of tokens redeemable from veMentoLocking contract.
+   * @param account address of the owner of lock
+   * @return amount of tokens redeemable
+   */
   function getAvailableForWithdraw(address account) external returns (uint96);
 }

--- a/contracts/governance/locking/interfaces/ILocking.sol
+++ b/contracts/governance/locking/interfaces/ILocking.sol
@@ -10,3 +10,29 @@ interface ILocking {
     uint32 cliff
   ) external returns (uint256);
 }
+
+interface ILockingExtended {
+  function lock(
+    address account,
+    address delegate,
+    uint96 amount,
+    uint32 slope,
+    uint32 cliff
+  ) external returns (uint256);
+
+  function getWeek() external view returns (uint256);
+
+  function locked(address account) external view returns (uint96);
+
+  function relock(
+    uint256 id,
+    address newDelegate,
+    uint96 newAmount,
+    uint32 newSlope,
+    uint32 newCliff
+  ) external returns (uint256);
+
+  function withdraw() external;
+
+  function getAvailableForWithdraw(address account) external returns (uint96);
+}

--- a/contracts/vesting/VestingLock.sol
+++ b/contracts/vesting/VestingLock.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import { ITokenVestingPlans } from "./interfaces/ITokenVestingPlans.sol";
+import { ILockingExtended } from "../governance/locking/interfaces/ILocking.sol";
+import { IERC20 } from "openzeppelin-contracts-next/contracts/token/ERC20/IERC20.sol";
+
+contract VestingLock {
+  address public immutable beneficiary;
+
+  address public immutable hedgeyVestingContract;
+  address public immutable veMentoLockingContract;
+
+  uint32 public immutable lockingSlopeEndWeek;
+  uint32 public immutable lockingCliffEndWeek;
+
+  address public mentoToken;
+
+  uint256 public planId;
+  uint256 public veMentoLockId;
+
+  uint256 public totalAmountToLock;
+  uint256 public totalUnlockedTokens;
+
+  constructor(
+    address _beneficiary,
+    address _hedgeyVestingContract,
+    address _veMentoLockingContract,
+    uint32 _lockingCliffEndWeek,
+    uint32 _lockingSlopeEndWeek
+  ) {
+    require(_beneficiary != address(0), "VestingLock: beneficiary is zero address");
+    require(_hedgeyVestingContract != address(0), "VestingLock: hedgeyVestingContract is zero address");
+    require(_veMentoLockingContract != address(0), "VestingLock: veMentoLockingContract is zero address");
+    require(_lockingCliffEndWeek > 0, "VestingLock: lockingCliffEndWeek is zero");
+    require(_lockingSlopeEndWeek > 0, "VestingLock: lockingSlopeEndWeek is zero");
+    require(
+      _lockingSlopeEndWeek > _lockingCliffEndWeek,
+      "VestingLock: lockingSlopeEndWeek is smaller than lockingCliffEndWeek"
+    );
+
+    beneficiary = _beneficiary;
+    hedgeyVestingContract = _hedgeyVestingContract;
+    veMentoLockingContract = _veMentoLockingContract;
+    lockingCliffEndWeek = _lockingCliffEndWeek;
+    lockingSlopeEndWeek = _lockingSlopeEndWeek;
+  }
+
+  /**
+   * @notice Sets the plan id for the vesting lock and configures variables based on the plan struct.
+   */
+  function setPlanId() public {
+    require(planId == 0, "VestingLock: plan id already set");
+    require(
+      ITokenVestingPlans(hedgeyVestingContract).balanceOf(address(this)) == 1,
+      "VestingLock: None or too many plans configured"
+    );
+    planId = ITokenVestingPlans(hedgeyVestingContract).tokenOfOwnerByIndex(address(this), 0);
+    ITokenVestingPlans.Plan memory plan = ITokenVestingPlans(hedgeyVestingContract).plans(planId);
+
+    mentoToken = plan.token;
+    totalAmountToLock = plan.amount / 2;
+
+    IERC20(mentoToken).approve(veMentoLockingContract, plan.amount);
+  }
+
+  /**
+   * @notice Redeems the vested tokens, locks tokens from Year 1&2 in veMentoLocking contract,
+   *         and transfers avilable tokens to the beneficiary.
+   */
+  function redeem() public {
+    require(planId != 0, "VestingLock: no plan id set");
+    require(msg.sender == beneficiary, "VestingLock: only beneficiary can redeem");
+
+    uint256[] memory planIds = new uint256[](1);
+    planIds[0] = planId;
+
+    ITokenVestingPlans(hedgeyVestingContract).redeemPlans(planIds);
+    uint256 mentoTokenBalance = IERC20(mentoToken).balanceOf(address(this));
+
+    uint256 amountToLock = calculateAmountToLock(mentoTokenBalance);
+    totalUnlockedTokens += mentoTokenBalance;
+
+    if (amountToLock > 0) {
+      lockTokens(amountToLock);
+    }
+
+    ILockingExtended(veMentoLockingContract).withdraw();
+    uint256 amountToTransfer = IERC20(mentoToken).balanceOf(address(this));
+    if (amountToTransfer > 0) {
+      require(IERC20(mentoToken).transfer(beneficiary, amountToTransfer), "VestingLock: transfer failed");
+    }
+  }
+
+  /**
+   * @notice returns the amount of tokens not yet vested.
+   */
+  function getLockedHedgeyBalance() public view returns (uint256) {
+    require(planId != 0, "VestingLock: no plan id set");
+    return ((totalAmountToLock * 2) - totalUnlockedTokens);
+  }
+
+  /**
+   * @notice returns the amount of tokens redeemable from hedgey contract.
+   */
+  function getRedeemableHedgeyBalance() public view returns (uint256) {
+    require(planId != 0, "VestingLock: no plan id set");
+
+    (uint256 balance, , ) = ITokenVestingPlans(hedgeyVestingContract).planBalanceOf(
+      planId,
+      block.timestamp,
+      block.timestamp
+    );
+    return (balance);
+  }
+
+  /**
+   * @notice returns the amount of tokens locked in veMentoLocking contract.
+   */
+  function getLockedVeMentoBalance() public view returns (uint256) {
+    return (ILockingExtended(veMentoLockingContract).locked(address(this)));
+  }
+
+  /**
+   * @notice returns the amount of tokens redeemable from veMentoLocking contract.
+   */
+  function getRedeemableVeMentoBalance() public returns (uint256) {
+    return (uint256(ILockingExtended(veMentoLockingContract).getAvailableForWithdraw(address(this))));
+  }
+
+  /**
+   * @notice locks/relocks tokens in veMentoLocking contract.
+   * @param amountToLock the amount of tokens to lock.
+   */
+  function lockTokens(uint256 amountToLock) internal {
+    (uint256 cliff, uint256 slope) = calculateSlopeAndCliff();
+    if (veMentoLockId != 0) {
+      uint256 currentAmount = getLockedVeMentoBalance();
+
+      veMentoLockId = ILockingExtended(veMentoLockingContract).relock(
+        veMentoLockId,
+        beneficiary,
+        uint96(amountToLock) + uint96(currentAmount),
+        uint32(slope),
+        uint32(cliff)
+      );
+    } else {
+      veMentoLockId = ILockingExtended(veMentoLockingContract).lock(
+        address(this),
+        beneficiary,
+        uint96(amountToLock),
+        uint32(slope),
+        uint32(cliff)
+      );
+    }
+  }
+
+  /**
+   * @notice Calculates the amount of tokens to lock in veMentoLocking contract.
+   * @param vestedAmount the amount of tokens vested from hedgey.
+   * @return amountToLock the amount of tokens to lock.
+   */
+  function calculateAmountToLock(uint256 vestedAmount) internal view returns (uint256 amountToLock) {
+    require(vestedAmount > 0, "VestingLock: no vested tokens");
+    uint256 _totalAmountToLock = totalAmountToLock;
+    uint256 currentWeek = ILockingExtended(veMentoLockingContract).getWeek();
+
+    if (totalUnlockedTokens <= _totalAmountToLock && currentWeek < lockingSlopeEndWeek) {
+      amountToLock = _totalAmountToLock - totalUnlockedTokens;
+      amountToLock = min(amountToLock, vestedAmount);
+
+      return (amountToLock);
+    } else {
+      return (0);
+    }
+  }
+
+  /**
+   * @notice Calculates the slope and cliff for lock.
+   * @return cliff in weeks for lock.
+   * @return slope in weeks for lock.
+   */
+  function calculateSlopeAndCliff() internal view returns (uint256 cliff, uint256 slope) {
+    uint256 currentWeek = ILockingExtended(veMentoLockingContract).getWeek();
+    if (currentWeek < lockingCliffEndWeek) {
+      cliff = lockingCliffEndWeek - currentWeek;
+    } else {
+      cliff = 0;
+    }
+
+    if (currentWeek < lockingSlopeEndWeek) {
+      slope = min(lockingSlopeEndWeek - currentWeek, lockingSlopeEndWeek - lockingCliffEndWeek);
+    } else {
+      slope = 0;
+    }
+    return (cliff, slope);
+  }
+
+  /**
+   * @dev Returns the smallest of two numbers.
+   */
+  function min(uint256 a, uint256 b) internal pure returns (uint256) {
+    return a < b ? a : b;
+  }
+}

--- a/contracts/vesting/VestingLock.sol
+++ b/contracts/vesting/VestingLock.sol
@@ -36,7 +36,7 @@ contract VestingLock {
     require(_lockingSlopeEndWeek > 0, "VestingLock: lockingSlopeEndWeek is zero");
     require(
       _lockingSlopeEndWeek > _lockingCliffEndWeek,
-      "VestingLock: lockingSlopeEndWeek is smaller than lockingCliffEndWeek"
+      "VestingLock: lockingSlopeEndWeek is smaller lockingCliffEndWeek"
     );
     beneficiary = _beneficiary;
     hedgeyVestingContract = _hedgeyVestingContract;

--- a/contracts/vesting/VestingLock.sol
+++ b/contracts/vesting/VestingLock.sol
@@ -48,7 +48,7 @@ contract VestingLock {
   /**
    * @notice Sets the plan id for the vesting lock and configures variables based on the plan struct.
    */
-  function setPlanId() public {
+  function initializeVestingPlan() public {
     require(planId == 0, "VestingLock: plan id already set");
     require(
       ITokenVestingPlans(hedgeyVestingContract).balanceOf(address(this)) == 1,

--- a/contracts/vesting/VestingLock.sol
+++ b/contracts/vesting/VestingLock.sol
@@ -94,7 +94,7 @@ contract VestingLock {
   /**
    * @notice returns the amount of tokens not yet vested.
    */
-  function getLockedHedgeyBalance() public view returns (uint256) {
+  function getLockedHedgeyBalance() external view returns (uint256) {
     require(planId != 0, "VestingLock: no plan id set");
     return ((totalAmountToLock * 2) - totalUnlockedTokens);
   }
@@ -102,7 +102,7 @@ contract VestingLock {
   /**
    * @notice returns the amount of tokens redeemable from hedgey contract.
    */
-  function getRedeemableHedgeyBalance() public view returns (uint256) {
+  function getRedeemableHedgeyBalance() external view returns (uint256) {
     require(planId != 0, "VestingLock: no plan id set");
 
     (uint256 balance, , ) = ITokenVestingPlans(hedgeyVestingContract).planBalanceOf(
@@ -123,7 +123,7 @@ contract VestingLock {
   /**
    * @notice returns the amount of tokens redeemable from veMentoLocking contract.
    */
-  function getRedeemableVeMentoBalance() public returns (uint256) {
+  function getRedeemableVeMentoBalance() external returns (uint256) {
     return (uint256(ILockingExtended(veMentoLockingContract).getAvailableForWithdraw(address(this))));
   }
 

--- a/contracts/vesting/VestingLock.sol
+++ b/contracts/vesting/VestingLock.sol
@@ -38,7 +38,6 @@ contract VestingLock {
       _lockingSlopeEndWeek > _lockingCliffEndWeek,
       "VestingLock: lockingSlopeEndWeek is smaller than lockingCliffEndWeek"
     );
-
     beneficiary = _beneficiary;
     hedgeyVestingContract = _hedgeyVestingContract;
     veMentoLockingContract = _veMentoLockingContract;
@@ -61,7 +60,7 @@ contract VestingLock {
     mentoToken = plan.token;
     totalAmountToLock = plan.amount / 2;
 
-    IERC20(mentoToken).approve(veMentoLockingContract, plan.amount);
+    IERC20(mentoToken).approve(veMentoLockingContract, totalAmountToLock);
   }
 
   /**

--- a/contracts/vesting/interfaces/ITokenVestingPlans.sol
+++ b/contracts/vesting/interfaces/ITokenVestingPlans.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+interface ITokenVestingPlans {
+  /**
+   * @notice The Plan is the storage in a struct of the tokens that are currently being vested
+   * @param token is the token address being timelocked
+   * @param amount is the current amount of tokens locked in the vesting plan,
+   *  both unclaimed vested and unvested tokens. This parameter is updated each time tokens are redeemed,
+   *  reset to the new remaining unvested and unclaimed amount
+   * @param start is the start date when token vesting begins or began.
+   *  This parameter gets updated each time tokens are redeemed and claimed, reset to the most recent redeem time.
+   * @param cliff is an optional field to add a single cliff date prior to which the tokens cannot be redeemed,
+   *  this does not change
+   * @param rate is the amount of tokens that vest in a period. This parameter is constand for each plan.
+   * @param period is the length of time in between each discrete time when tokens vest.
+   *  If this is set to 1, then tokens unlocke every second.
+   *  Otherwise the period is longer to allow for interval vesting plans.
+   * @param vestingAdmin is the adress of the administrator of the plans who can revoke plans at any time prior to
+   *  them fully vesting. They may also be allowed to transfer plans on behalf of the beneficiary.
+   * @param adminTransferOBO is a toggle that when true allows a vesting admin to transfer plans on behalf of (OBO)
+   */
+  struct Plan {
+    address token;
+    uint256 amount;
+    uint256 start;
+    uint256 cliff;
+    uint256 rate;
+    uint256 period;
+    address vestingAdmin;
+    bool adminTransferOBO;
+  }
+
+  /**
+   * @notice gets the plan struct for a given planId
+   * @param planId is the id of the plan to get
+   * @return Plan is the struct of the plan
+   */
+  function plans(uint256 planId) external view returns (Plan memory);
+
+  /**
+   * @notice returns the amount of plans owned by `owner`.
+   * @param owner is the address to query
+   * @return balance is the number of plans owned by `owner`, possibly zero
+   */
+  function balanceOf(address owner) external view returns (uint256 balance);
+
+  /**
+   * @notice returns the `tokenId` plan ID owned by `owner`.
+   * @param owner is the address to query
+   * @param index is the index of the plan owned by `owner` to query
+   */
+  function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256 tokenId);
+
+  /**
+   * @notice redeems vested tokens from a group of plans
+   * @param planIds is the array of planIds to redeem from
+   */
+  function redeemPlans(uint256[] calldata planIds) external;
+
+  /**
+   * @notice gets the balance of a plan
+   * @param planId is the NFT token ID and plan Id
+   * @param timeStamp is the effective current time stamp,
+   *  can be polled for the future for estimating redeemable tokens
+   * @param redemptionTime is the time of the request that the user is attemptint to redeem tokens,
+   *  which can be prior to the timeStamp, though not beyond it.
+   * @return balance is the amount of tokens that are currently redeemable
+   * @return remainder is the amount of tokens that are not yet redeemable
+   * @return latestUnlock is the most recent time that tokens were unlocked
+   */
+  function planBalanceOf(
+    uint256 planId,
+    uint256 timeStamp,
+    uint256 redemptionTime
+  )
+    external
+    view
+    returns (
+      uint256 balance,
+      uint256 remainder,
+      uint256 latestUnlock
+    );
+}

--- a/test/mocks/MockLocking.sol
+++ b/test/mocks/MockLocking.sol
@@ -39,10 +39,6 @@ contract MockLockingExtended is ILockingExtended {
     return lockedAmount;
   }
 
-  function setRelockAmount(uint256 _relockAmount) external {
-    relockAmount = _relockAmount;
-  }
-
   function relock(
     uint256,
     address,

--- a/test/mocks/MockLocking.sol
+++ b/test/mocks/MockLocking.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.8.0;
 
 import "../../contracts/governance/locking/Locking.sol";
+import { ILockingExtended } from "contracts/governance/locking/interfaces/ILocking.sol";
+import { MockMentoToken } from "./MockMentoToken.sol";
 
 contract MockLocking {
   function initiateData(
@@ -9,4 +11,72 @@ contract MockLocking {
     address locker,
     address delegate
   ) external {}
+}
+
+contract MockLockingExtended is ILockingExtended {
+  uint256 public week;
+  uint256 public lockId;
+  address public withdrawToken;
+
+  uint96 public lockedAmount;
+  uint256 public withdrawAmount;
+  uint256 public relockAmount;
+  uint256 public rebalanceAmount;
+
+  function setWeek(uint256 _week) external {
+    week = _week;
+  }
+
+  function getWeek() public view returns (uint256) {
+    return week;
+  }
+
+  function setLockedAmount(uint96 _lockedAmount) external {
+    lockedAmount = _lockedAmount;
+  }
+
+  function locked(address) external view override returns (uint96) {
+    return lockedAmount;
+  }
+
+  function setRelockAmount(uint256 _relockAmount) external {
+    relockAmount = _relockAmount;
+  }
+
+  function relock(
+    uint256,
+    address,
+    uint96 newAmount,
+    uint32,
+    uint32
+  ) external returns (uint256) {
+    MockMentoToken(withdrawToken).transferFrom(msg.sender, address(this), newAmount - lockedAmount);
+    lockedAmount = newAmount;
+    return lockId + 1;
+  }
+
+  function lock(
+    address,
+    address,
+    uint96 amount,
+    uint32,
+    uint32
+  ) external returns (uint256) {
+    MockMentoToken(withdrawToken).transferFrom(msg.sender, address(this), amount);
+    lockedAmount = amount;
+    return lockId + 1;
+  }
+
+  function setWithdraw(uint256 amount, address token) external {
+    withdrawAmount = amount;
+    withdrawToken = token;
+  }
+
+  function getAvailableForWithdraw(address) external view returns (uint96) {
+    return uint96(withdrawAmount);
+  }
+
+  function withdraw() external {
+    MockMentoToken(withdrawToken).mint(msg.sender, withdrawAmount);
+  }
 }

--- a/test/mocks/MockTokenVestingPlans.sol
+++ b/test/mocks/MockTokenVestingPlans.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.18;
+
+import { ITokenVestingPlans } from "contracts/vesting/interfaces/ITokenVestingPlans.sol";
+import { MockMentoToken } from "./MockMentoToken.sol";
+import { console } from "forge-std-next/Test.sol";
+
+contract MockTokenVestingPlans is ITokenVestingPlans {
+  uint256 public balance;
+  uint256 public redeemableTokens;
+  uint256 public _planBalanceOf;
+  address public token;
+
+  ITokenVestingPlans.Plan public plan;
+
+  function setBalanceOf(uint256 _balance) external {
+    balance = _balance;
+  }
+
+  function balanceOf(address) external view returns (uint256) {
+    return balance;
+  }
+
+  function tokenOfOwnerByIndex(address, uint256) external pure returns (uint256) {
+    return 1;
+  }
+
+  function setPlans(ITokenVestingPlans.Plan memory _plan) external {
+    plan = _plan;
+    token = _plan.token;
+  }
+
+  function plans(uint256) external view returns (ITokenVestingPlans.Plan memory) {
+    return plan;
+  }
+
+  function setRedeemableTokens(uint256 _redeemableTokens) external {
+    redeemableTokens = _redeemableTokens;
+  }
+
+  function redeemPlans(uint256[] calldata) public {
+    MockMentoToken(token).mint(msg.sender, redeemableTokens);
+  }
+
+  function setPlanBalanceOf(uint256 _balance) external {
+    _planBalanceOf = _balance;
+  }
+
+  function planBalanceOf(
+    uint256,
+    uint256,
+    uint256
+  )
+    public
+    view
+    returns (
+      uint256,
+      uint256,
+      uint256
+    )
+  {
+    return (_planBalanceOf, 0, 0);
+  }
+}

--- a/test/vesting/VestingLock.t.sol
+++ b/test/vesting/VestingLock.t.sol
@@ -35,14 +35,12 @@ contract VestingLockTest is Test {
   /* ---------- Utils ---------- */
 
   function skipWeeks(uint256 numberOfWeeks) public {
-    mockLocking.setWeek(numberOfWeeks);
-
     uint256 withdrawable = ((basicPlan.amount * numberOfWeeks) / slopeEndWeek) - vestingLock.totalUnlockedTokens();
 
-    mockTokenVestingPlans.setRedeemableTokens(withdrawable);
     mockLocking.setWeek(numberOfWeeks);
-
+    mockTokenVestingPlans.setRedeemableTokens(withdrawable);
     mockLocking.setWithdraw(0, mentoTokenAddr);
+
     if (vestingLock.planId() == 0) {
       vestingLock.initializeVestingPlan();
     }

--- a/test/vesting/VestingLock.t.sol
+++ b/test/vesting/VestingLock.t.sol
@@ -1,0 +1,516 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+// solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
+pragma solidity 0.8.18;
+
+import { Test } from "forge-std-next/Test.sol";
+import { console } from "forge-std-next/console.sol";
+import { Vm } from "forge-std-next/Vm.sol";
+import { Arrays } from "test/utils/Arrays.sol";
+import { VestingLock } from "contracts/vesting/VestingLock.sol";
+import { ITokenVestingPlans } from "contracts/vesting/interfaces/ITokenVestingPlans.sol";
+import { MockTokenVestingPlans } from "../mocks/MockTokenVestingPlans.sol";
+import { MockLockingExtended } from "../mocks/MockLocking.sol";
+import { MockMentoToken } from "../mocks/MockMentoToken.sol";
+
+contract VestingLockTest is Test {
+  uint32 public cliffEndWeek = 104; // ~ 2 years
+  uint32 public slopeEndWeek = 208; // ~ 4 years
+
+  MockTokenVestingPlans public mockTokenVestingPlans = new MockTokenVestingPlans();
+  MockLockingExtended public mockLocking = new MockLockingExtended();
+  MockMentoToken public mentoToken = new MockMentoToken();
+
+  address public beneficiary = actor("beneficary");
+  address public nonBeneficiary = actor("nonBeneficiary");
+  address public hedgeyVestingAddr = address(mockTokenVestingPlans);
+  address public veMentoLockingAddr = address(mockLocking);
+  address public mentoTokenAddr = address(mentoToken);
+
+  ITokenVestingPlans.Plan public basicPlan =
+    ITokenVestingPlans.Plan(mentoTokenAddr, 40_000 * 1e18, 1, 1, 1, 1, actor("admin"), false);
+
+  VestingLock public vestingLock;
+
+  /* ---------- Utils ---------- */
+
+  function actor(string memory name) public returns (address) {
+    uint256 pk = uint256(keccak256(bytes(name)));
+    address addr = vm.addr(pk);
+    vm.label(addr, name);
+    return addr;
+  }
+
+  function skip(uint256 numberOfWeeks, uint256 totalAmount) public {
+    mockLocking.setWeek(numberOfWeeks);
+
+    uint256 withdrawable = ((totalAmount * numberOfWeeks) / slopeEndWeek) - vestingLock.totalUnlockedTokens();
+
+    mockTokenVestingPlans.setRedeemableTokens(withdrawable);
+    mockLocking.setWeek(numberOfWeeks);
+
+    mockLocking.setWithdraw(0, mentoTokenAddr);
+    if (vestingLock.planId() == 0) {
+      vestingLock.setPlanId();
+    }
+  }
+}
+
+/* ---------- Constructor ---------- */
+
+contract VestingLockTest_constructor is VestingLockTest {
+  function test_constructor_whenBeneficiaryIsZero_shouldRevert() public {
+    vm.expectRevert("VestingLock: beneficiary is zero address");
+    vestingLock = new VestingLock(address(0), hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_constructor_whenHedgeyVestingContractIsZero_shouldRevert() public {
+    vm.expectRevert("VestingLock: hedgeyVestingContract is zero address");
+    vestingLock = new VestingLock(beneficiary, address(0), veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_constructor_whenVeMentoLockingContractIsZero_shouldRevert() public {
+    vm.expectRevert("VestingLock: veMentoLockingContract is zero address");
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, address(0), cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_constructor_whenLockingCliffEndWeekIsZero_shouldRevert() public {
+    vm.expectRevert("VestingLock: lockingCliffEndWeek is zero");
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, 0, slopeEndWeek);
+  }
+
+  function test_constructor_whenLockingSlopeEndWeekIsZero_shouldRevert() public {
+    vm.expectRevert("VestingLock: lockingSlopeEndWeek is zero");
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, 0);
+  }
+
+  function test_constructor_whenLockingSlopeEndWeekIsSmallerThanLockingCliffEndWeek_shouldRevert() public {
+    vm.expectRevert("VestingLock: lockingSlopeEndWeek is smaller than lockingCliffEndWeek");
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, 10, 5);
+  }
+
+  function test_constructor_shouldSetStateVariables() public {
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+
+    assertEq(vestingLock.beneficiary(), beneficiary);
+    assertEq(vestingLock.hedgeyVestingContract(), hedgeyVestingAddr);
+    assertEq(vestingLock.veMentoLockingContract(), veMentoLockingAddr);
+    assertEq(vestingLock.lockingCliffEndWeek(), cliffEndWeek);
+    assertEq(vestingLock.lockingSlopeEndWeek(), slopeEndWeek);
+  }
+}
+
+contract VestingLockTest_redeem is VestingLockTest {
+  function setUp() public {
+    mockTokenVestingPlans.setBalanceOf(1);
+    mockTokenVestingPlans.setPlans(basicPlan);
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_redeem_whenNoVestingPlan_shouldRevert() public {
+    vm.expectRevert("VestingLock: no plan id set");
+    vestingLock.redeem();
+  }
+
+  function test_redeem_whenCallerNotBeneficiary_shouldRevert() public {
+    vestingLock.setPlanId();
+    vm.prank(nonBeneficiary);
+    vm.expectRevert("VestingLock: only beneficiary can redeem");
+    vestingLock.redeem();
+  }
+
+  function test_redeem_whenBeforeCliffEndAndFirstRedeem_shouldLockAll() public {
+    uint256 hedgeyRedeemableAmount = 10_000 * 1e18;
+
+    uint256 currentWeek = 52;
+
+    // because currentWeek is pre cliffEndWeek 105
+    uint32 cliff = uint32(cliffEndWeek - currentWeek);
+    // full 2 year slope period since currentWeek is pre slopeStart(cliffEndWeek)
+    uint32 slope = uint32(slopeEndWeek - cliffEndWeek);
+
+    mockTokenVestingPlans.setRedeemableTokens(hedgeyRedeemableAmount);
+    mockLocking.setWeek(currentWeek);
+    mockLocking.setWithdraw(0, mentoTokenAddr);
+
+    vestingLock.setPlanId();
+    uint256 planId = vestingLock.planId();
+    uint256 lockIdBefore = vestingLock.veMentoLockId();
+    assertEq(lockIdBefore, 0);
+
+    vm.prank(beneficiary);
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    vm.expectCall( // ensure lock is called with correct parameters
+      veMentoLockingAddr,
+      abi.encodeWithSelector(
+        MockLockingExtended.lock.selector,
+        address(vestingLock),
+        beneficiary,
+        hedgeyRedeemableAmount,
+        slope,
+        cliff
+      )
+    );
+    // ensure no tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector), 0);
+
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), 0);
+    assertEq(vestingLock.totalUnlockedTokens(), 10_000 * 1e18);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+
+  function test_redeem_whenBeforeCliffEndAndNotFirstRedeem_shouldRelockAll() public {
+    skip(52, basicPlan.amount);
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(vestingLock.totalUnlockedTokens(), basicPlan.amount / 4);
+
+    skip(52 + 26, basicPlan.amount);
+
+    uint256 planId = vestingLock.planId();
+    uint32 slope = uint32(slopeEndWeek - cliffEndWeek);
+    uint32 cliff = uint32(cliffEndWeek - (52 + 26));
+
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    vm.expectCall( // ensure relock is called with correct parameters
+      veMentoLockingAddr,
+      abi.encodeWithSelector(
+        MockLockingExtended.relock.selector,
+        vestingLock.veMentoLockId(),
+        beneficiary,
+        (basicPlan.amount * 3) / 8, // (52+26)/208 ~ 3/8
+        slope,
+        cliff
+      )
+    );
+    // ensure no tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector), 0);
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), 0);
+    assertEq(vestingLock.totalUnlockedTokens(), 15_000 * 1e18);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+
+  function test_redeem_whenAtCliffEndAndFirstRedeem_shouldLockAllWithNoCliff() public {
+    uint256 hedgeyRedeemableAmount = 20_000 * 1e18;
+
+    uint256 currentWeek = 104;
+
+    // 0 cliff because currentWeek is cliffEndWeek
+    uint32 cliff = uint32(cliffEndWeek - currentWeek);
+    // full 2 year slope period since currentWeek is pre slopeStart(cliffEndWeek)
+    uint32 slope = uint32(slopeEndWeek - cliffEndWeek);
+
+    mockTokenVestingPlans.setRedeemableTokens(hedgeyRedeemableAmount);
+    mockLocking.setWeek(currentWeek);
+    mockLocking.setWithdraw(0, mentoTokenAddr);
+
+    vestingLock.setPlanId();
+    uint256 planId = vestingLock.planId();
+    uint256 lockIdBefore = vestingLock.veMentoLockId();
+    assertEq(lockIdBefore, 0);
+
+    vm.prank(beneficiary);
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    vm.expectCall( // ensure lock is called with correct parameters
+      veMentoLockingAddr,
+      abi.encodeWithSelector(
+        MockLockingExtended.lock.selector,
+        address(vestingLock),
+        beneficiary,
+        hedgeyRedeemableAmount,
+        slope,
+        cliff
+      )
+    );
+    // ensure no tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector), 0);
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), 0 * 1e18);
+    assertEq(vestingLock.totalUnlockedTokens(), 20_000 * 1e18);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+
+  function test_redeem_whenAtCliffEndAndNotFirstRedeem_shouldRelockAll() public {
+    skip(52, basicPlan.amount);
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(vestingLock.totalUnlockedTokens(), basicPlan.amount / 4);
+
+    skip(52 + 52, basicPlan.amount);
+
+    uint256 planId = vestingLock.planId();
+
+    // full 2 year slope period since currentWeek is pre slopeStart(cliffEndWeek)
+    uint32 slope = uint32(slopeEndWeek - cliffEndWeek);
+    // 0 cliff because currentWeek is cliffEndWeek
+    uint32 cliff = uint32(cliffEndWeek - (52 + 52));
+
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    vm.expectCall( // ensure relock is called with correct parameters
+      veMentoLockingAddr,
+      abi.encodeWithSelector(
+        MockLockingExtended.relock.selector,
+        vestingLock.veMentoLockId(),
+        beneficiary,
+        (basicPlan.amount) / 2, // (52+52)/208 ~ 1/2
+        slope,
+        cliff
+      )
+    );
+    // ensure no tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector), 0);
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), 0);
+    assertEq(vestingLock.totalUnlockedTokens(), 20_000 * 1e18);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+
+  function test_redeem_whenAfterCliffEndAndFirstRedeem_shouldLockHalfWithSlopeRemainderAndTransferRest() public {
+    uint256 hedgeyRedeemableAmount = 30_000 * 1e18;
+
+    uint256 currentWeek = 156;
+    uint32 cliff = uint32(0); // because currentWeek is greater cliffEndWeek 0
+    uint32 slope = uint32(slopeEndWeek - currentWeek); // 1 year slope period since currentWeek is Year 3
+
+    mockTokenVestingPlans.setRedeemableTokens(hedgeyRedeemableAmount);
+    mockLocking.setWeek(currentWeek);
+    mockLocking.setWithdraw(0, mentoTokenAddr);
+
+    vestingLock.setPlanId();
+    uint256 planId = vestingLock.planId();
+    uint256 lockIdBefore = vestingLock.veMentoLockId();
+    assertEq(lockIdBefore, 0);
+
+    vm.prank(beneficiary);
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    vm.expectCall( // ensure lock is called with correct parameters
+      veMentoLockingAddr,
+      abi.encodeWithSelector(
+        MockLockingExtended.lock.selector,
+        address(vestingLock),
+        beneficiary,
+        20_000 * 1e18, // only tokens from  year 1&2 are locked
+        slope,
+        cliff
+      )
+    );
+    // ensure year 3 vested tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector, beneficiary, 10_000 * 1e18), 1);
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), 10_000 * 1e18);
+    assertEq(vestingLock.totalUnlockedTokens(), 30_000 * 1e18);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+
+  function test_redeem_whenAfterCliffEndAndNotFirstRedeem_shouldRelockReminderAndTransferAvailable() public {
+    skip(78, basicPlan.amount); // last redeem at 1.5 Years
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(vestingLock.totalUnlockedTokens(), (basicPlan.amount * 3) / 8);
+
+    uint256 currentWeek = 156; // Year 3
+    skip(currentWeek, basicPlan.amount);
+
+    uint256 planId = vestingLock.planId();
+    uint32 slope = uint32(slopeEndWeek - currentWeek); // slopePeriod remainder
+    uint32 cliff = uint32(cliffEndWeek - (52 + 52)); // 0 because currentWeek is larger cliffEndWeek
+
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    vm.expectCall( // ensure relock is called with correct parameters
+      veMentoLockingAddr,
+      abi.encodeWithSelector(
+        MockLockingExtended.relock.selector,
+        vestingLock.veMentoLockId(),
+        beneficiary,
+        (basicPlan.amount) / 2, // (52+52)/208 ~ 1/2
+        slope,
+        cliff
+      )
+    );
+    // ensure year 3 vested tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector, beneficiary, 10_000 * 1e18), 1);
+
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), 10_000 * 1e18);
+    assertEq(vestingLock.totalUnlockedTokens(), 30_000 * 1e18);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+
+  function test_redeem_whenAfterSlopeEndAndFirstRedeem_shouldTransferAll() public {
+    skip(208, basicPlan.amount); // redeem at 4 Years
+    uint256 planId = vestingLock.planId();
+
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    // ensure no tokens are locked
+    vm.expectCall(veMentoLockingAddr, abi.encodeWithSelector(mockLocking.lock.selector), 0);
+    // ensure vested tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector, beneficiary, 40_000 * 1e18), 1);
+
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), basicPlan.amount);
+    assertEq(vestingLock.totalUnlockedTokens(), basicPlan.amount);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+
+  function test_redeem_whenAfterSlopeEndAndNotFirstRedeem_shouldRedeemFromLockAndTransferAll() public {
+    skip(104, basicPlan.amount); // first redeem at Year 2
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    skip(208, basicPlan.amount); // second redeem at Year 2
+
+    // set withdrawable amount to 20_000 since 20_000 was locked for 2 years
+    mockLocking.setWithdraw(20_000 * 1e18, mentoTokenAddr);
+
+    uint256 planId = vestingLock.planId();
+
+    vm.expectCall( // ensure redeemPlans is called with correct parameters
+      hedgeyVestingAddr,
+      abi.encodeWithSelector(ITokenVestingPlans.redeemPlans.selector, Arrays.uints(planId))
+    );
+    // ensure no tokens are locked
+    vm.expectCall(veMentoLockingAddr, abi.encodeWithSelector(mockLocking.lock.selector), 0);
+    // ensure contract withdraws from lock
+    vm.expectCall(veMentoLockingAddr, abi.encodeWithSelector(mockLocking.withdraw.selector), 1);
+    // ensure vested tokens are transferred to beneficiary
+    vm.expectCall(mentoTokenAddr, abi.encodeWithSelector(mentoToken.transfer.selector, beneficiary, 40_000 * 1e18), 1);
+
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(mentoToken.balanceOf(beneficiary), basicPlan.amount);
+    assertEq(vestingLock.totalUnlockedTokens(), basicPlan.amount);
+    assertEq(mentoToken.balanceOf(address(vestingLock)), 0);
+  }
+}
+
+contract VestingLockTest_getLockedHedgeyBalance is VestingLockTest {
+  function setUp() public {
+    mockTokenVestingPlans.setBalanceOf(1);
+    mockTokenVestingPlans.setPlans(basicPlan);
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_getLockedHedgeyBalance_whenNoVestingPlan_shouldReturnZero() public {
+    vm.expectRevert("VestingLock: no plan id set");
+    vestingLock.getLockedHedgeyBalance();
+  }
+
+  function test_getLockedHedgeyBalance_whenNoRedeem_shouldReturnTotalAmount() public {
+    vestingLock.setPlanId();
+    assertEq(vestingLock.getLockedHedgeyBalance(), basicPlan.amount);
+  }
+
+  function test_getLockedHedgeyBalance_whenRedeemed_shouldReturnCorrectAmount() public {
+    vestingLock.setPlanId();
+    skip(104, basicPlan.amount);
+
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(vestingLock.getLockedHedgeyBalance(), basicPlan.amount / 2);
+
+    skip(208, basicPlan.amount);
+
+    vm.prank(beneficiary);
+    vestingLock.redeem();
+
+    assertEq(vestingLock.getLockedHedgeyBalance(), 0);
+  }
+}
+
+contract VestingLockTest_getRedeemableHedgeyBalance is VestingLockTest {
+  function setUp() public {
+    mockTokenVestingPlans.setBalanceOf(1);
+    mockTokenVestingPlans.setPlans(basicPlan);
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_getRedeemableHedgeyBalance_whenNoVestingPlan_shouldReturnZero() public {
+    vm.expectRevert("VestingLock: no plan id set");
+    vestingLock.getRedeemableHedgeyBalance();
+  }
+
+  function test_getRedeemableHedgeyBalance_whenPlanConfigured_shouldReturnPlanBalanceOf() public {
+    vestingLock.setPlanId();
+
+    mockTokenVestingPlans.setPlanBalanceOf(10_000 * 1e18);
+    assertEq(vestingLock.getRedeemableHedgeyBalance(), 10_000 * 1e18);
+
+    mockTokenVestingPlans.setPlanBalanceOf(40_000 * 1e18);
+    assertEq(vestingLock.getRedeemableHedgeyBalance(), 40_000 * 1e18);
+  }
+}
+
+contract VestingLockTest_getLockedVeMentoBalance is VestingLockTest {
+  function setUp() public {
+    mockTokenVestingPlans.setBalanceOf(1);
+    mockTokenVestingPlans.setPlans(basicPlan);
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_getLockedVeMentoBalance_whenConfigured_shouldReturnLockingLocked() public {
+    vestingLock.setPlanId();
+
+    mockLocking.setLockedAmount(10_000 * 1e18);
+    assertEq(vestingLock.getLockedVeMentoBalance(), 10_000 * 1e18);
+
+    mockLocking.setLockedAmount(40_000 * 1e18);
+    assertEq(vestingLock.getLockedVeMentoBalance(), 40_000 * 1e18);
+  }
+}
+
+contract VestingLockTest_getRedeemableVeMentoBalance is VestingLockTest {
+  function setUp() public {
+    mockTokenVestingPlans.setBalanceOf(1);
+    mockTokenVestingPlans.setPlans(basicPlan);
+    vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, cliffEndWeek, slopeEndWeek);
+  }
+
+  function test_getRedeemableVeMentoBalance_whenConfigured_shouldReturnLockingAvailableForWithdraw() public {
+    vestingLock.setPlanId();
+
+    mockLocking.setWithdraw(10_000 * 1e18, mentoTokenAddr);
+    assertEq(vestingLock.getRedeemableVeMentoBalance(), 10_000 * 1e18);
+
+    mockLocking.setWithdraw(40_000 * 1e18, mentoTokenAddr);
+    assertEq(vestingLock.getRedeemableVeMentoBalance(), 40_000 * 1e18);
+  }
+}

--- a/test/vesting/VestingLock.t.sol
+++ b/test/vesting/VestingLock.t.sol
@@ -119,8 +119,6 @@ contract VestingLockTest_initializeVestingPlan is VestingLockTest {
   }
 
   function test_initializeVestingPlan_whenPlanConfigured_shouldSetPlanIdAndStateVariables() public {
-    mockTokenVestingPlans.setBalanceOf(1);
-    mockTokenVestingPlans.setPlans(basicPlan);
     vestingLock.initializeVestingPlan();
 
     assertEq(vestingLock.planId(), 1);

--- a/test/vesting/VestingLock.t.sol
+++ b/test/vesting/VestingLock.t.sol
@@ -78,7 +78,7 @@ contract VestingLockTest_constructor is VestingLockTest {
   }
 
   function test_constructor_whenLockingSlopeEndWeekIsSmallerThanLockingCliffEndWeek_shouldRevert() public {
-    vm.expectRevert("VestingLock: lockingSlopeEndWeek is smaller than lockingCliffEndWeek");
+    vm.expectRevert("VestingLock: lockingSlopeEndWeek is smaller lockingCliffEndWeek");
     vestingLock = new VestingLock(beneficiary, hedgeyVestingAddr, veMentoLockingAddr, 10, 5);
   }
 

--- a/test/vesting/VestingLock.t.sol
+++ b/test/vesting/VestingLock.t.sol
@@ -21,25 +21,18 @@ contract VestingLockTest is Test {
   MockLockingExtended public mockLocking = new MockLockingExtended();
   MockMentoToken public mentoToken = new MockMentoToken();
 
-  address public beneficiary = actor("beneficary");
-  address public nonBeneficiary = actor("nonBeneficiary");
+  address public beneficiary = makeAddr("beneficary");
+  address public nonBeneficiary = makeAddr("nonBeneficiary");
   address public hedgeyVestingAddr = address(mockTokenVestingPlans);
   address public veMentoLockingAddr = address(mockLocking);
   address public mentoTokenAddr = address(mentoToken);
 
   ITokenVestingPlans.Plan public basicPlan =
-    ITokenVestingPlans.Plan(mentoTokenAddr, 40_000 * 1e18, 1, 1, 1, 1, actor("admin"), false);
+    ITokenVestingPlans.Plan(mentoTokenAddr, 40_000 * 1e18, 1, 1, 1, 1, makeAddr("admin"), false);
 
   VestingLock public vestingLock;
 
   /* ---------- Utils ---------- */
-
-  function actor(string memory name) public returns (address) {
-    uint256 pk = uint256(keccak256(bytes(name)));
-    address addr = vm.addr(pk);
-    vm.label(addr, name);
-    return addr;
-  }
 
   function skipWeeks(uint256 numberOfWeeks) public {
     mockLocking.setWeek(numberOfWeeks);


### PR DESCRIPTION
### Description

This PR adds the new VestingLock contract between a hedgey vesting plan and a beneficiary. 
The contract will lock/relock all tokens released in Years 1&2 into the veMento contract, redeem all potential withdrawable tokens from a lock and transfer them with redeemable tokens from Year 3&4 to the beneficiary. 

### Other changes

- Extended the ILocking interface
- Added ITokenVestingPlans interface

### Tested

- unit tests for the VEstingLock contract 
- fork test to test/verify the actual interaction between the 3 contracts are designed and will be written in the next step

### Open Questions:
- Not sure whether we want this contract to emit any Events e.g `redeemed(amountLocked, amountWithdrawn, lockID)`
- So far the lock calculation is not 100% perfect e.g if someone does the first redemption after year 3 this contract would lock up the whole 50% of tokens with a slope of 1 year. This is not super bad but we could add a step in the calculation that:  when a redeem with a lock happens after the cliffPeriodEnd, it calculates the amount that would be redeemable from the lock by now and transfers that amount to the beneficiary and only locks the remainder. 
Let me know what you think @bowd @baroooo 
this could look something like this:
`if(amountToLock > 0 && lockingCliffEndWeek < currentWeek):`
`uint256 denominator = lockingSlopeEnd - lockingCliffEnd`
`uint256 numerator = lockingSlopeEnd - currentWeek`
`amountToLock = (amountToLock * numerator) / denominator `


### Related issues

- Fixes #342 

### Backwards compatibility



### Documentation


