### PR TITLE
feat: make Token pausable

### DIFF
--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -139,7 +139,12 @@ contract GovernanceFactory is Ownable {
     allocationRecipients[numberOfRecipients - 2] = airgrabPrecalculated;
     allocationRecipients[numberOfRecipients - 1] = governanceTimelockPrecalculated;
 
-    mentoToken = MentoTokenDeployerLib.deploy(allocationRecipients, allocationAmounts, address(emission)); // NONCE:3
+    mentoToken = MentoTokenDeployerLib.deploy( // NONCE:3
+      allocationRecipients,
+      allocationAmounts,
+      address(emission),
+      lockingPrecalculated
+    );
     assert(address(mentoToken) == tokenPrecalculated);
 
     // ========================================
@@ -232,6 +237,7 @@ contract GovernanceFactory is Ownable {
     emission.transferOwnership(address(governanceTimelock));
     locking.transferOwnership(address(governanceTimelock));
     proxyAdmin.transferOwnership(address(governanceTimelock));
+    mentoToken.transferOwnership(address(governanceTimelock));
 
     emit GovernanceCreated(
       address(proxyAdmin),

--- a/contracts/governance/MentoToken.sol
+++ b/contracts/governance/MentoToken.sol
@@ -51,7 +51,7 @@ contract MentoToken is Ownable, Pausable, ERC20Burnable {
     locking = locking_;
     emission = emission_;
 
-    uint256 supply = 1_000_000_000 * 10 ** decimals();
+    uint256 supply = 1_000_000_000 * 10**decimals();
 
     uint256 totalAllocated;
     for (uint256 i = 0; i < allocationRecipients_.length; i++) {
@@ -100,7 +100,11 @@ contract MentoToken is Ownable, Pausable, ERC20Burnable {
    * @param to The account that should receive the tokens
    * @param amount Amount of tokens that should be transferred
    */
-  function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+  ) internal virtual override {
     super._beforeTokenTransfer(from, to, amount);
 
     require(to != address(this), "MentoToken: cannot transfer tokens to token contract");

--- a/contracts/governance/MentoToken.sol
+++ b/contracts/governance/MentoToken.sol
@@ -15,7 +15,7 @@ contract MentoToken is Ownable, Pausable, ERC20Burnable {
   /// even when the contract is paused.
   address public immutable locking;
 
-  /// @notice The address of the emission contract that has the capability to emit new tokens.
+  /// @notice The address of the emission contract that has the capability to emit new tokens
   /// and transfer even when the contract is paused.
   address public immutable emission;
 

--- a/contracts/governance/MentoToken.sol
+++ b/contracts/governance/MentoToken.sol
@@ -11,8 +11,8 @@ import { Pausable } from "openzeppelin-contracts-next/contracts/security/Pausabl
  * @notice This contract represents the Mento Protocol Token which is a Burnable ERC20 token.
  */
 contract MentoToken is Ownable, Pausable, ERC20Burnable {
-  /// @notice The address of the lockin contract that has the capability to transfer tokens
-  /// even when the contarct is paused.
+  /// @notice The address of the locking contract that has the capability to transfer tokens
+  /// even when the contract is paused.
   address public immutable locking;
 
   /// @notice The address of the emission contract that has the capability to emit new tokens.

--- a/contracts/governance/MentoToken.sol
+++ b/contracts/governance/MentoToken.sol
@@ -11,10 +11,12 @@ import { Pausable } from "openzeppelin-contracts-next/contracts/security/Pausabl
  * @notice This contract represents the Mento Protocol Token which is a Burnable ERC20 token.
  */
 contract MentoToken is Ownable, Pausable, ERC20Burnable {
-  /// @notice The address of the emission contract that has the capability to emit new tokens.
+  /// @notice The address of the lockin contract that has the capability to transfer tokens
+  /// even when the contarct is paused.
   address public immutable locking;
 
   /// @notice The address of the emission contract that has the capability to emit new tokens.
+  /// and transfer even when the contract is paused.
   address public immutable emission;
 
   /// @notice The total amount of tokens that can be minted by the emission contract.
@@ -49,7 +51,7 @@ contract MentoToken is Ownable, Pausable, ERC20Burnable {
     locking = locking_;
     emission = emission_;
 
-    uint256 supply = 1_000_000_000 * 10**decimals();
+    uint256 supply = 1_000_000_000 * 10 ** decimals();
 
     uint256 totalAllocated;
     for (uint256 i = 0; i < allocationRecipients_.length; i++) {
@@ -91,16 +93,14 @@ contract MentoToken is Ownable, Pausable, ERC20Burnable {
     _mint(target, amount);
   }
 
-  /// @dev See {ERC20-_beforeTokenTransfer}
-  /// Requirements: the contract must not be paused OR transfer must be initiated by owner
-  /// @param from The account that is sending the tokens
-  /// @param to The account that should receive the tokens
-  /// @param amount Amount of tokens that should be transferred
-  function _beforeTokenTransfer(
-    address from,
-    address to,
-    uint256 amount
-  ) internal virtual override {
+  /*
+   * @dev See {ERC20-_beforeTokenTransfer}
+   * Requirements: the contract must not be paused OR transfer must be initiated by owner
+   * @param from The account that is sending the tokens
+   * @param to The account that should receive the tokens
+   * @param amount Amount of tokens that should be transferred
+   */
+  function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
     super._beforeTokenTransfer(from, to, amount);
 
     require(to != address(this), "MentoToken: cannot transfer tokens to token contract");

--- a/contracts/governance/MentoToken.sol
+++ b/contracts/governance/MentoToken.sol
@@ -2,13 +2,18 @@
 pragma solidity 0.8.18;
 
 import { ERC20Burnable, ERC20 } from "openzeppelin-contracts-next/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import { Ownable } from "openzeppelin-contracts-next/contracts/access/Ownable.sol";
+import { Pausable } from "openzeppelin-contracts-next/contracts/security/Pausable.sol";
 
 /**
  * @title Mento Token
  * @author Mento Labs
  * @notice This contract represents the Mento Protocol Token which is a Burnable ERC20 token.
  */
-contract MentoToken is ERC20Burnable {
+contract MentoToken is Ownable, Pausable, ERC20Burnable {
+  /// @notice The address of the emission contract that has the capability to emit new tokens.
+  address public immutable locking;
+
   /// @notice The address of the emission contract that has the capability to emit new tokens.
   address public immutable emission;
 
@@ -25,18 +30,24 @@ contract MentoToken is ERC20Burnable {
    * @param allocationRecipients_ The addresses of the initial token recipients.
    * @param allocationAmounts_ The percentage of tokens to be allocated to each recipient.
    * @param emission_ The address of the emission contract where the rest of the supply will be emitted.
+   * @param locking_ The address of the locking contract where the tokens will be locked.
    */
   // solhint-enable max-line-length
   constructor(
     address[] memory allocationRecipients_,
     uint256[] memory allocationAmounts_,
-    address emission_
-  ) ERC20("Mento Token", "MENTO") {
+    address emission_,
+    address locking_
+  ) ERC20("Mento Token", "MENTO") Ownable() {
     require(emission_ != address(0), "MentoToken: emission is zero address");
+    require(locking_ != address(0), "MentoToken: locking is zero address");
     require(
       allocationRecipients_.length == allocationAmounts_.length,
       "MentoToken: recipients and amounts length mismatch"
     );
+
+    locking = locking_;
+    emission = emission_;
 
     uint256 supply = 1_000_000_000 * 10**decimals();
 
@@ -50,9 +61,19 @@ contract MentoToken is ERC20Burnable {
       _mint(allocationRecipients_[i], (supply * allocationAmounts_[i]) / 1000);
     }
     require(totalAllocated <= 1000, "MentoToken: total allocation exceeds 100%");
-
-    emission = emission_;
     emissionSupply = (supply * (1000 - totalAllocated)) / 1000;
+
+    _pause();
+  }
+
+  /**
+   * @notice Unpauses all token transfers.
+   * @dev See {Pausable-_unpause}
+   * Requirements: caller must be the owner
+   */
+  function unpause() public virtual onlyOwner {
+    require(paused(), "MentoToken: token is not paused");
+    _unpause();
   }
 
   /**
@@ -68,5 +89,28 @@ contract MentoToken is ERC20Burnable {
 
     emittedAmount += amount;
     _mint(target, amount);
+  }
+
+  /// @dev See {ERC20-_beforeTokenTransfer}
+  /// Requirements: the contract must not be paused OR transfer must be initiated by owner
+  /// @param from The account that is sending the tokens
+  /// @param to The account that should receive the tokens
+  /// @param amount Amount of tokens that should be transferred
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+  ) internal virtual override {
+    super._beforeTokenTransfer(from, to, amount);
+
+    require(to != address(this), "MentoToken: cannot transfer tokens to token contract");
+    // Token transfers are only possible if the contract is not paused
+    // OR if triggered by the owner of the contract
+    // OR if triggered by the locking contract
+    // OR if triggered by the emission contract
+    require(
+      !paused() || owner() == _msgSender() || locking == _msgSender() || emission == _msgSender(),
+      "MentoToken: token transfer while paused"
+    );
   }
 }

--- a/contracts/governance/deployers/MentoTokenDeployerLib.sol
+++ b/contracts/governance/deployers/MentoTokenDeployerLib.sol
@@ -10,13 +10,15 @@ library MentoTokenDeployerLib {
    * @param allocationRecipients The addresses of the initial token recipients
    * @param allocationAmounts The percentage of tokens to be allocated to each recipient
    * @param emission The address of the emission contract
+   * @param locking The address of the locking contract
    * @return The address of the new MentoToken contract
    */
   function deploy(
     address[] memory allocationRecipients,
     uint256[] memory allocationAmounts,
-    address emission
+    address emission,
+    address locking
   ) external returns (MentoToken) {
-    return new MentoToken(allocationRecipients, allocationAmounts, emission);
+    return new MentoToken(allocationRecipients, allocationAmounts, emission, locking);
   }
 }

--- a/test/governance/MentoToken.t.sol
+++ b/test/governance/MentoToken.t.sol
@@ -256,4 +256,45 @@ contract MentoTokenTest is TestSetup {
     mentoToken.transferFrom(alice, bob, amount);
     assertEq(mentoToken.balanceOf(bob), amount);
   }
+
+  function test_transfer_whenPaused_calledByEmission_shouldWork() public {
+    uint256 amount = 10e18;
+    deal(address(mentoToken), emission, amount);
+    vm.prank(emission);
+    mentoToken.transfer(bob, amount);
+    assertEq(mentoToken.balanceOf(bob), amount);
+  }
+
+  function test_transferFrom_whenPaused_calledByEmission_shouldWork() public {
+    uint256 amount = 10e18;
+    deal(address(mentoToken), alice, amount);
+    vm.prank(alice);
+    mentoToken.approve(emission, amount);
+
+    vm.prank(emission);
+    mentoToken.transferFrom(alice, bob, amount);
+    assertEq(mentoToken.balanceOf(bob), amount);
+  }
+
+  function test_mint_whenPaused_calledByEmission_shouldWork() public {
+    vm.prank(emission);
+    mentoToken.mint(emission, 10e18);
+    assertEq(mentoToken.balanceOf(emission), 10e18);
+  }
+
+  function test_unpause_whenPaused_calledByOwner_shouldUnpause() public {
+    mentoToken.unpause();
+    assertEq(mentoToken.paused(), false);
+  }
+
+  function test_unpause_whenNotPaused_shouldRevert() public notPaused {
+    vm.expectRevert("MentoToken: token is not paused");
+    mentoToken.unpause();
+  }
+
+  function test_unpause_whenNotCalledByOwner_shouldRevert() public {
+    vm.prank(bob);
+    vm.expectRevert("Ownable: caller is not the owner");
+    mentoToken.unpause();
+  }
 }


### PR DESCRIPTION
### Description

Based on recent token-related conversations we've decided we want more flexibility when it comes to the time between when we launch governance and give utility to the token, and the time when the token is transferable, i.e. tradable.
Most recent token launches have followed this approach, most notably Safe.
These changes make the token ownable and pausable. 

However, even when paused the token can still be transferred by:
- The owner
- The locking contract - it can be locked and unlocked, thus the airgrab can run while paused
- The emissions contract - it can be minted into existence while paused

### Other changes

N/A

### Tested

- Tests have been added for the paused scenario
 
### Backwards compatibility

N/A

### Documentation

N/A