### PR TITLE
feat: Improve how the initial allocation is forwarded.

### DIFF
--- a/test/governance/GovernanceFactory.t.sol
+++ b/test/governance/GovernanceFactory.t.sol
@@ -35,16 +35,15 @@ contract GovernanceFactoryTest is TestSetup {
   }
 
   function _createGovernance() internal {
-    address[] memory allocationRecipients = Arrays.addresses(mentoLabsMultiSig);
-    uint256[] memory allocationAmounts = Arrays.uints(200, 50, 100);
-    factory.createGovernance(
-      watchdogMultiSig,
-      celoCommunityFund,
-      airgrabMerkleRoot,
-      fractalSigner,
-      allocationRecipients,
-      allocationAmounts
-    );
+    GovernanceFactory.MentoTokenAllocationParams memory allocationParams = GovernanceFactory
+      .MentoTokenAllocationParams({
+        airgrabAllocation: 50,
+        mentoTreasuryAllocation: 100,
+        additionalAllocationRecipients: Arrays.addresses(mentoLabsMultiSig),
+        additionalAllocationAmounts: Arrays.uints(200)
+      });
+
+    factory.createGovernance(watchdogMultiSig, celoCommunityFund, airgrabMerkleRoot, fractalSigner, allocationParams);
   }
 
   // ========================================
@@ -99,24 +98,23 @@ contract GovernanceFactoryTest is TestSetup {
   }
 
   function test_createGovernance_whenAdditionalAllocationRecipients_shouldCombineRecipients() public i_setUp {
-    address[] memory allocationRecipients = Arrays.addresses(
-      makeAddr("Recipient1"),
-      makeAddr("Recipient2"),
-      mentoLabsMultiSig
-    );
     uint256 supply = 1_000_000_000 * 10**18;
-    uint256[] memory allocationAmounts = Arrays.uints(50, 50, 80, 50, 100);
-    vm.prank(owner);
-    factory.createGovernance(
-      watchdogMultiSig,
-      celoCommunityFund,
-      airgrabMerkleRoot,
-      fractalSigner,
-      allocationRecipients,
-      allocationAmounts
-    );
+    GovernanceFactory.MentoTokenAllocationParams memory allocationParams = GovernanceFactory
+      .MentoTokenAllocationParams({
+        airgrabAllocation: 50,
+        mentoTreasuryAllocation: 100,
+        additionalAllocationRecipients: Arrays.addresses(
+          makeAddr("Recipient1"),
+          makeAddr("Recipient2"),
+          mentoLabsMultiSig
+        ),
+        additionalAllocationAmounts: Arrays.uints(55, 50, 80)
+      });
 
-    assertEq(factory.mentoToken().balanceOf(makeAddr("Recipient1")), (supply * 50) / 1000);
+    vm.prank(owner);
+    factory.createGovernance(watchdogMultiSig, celoCommunityFund, airgrabMerkleRoot, fractalSigner, allocationParams);
+
+    assertEq(factory.mentoToken().balanceOf(makeAddr("Recipient1")), (supply * 55) / 1000);
     assertEq(factory.mentoToken().balanceOf(makeAddr("Recipient2")), (supply * 50) / 1000);
     assertEq(factory.mentoToken().balanceOf(mentoLabsMultiSig), (supply * 80) / 1000);
     assertEq(factory.mentoToken().balanceOf(address(factory.airgrab())), (supply * 50) / 1000);

--- a/test/governance/IntegrationTests/GovernanceIntegration.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.t.sol
@@ -123,21 +123,19 @@ contract GovernanceIntegrationTest is TestSetup {
       )
     );
 
-    address[] memory allocationRecipients = Arrays.addresses(address(mentoLabsMultisig));
-    uint256[] memory allocationAmounts = Arrays.uints(200, 50, 100);
+    GovernanceFactory.MentoTokenAllocationParams memory allocationParams = GovernanceFactory
+      .MentoTokenAllocationParams({
+        airgrabAllocation: 50,
+        mentoTreasuryAllocation: 100,
+        additionalAllocationRecipients: Arrays.addresses(address(mentoLabsMultisig)),
+        additionalAllocationAmounts: Arrays.uints(200)
+      });
 
     vm.prank(owner);
     factory = new GovernanceFactory(celoGovernance);
 
     vm.prank(celoGovernance);
-    factory.createGovernance(
-      watchdogMultisig,
-      celoCommunityFund,
-      merkleRoot,
-      fractalSigner,
-      allocationRecipients,
-      allocationAmounts
-    );
+    factory.createGovernance(watchdogMultisig, celoCommunityFund, merkleRoot, fractalSigner, allocationParams);
     proxyAdmin = factory.proxyAdmin();
     mentoToken = factory.mentoToken();
     emission = factory.emission();


### PR DESCRIPTION
### Description

When we moved to a dynamic initial allocation calculation, we did something that has the potential for confusion: we're passing in two arrays to the GovernanceFactory contract:
- additionalAllocationRecipients
- allocationAmounts
With the implicit idea that `allocationAmounts.length == additionalAllocationRecipients.length + 2` and that the first two `allocationAmounts` relate to the airgrab and the Mento Treasury.

Even tho this is a one time thing I find that this adds the potential for confusion and will also make reviews more complicated.
I propose simplifying this by introducing an initial allocation struct:
```solidity
  struct MentoTokenAllocationParams {
    uint256 airgrabAllocation;
    uint256 mentoTreasuryAllocation;
    address[] additionalAllocationRecipients;
    uint256[] additionalAllocationAmounts;
  }
```

This explicitly defines the two "implicit" allocations and then has an array of 1:1 additional recipients and amounts.
It's also nicer to read when reviewing the CGP (in the cgp-viewer app I wrote): 
<img width="808" alt="image" src="https://github.com/mento-protocol/mento-core/assets/304771/1ed14b9c-0a74-4471-a0f5-1b1352b712df">

### Other changes

N/A

### Tested

- Tests covered

### Backwards compatibility

N/A

### Documentation

N/A