### PR TITLE
Update locking formula

### DIFF
--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -223,10 +223,8 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
     require(cliff >= minCliffPeriod, "cliff period < minimal lock period");
     require(slopePeriod >= minSlopePeriod, "slope period < minimal lock period");
 
-    uint96 cliffSide = (uint96(cliff - uint32(minCliffPeriod)) * (ST_FORMULA_CLIFF_MULTIPLIER)) /
-      (MAX_CLIFF_PERIOD - uint32(minCliffPeriod));
-    uint96 slopeSide = (uint96((slopePeriod - uint32(minSlopePeriod))) * (ST_FORMULA_SLOPE_MULTIPLIER)) /
-      (MAX_SLOPE_PERIOD - uint32(minSlopePeriod));
+    uint96 cliffSide = (uint96(cliff) * ST_FORMULA_CLIFF_MULTIPLIER) / MAX_CLIFF_PERIOD;
+    uint96 slopeSide = (uint96(slopePeriod) * ST_FORMULA_SLOPE_MULTIPLIER) / MAX_SLOPE_PERIOD;
     uint96 multiplier = cliffSide + slopeSide;
 
     if (multiplier > ST_FORMULA_DIVIDER) {

--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -190,9 +190,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
 
   /**
    * @dev Сalculate and return (newAmount, newSlope), using formula:
-   * P = t * min(scale(c, c_min, c_max) + scale(s, s_min, s_max), 1),
-   * where:
-   *    scale(v, min, max) = (v - min) / (max - min)
+   * P = t * min(c/c_max + s/s_max, 1),
    *
    * The formula has the following properties:
    * - the voting power can't exceed the amount of tokens locked.
@@ -208,8 +206,8 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    * locking = (
    *   tokens *
    *   min(
-   *    (ST_FORMULA_CLIFF_MULTIPLIER * (cliffPeriod - minCliffPeriod))/(MAX_CLIFF_PERIOD - minCliffPeriod) +
-   *    (ST_FORMULA_SLOPE_MULTIPLIER * (slopePeriod - minSlopePeriod))/(MAX_SLOPE_PERIOD - minSlopePeriod),
+   *    (ST_FORMULA_CLIFF_MULTIPLIER * cliffPeriod) / MAX_CLIFF_PERIOD +
+   *    (ST_FORMULA_SLOPE_MULTIPLIER * slopePeriod) / MAX_SLOPE_PERIOD,
    *    ST_FORMULA_DIVIDER
    *   )
    * ) / ST_FORMULA_DIVIDER

--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -186,7 +186,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
   }
 
   /**
-   * @dev Сalculate and return (newAmount, newSlope), using formula:
+   * @dev Сalculate and return (lockAmount, lockSlope), using formula:
    * P = t * min(c/c_max + s/s_max, 1),
    *
    * The formula has the following properties:
@@ -199,8 +199,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    *
    *
    * The formula roughly translates to solidity as:
-   * ```
-   * locking = (
+   * votingPower = (
    *   tokens *
    *   min(
    *    (ST_FORMULA_BASIS * cliffPeriod) / MAX_CLIFF_PERIOD +
@@ -208,7 +207,6 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    *    ST_FORMULA_BASIS
    *   )
    * ) / ST_FORMULA_BASIS
-   * ```
    **/
   function getLock(
     uint96 amount,

--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.18;
 // solhint-disable state-visibility, func-name-mixedcase
 
-import { console } from "forge-std-next/console.sol";
 import "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
 import "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "openzeppelin-contracts-upgradeable/contracts/governance/utils/IVotesUpgradeable.sol";

--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -236,7 +236,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
 
     uint256 amountMultiplied = uint256(amount) * uint256(multiplier);
     lockAmount = uint96(amountMultiplied / (ST_FORMULA_DIVIDER));
-    require(lockAmount > 0, "voting power is < 0");
+    require(lockAmount > 0, "voting power is 0");
     lockSlope = divUp(lockAmount, slopePeriod);
   }
 

--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -19,9 +19,9 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
   uint32 constant MAX_CLIFF_PERIOD = 103;
   uint32 constant MAX_SLOPE_PERIOD = 104;
 
-  uint32 constant ST_FORMULA_DIVIDER = 1 * (10 ** 8); //stFormula divider          100000000 / 1.0 / 100%
-  uint32 constant ST_FORMULA_CLIFF_MULTIPLIER = 1 * (10 ** 8); //stFormula cliff multiplier  100000000 / 1.0 / 100%
-  uint32 constant ST_FORMULA_SLOPE_MULTIPLIER = 1 * (10 ** 8); //stFormula slope multiplier  100000000 / 1.0 / 100%
+  uint32 constant ST_FORMULA_DIVIDER = 1 * (10**8); //stFormula divider          100000000 / 1.0 / 100%
+  uint32 constant ST_FORMULA_CLIFF_MULTIPLIER = 1 * (10**8); //stFormula cliff multiplier  100000000 / 1.0 / 100%
+  uint32 constant ST_FORMULA_SLOPE_MULTIPLIER = 1 * (10**8); //stFormula slope multiplier  100000000 / 1.0 / 100%
 
   /**
    * @dev ERC20 token to lock
@@ -179,7 +179,11 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
     locks[counter].delegate = _delegate;
   }
 
-  function updateLines(address account, address _delegate, uint32 time) internal {
+  function updateLines(
+    address account,
+    address _delegate,
+    uint32 time
+  ) internal {
     totalSupplyLine.update(time);
     accounts[_delegate].balance.update(time);
     accounts[account].locked.update(time);
@@ -195,7 +199,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    * - the voting power can't exceed the amount of tokens locked.
    * - a voter can reach 100% voting power by relying on either the slope or the cliff,
    *   or a combination of both.
-   * - there is a parameter space above a diagonal on the (c, s) plane where the 
+   * - there is a parameter space above a diagonal on the (c, s) plane where the
    *   voting power is capped at 100%, moving past that diagonal is disadvantageous
    *   but the contract doesn't forbid it.
    *
@@ -229,7 +233,6 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
     if (multiplier > ST_FORMULA_DIVIDER) {
       multiplier = ST_FORMULA_DIVIDER;
     }
-
 
     uint256 amountMultiplied = uint256(amount) * uint256(multiplier);
     lockAmount = uint96(amountMultiplied / (ST_FORMULA_DIVIDER));
@@ -317,10 +320,12 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
     totalSupplyLine.update(time);
   }
 
-  function updateAccountLinesBlockNumber(
-    address account,
-    uint32 blockNumber
-  ) external notStopped notMigrating onlyOwner {
+  function updateAccountLinesBlockNumber(address account, uint32 blockNumber)
+    external
+    notStopped
+    notMigrating
+    onlyOwner
+  {
     uint32 time = roundTimestamp(blockNumber);
     updateAccountLines(account, time);
   }

--- a/test/governance/Airgrab.t.sol
+++ b/test/governance/Airgrab.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.18;
 // solhint-disable func-name-mixedcase, state-visibility, max-states-count, var-name-mixedcase
 
-import { console } from "forge-std-next/console.sol";
 import { Test } from "forge-std-next/Test.sol";
 import { Arrays } from "test/utils/Arrays.sol";
 

--- a/test/governance/IntegrationTests/GovernanceIntegration.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.t.sol
@@ -221,10 +221,10 @@ contract GovernanceIntegrationTest is TestSetup {
     vm.prank(bob);
     uint256 bobsLockId = locking.lock(bob, bob, 1000e18, 52, 0);
 
-    // 1000e18 * ((uint96((26 - 1)) * (1e8)) / (104 - 1) / 1e8) = 242718440000000000000
-    assertEq(locking.getVotes(alice), 242718440000000000000);
-    // 1000e18 * ((uint96((52 - 1)) * (1e8)) / (104 - 1) / 1e8) = 495145630000000000000
-    assertEq(locking.getVotes(bob), 495145630000000000000);
+    // 1000e18 * ((uint96((26)) * (1e8)) / (104 ) / 1e8) = 250e18
+    assertEq(locking.getVotes(alice), 250e18);
+    // 1000e18 * ((uint96((52)) * (1e8)) / (104) / 1e8) = 500e18
+    assertEq(locking.getVotes(bob), 500e18);
 
     vm.timeTravel(13 * BLOCKS_WEEK);
 
@@ -232,26 +232,26 @@ contract GovernanceIntegrationTest is TestSetup {
     vm.prank(alice);
     locking.withdraw();
 
-    // (242718440000000000000 - 1) / 26 + 1 = 9335324615384615385
-    //  242718440000000000000 - 9335324615384615385 * 13 = 121359219999999999995
-    assertEq(locking.getVotes(alice), 121359219999999999995);
+    // (250e18 - 1) / 26 + 1 = 9615384615384615385
+    //  250e18 - 9615384615384615385 * 13 = 124999999999999999995
+    assertEq(locking.getVotes(alice), 124999999999999999995);
     // Slight difference between calculated and returned amount due to rounding
     assertApproxEqAbs(mentoToken.balanceOf(alice), 500e18, 10);
 
-    // (495145630000000000000 - 1) / 52 + 1 = 9522031346153846154
-    //  495145630000000000000 - 9522031346153846154 * 13 = 37135922249999999999999999995
-    assertEq(locking.getVotes(bob), 371359222499999999998);
+    // (500e18 - 1) / 52 + 1 = 9615384615384615385
+    //  500e18 - 9615384615384615385 * 13 = 374999999999999999995
+    assertEq(locking.getVotes(bob), 374999999999999999995);
     assertEq(mentoToken.balanceOf(bob), 0);
 
     vm.timeTravel(13 * BLOCKS_WEEK);
 
     // Bob relocks and delegates to alice
-    // 1000e18 * ((uint96((26 - 1)) * (1e8)) / (104 - 1) / 1e8) = 242718440000000000000
+    // 1000e18 * ((uint96((26)) * (1e8)) / (104 ) / 1e8) = 250e18
     vm.prank(bob);
     bobsLockId = locking.relock(bobsLockId, alice, 1000e18, 26, 0);
 
     // Alice has the voting power from Bob's lock
-    assertEq(locking.getVotes(alice), 242718440000000000000);
+    assertEq(locking.getVotes(alice), 250e18);
     assertEq(locking.getVotes(bob), 0);
 
     vm.timeTravel(13 * BLOCKS_WEEK);
@@ -262,9 +262,9 @@ contract GovernanceIntegrationTest is TestSetup {
 
     assertEq(locking.getVotes(alice), 0);
     assertEq(locking.getVotes(bob), 0);
-    // (242718440000000000000 - 1) / 26 + 1 = 9335324615384615385
-    //  242718440000000000000 - 9335324615384615385 * 13 = 121359219999999999995
-    assertEq(locking.getVotes(charlie), 121359219999999999995);
+    // (250e18 - 1) / 26 + 1 = 9615384615384615385
+    //  250e18 - 9615384615384615385 * 13 = 124999999999999999995
+    assertEq(locking.getVotes(charlie), 124999999999999999995);
 
     // End of the locking period
     vm.timeTravel(13 * BLOCKS_WEEK);

--- a/test/governance/IntegrationTests/LockingIntegration.fuzz.t.sol
+++ b/test/governance/IntegrationTests/LockingIntegration.fuzz.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.18;
+// solhint-disable func-name-mixedcase, max-line-length, max-states-count
+
+import { TestSetup } from "../TestSetup.sol";
+import { Vm } from "forge-std-next/Vm.sol";
+import { VmExtension } from "test/utils/VmExtension.sol";
+import { Arrays } from "test/utils/Arrays.sol";
+
+import { GovernanceFactory } from "contracts/governance/GovernanceFactory.sol";
+import { MentoToken } from "contracts/governance/MentoToken.sol";
+import { Locking } from "contracts/governance/locking/Locking.sol";
+import { TimelockController } from "contracts/governance/TimelockController.sol";
+import { console } from "forge-std-next/console.sol";
+
+/**
+ * @title Fuzz Testing for Locking Integration
+ * @dev Fuzz tests to ensure the locking mechanism integrates correctly with the governance system, providing the expected voting power based on token lock amount and duration.
+ */
+contract FuzzLockingIntegrationTest is TestSetup {
+  using VmExtension for Vm;
+
+  GovernanceFactory public factory;
+
+  MentoToken public mentoToken;
+  TimelockController public governanceTimelock;
+  Locking public locking;
+
+  address public celoGovernance = makeAddr("CeloGovernance");
+  address public celoCommunityFund = makeAddr("CeloCommunityFund");
+  address public watchdogMultisig = makeAddr("WatchdogMultisig");
+  address public mentoLabsMultisig = makeAddr("MentoLabsMultisig");
+  address public fractalSigner = makeAddr("FractalSigner");
+
+  bytes32 public merkleRoot = bytes32("MockMerkleRoot");
+
+  function setUp() public {
+    vm.roll(21871402); // (Oct-11-2023 WED 12:00:01 PM +UTC)
+    vm.warp(1697025601); // (Oct-11-2023 WED 12:00:01 PM +UTC)
+
+    vm.prank(owner);
+    factory = new GovernanceFactory(celoGovernance);
+
+    GovernanceFactory.MentoTokenAllocationParams memory allocationParams = GovernanceFactory
+      .MentoTokenAllocationParams({
+        airgrabAllocation: 50,
+        mentoTreasuryAllocation: 100,
+        additionalAllocationRecipients: Arrays.addresses(address(mentoLabsMultisig)),
+        additionalAllocationAmounts: Arrays.uints(200)
+      });
+
+    vm.prank(celoGovernance);
+    factory.createGovernance(watchdogMultisig, celoCommunityFund, merkleRoot, fractalSigner, allocationParams);
+    mentoToken = factory.mentoToken();
+    governanceTimelock = factory.governanceTimelock();
+    locking = factory.locking();
+
+    vm.prank(alice);
+    mentoToken.approve(address(locking), type(uint256).max);
+  }
+
+  /**
+   * @dev Fuzz test to verify correct voting power allocation for locked tokens over a shorter timeframe.
+   */
+  function test_lock_shouldGiveCorrectVotingPower_whenShorterTimeframe_Fuzz(
+    uint96 amount,
+    uint32 slope,
+    uint32 cliff,
+    uint96 period
+  ) public {
+    vm.assume(amount < mentoToken.balanceOf(address(address(governanceTimelock))));
+    vm.assume(amount > 1000);
+    vm.assume(slope >= locking.minSlopePeriod());
+    vm.assume(slope <= 104);
+    vm.assume(cliff >= locking.minCliffPeriod());
+    vm.assume(cliff <= 103);
+    vm.assume(period <= 208); // 4 years
+
+    vm.prank(address(governanceTimelock));
+    mentoToken.transfer(alice, amount);
+
+    vm.prank(alice);
+    locking.lock(alice, alice, amount, slope, cliff);
+
+    assertEq(locking.getVotes(alice), calculateVotes(amount, slope, cliff));
+
+    vm.timeTravel(BLOCKS_WEEK * period);
+
+    uint256 balanceBefore = mentoToken.balanceOf(alice);
+
+    vm.prank(alice);
+    locking.withdraw();
+
+    uint256 balanceAfter = mentoToken.balanceOf(alice);
+
+    if (period > cliff) {
+      assert(balanceAfter > balanceBefore);
+    } else {
+      assertEq(balanceAfter, balanceBefore);
+    }
+
+    if (period > slope + cliff) {
+      assertEq(locking.getVotes(alice), 0);
+      assertEq(balanceAfter, amount);
+    }
+  }
+
+  /**
+   * @dev Fuzz test to verify correct voting power allocation for locked tokens over a longer timeframe.
+   * Focuses on longer periods to avoid sparse coverage for more frequent usecase: period being < 4 years
+   */
+  function test_lock_shouldGiveCorrectVotingPower_whenLongerTimeframe_Fuzz(
+    uint96 amount,
+    uint32 slope,
+    uint32 cliff,
+    uint96 period
+  ) public {
+    vm.assume(amount < mentoToken.balanceOf(address(address(governanceTimelock))));
+    vm.assume(amount > 1000);
+    vm.assume(slope >= locking.minSlopePeriod());
+    vm.assume(slope <= 104);
+    vm.assume(cliff >= locking.minCliffPeriod());
+    vm.assume(cliff <= 103);
+    vm.assume(period <= 2080); // 40 years
+
+    vm.prank(address(governanceTimelock));
+    mentoToken.transfer(alice, amount);
+
+    vm.prank(alice);
+    locking.lock(alice, alice, amount, slope, cliff);
+
+    assertEq(locking.getVotes(alice), calculateVotes(amount, slope, cliff));
+
+    vm.timeTravel(BLOCKS_WEEK * period);
+
+    uint256 balanceBefore = mentoToken.balanceOf(alice);
+
+    vm.prank(alice);
+    locking.withdraw();
+
+    uint256 balanceAfter = mentoToken.balanceOf(alice);
+
+    if (period > cliff) {
+      assert(balanceAfter > balanceBefore);
+    } else {
+      assertEq(balanceAfter, balanceBefore);
+    }
+
+    if (period > slope + cliff) {
+      assertEq(locking.getVotes(alice), 0);
+      assertEq(balanceAfter, amount);
+    }
+  }
+
+  /**
+   * @dev Calculates the expected voting power based on lock amount, slope, and cliff.
+   */
+  function calculateVotes(
+    uint96 amount,
+    uint32 slope,
+    uint32 cliff
+  ) public pure returns (uint96) {
+    uint96 cliffSide = (uint96(cliff) * 1e8) / 103;
+    uint96 slopeSide = (uint96(slope) * 1e8) / 104;
+    uint96 multiplier = cliffSide + slopeSide;
+    if (multiplier > 1e8) multiplier = 1e8;
+
+    return uint96((uint256(amount) * uint256(multiplier)) / 1e8);
+  }
+}

--- a/test/governance/Locking/delegateTo.t.sol
+++ b/test/governance/Locking/delegateTo.t.sol
@@ -14,8 +14,10 @@ contract DelegateTo_Locking_Test is Locking_Test {
     lockId = locking.lock(alice, bob, 60000, 30, 0);
 
     _incrementBlock(20 * weekInBlocks);
-
-    assertEq(locking.balanceOf(bob), 6303);
+    // 60000 * (30 / 104) = 17307
+    // (17307 - 1) / 30 + 1 = 577
+    // 17307 - 20 * 577 = 5767
+    assertEq(locking.balanceOf(bob), 5767);
 
     vm.prank(alice);
     locking.withdraw();
@@ -27,7 +29,7 @@ contract DelegateTo_Locking_Test is Locking_Test {
     locking.delegateTo(lockId, charlie);
 
     assertEq(locking.balanceOf(bob), 0);
-    assertEq(locking.balanceOf(charlie), 6303);
+    assertEq(locking.balanceOf(charlie), 5767);
 
     _incrementBlock(10 * weekInBlocks);
 
@@ -55,8 +57,10 @@ contract DelegateTo_Locking_Test is Locking_Test {
 
     vm.prank(alice);
     locking.delegateTo(lockId, bob);
-
-    assertEq(locking.balanceOf(bob), 3148);
+    // 60000 * (30 / 104) = 17307
+    // (17307 - 1) / 30 + 1 = 577
+    // 17307 - 25 * 577 = 2882
+    assertEq(locking.balanceOf(bob), 2882);
     assertEq(locking.balanceOf(charlie), 0);
 
     vm.prank(alice);
@@ -82,8 +86,10 @@ contract DelegateTo_Locking_Test is Locking_Test {
     lockId = locking.lock(alice, bob, 6300, 7, 0);
 
     _incrementBlock(6 * weekInBlocks);
-
-    assertEq(locking.balanceOf(bob), 199);
+    // 7 / 104 * 6300 = 424
+    // (424 - 1) / 7 + 1 = 61
+    // 424 - 6 * 61 = 58
+    assertEq(locking.balanceOf(bob), 58);
 
     vm.prank(alice);
     locking.withdraw();
@@ -95,7 +101,7 @@ contract DelegateTo_Locking_Test is Locking_Test {
     locking.delegateTo(lockId, charlie);
 
     assertEq(locking.balanceOf(bob), 0);
-    assertEq(locking.balanceOf(charlie), 199);
+    assertEq(locking.balanceOf(charlie), 58);
 
     _incrementBlock(weekInBlocks);
 
@@ -115,8 +121,8 @@ contract DelegateTo_Locking_Test is Locking_Test {
     lockId = locking.lock(alice, bob, 630000, 7, 2);
 
     _incrementBlock(weekInBlocks);
-
-    assertEq(locking.balanceOf(bob), 152747);
+    // 630000 * (7 / 104 + 2 / 103) = 54636
+    assertEq(locking.balanceOf(bob), 54636);
 
     vm.prank(alice);
     locking.withdraw();
@@ -128,11 +134,11 @@ contract DelegateTo_Locking_Test is Locking_Test {
     locking.delegateTo(lockId, charlie);
 
     assertEq(locking.balanceOf(bob), 0);
-    assertEq(locking.balanceOf(charlie), 152747);
+    assertEq(locking.balanceOf(charlie), 54636);
 
     _incrementBlock(weekInBlocks);
 
-    assertEq(locking.balanceOf(charlie), 152747);
+    assertEq(locking.balanceOf(charlie), 54636);
 
     _incrementBlock(7 * weekInBlocks);
     assertEq(locking.balanceOf(charlie), 0);
@@ -161,8 +167,11 @@ contract DelegateTo_Locking_Test is Locking_Test {
     vm.prank(alice);
     locking.delegateTo(lockId, charlie);
 
+    // 630000 * (7 / 104 + 2 / 103) = 54636
+    // (54636 - 1) / 7 + 1 = 7806
+    //  54636 - 7806 * 2 = 39024
     assertEq(locking.balanceOf(bob), 0);
-    assertEq(locking.balanceOf(charlie), 109105);
+    assertEq(locking.balanceOf(charlie), 39024);
 
     _incrementBlock(5 * weekInBlocks);
 
@@ -185,7 +194,6 @@ contract DelegateTo_Locking_Test is Locking_Test {
 
     vm.prank(alice);
     locking.withdraw();
-
     assertEq(mentoToken.balanceOf(address(locking)), 90000);
     assertEq(mentoToken.balanceOf(alice), 910000);
 
@@ -193,7 +201,10 @@ contract DelegateTo_Locking_Test is Locking_Test {
     locking.delegateTo(lockId, charlie);
 
     assertEq(locking.balanceOf(bob), 0);
-    assertEq(locking.balanceOf(charlie), 21821);
+    // 630000 * (7 / 104 + 2 / 103) = 54636
+    // (54636 - 1) / 7 + 1 = 7806
+    // 54636 - (7806 * 6) = 7800
+    assertEq(locking.balanceOf(charlie), 7800);
 
     _incrementBlock(weekInBlocks);
 

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.18;
 // solhint-disable func-name-mixedcase, contract-name-camelcase
 
+import { console } from "forge-std-next/console.sol";
 import { Locking_Test } from "./Base.t.sol";
 import { MockLocking } from "../../mocks/MockLocking.sol";
 
@@ -104,17 +105,17 @@ contract Lock_Locking_Test is Locking_Test {
   }
 
   function test_withdraw_whenInSlope_shouldReleaseCorrectAmount() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.prank(alice);
-    locking.lock(alice, alice, 30, 3, 3);
+    locking.lock(alice, alice, 300, 3, 3);
 
     _incrementBlock(3 * weekInBlocks);
 
     vm.prank(alice);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 30);
+    assertEq(mentoToken.balanceOf(address(locking)), 300);
     assertEq(mentoToken.balanceOf(alice), 70);
 
     _incrementBlock(weekInBlocks);
@@ -160,6 +161,8 @@ contract Lock_Locking_Test is Locking_Test {
     mentoToken.mint(alice, 100);
 
     vm.prank(alice);
+    console.log(locking.minSlopePeriod());
+    console.log(locking.minCliffPeriod());
     locking.lock(bob, bob, 30, 3, 0);
 
     _incrementBlock(weekInBlocks);

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -116,15 +116,15 @@ contract Lock_Locking_Test is Locking_Test {
     locking.withdraw();
 
     assertEq(mentoToken.balanceOf(address(locking)), 300);
-    assertEq(mentoToken.balanceOf(alice), 70);
+    assertEq(mentoToken.balanceOf(alice), 700);
 
     _incrementBlock(weekInBlocks);
 
     vm.prank(alice);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 20);
-    assertEq(mentoToken.balanceOf(alice), 80);
+    assertEq(mentoToken.balanceOf(address(locking)), 200);
+    assertEq(mentoToken.balanceOf(alice), 800);
   }
 
   function test_withdraw_whenCalledFromAnotherAccount_shouldNotSendTokens() public {
@@ -161,8 +161,6 @@ contract Lock_Locking_Test is Locking_Test {
     mentoToken.mint(alice, 1000);
 
     vm.prank(alice);
-    console.log(locking.minSlopePeriod());
-    console.log(locking.minCliffPeriod());
     locking.lock(bob, bob, 300, 3, 0);
 
     _incrementBlock(weekInBlocks);
@@ -183,14 +181,15 @@ contract Lock_Locking_Test is Locking_Test {
 
     assertEq(mentoToken.balanceOf(address(locking)), 5200);
     assertEq(mentoToken.balanceOf(alice), 800);
-    assertEq(locking.balanceOf(alice), 4220);
+    // (52 / 104 + 53 / 103) * 5200 = 5275 > 5200
+    assertEq(locking.balanceOf(alice), 5200);
 
     _incrementBlock(103 * weekInBlocks);
 
     vm.prank(alice);
     locking.withdraw();
 
-    assertEq(locking.balanceOf(alice), 120);
+    assertEq(locking.balanceOf(alice), 200);
 
     _incrementBlock(weekInBlocks);
 
@@ -199,7 +198,7 @@ contract Lock_Locking_Test is Locking_Test {
 
     assertEq(mentoToken.balanceOf(address(locking)), 100);
     assertEq(mentoToken.balanceOf(alice), 5900);
-    assertEq(locking.balanceOf(alice), 38);
+    assertEq(locking.balanceOf(alice), 100);
 
     _incrementBlock(weekInBlocks);
 
@@ -216,29 +215,37 @@ contract Lock_Locking_Test is Locking_Test {
     uint32 slopePeriod = 30;
     uint32 cliff = 30;
     (uint96 lockAmount, uint96 lockSlope) = locking.getLock(amount, slopePeriod, cliff);
-    assertEq(lockAmount, 32903);
-    assertEq(lockSlope, 1097);
+    // floor ((30 / 104 + 30 / 103) * 60000) = 34783
+    assertEq(lockAmount, 34783);
+    // divUp (34783, 30) = 1160
+    assertEq(lockSlope, 1160);
 
     amount = 96000;
     slopePeriod = 48;
     cliff = 48;
     (lockAmount, lockSlope) = locking.getLock(amount, slopePeriod, cliff);
-    assertEq(lockAmount, 72713);
-    assertEq(lockSlope, 1515);
+    // floor ((48 / 104 + 48 / 103) * 96000) = 89045
+    assertEq(lockAmount, 89045);
+    // divUp (89045, 48)  = 1856
+    assertEq(lockSlope, 1856);
 
     amount = 104000;
     slopePeriod = 104;
     cliff = 0;
     (lockAmount, lockSlope) = locking.getLock(amount, slopePeriod, cliff);
-    assertEq(lockAmount, 62400);
-    assertEq(lockSlope, 600);
+    // floor ((104 / 104 + 0 / 103) * 104000) = 104000
+    assertEq(lockAmount, 104000);
+    // divUp (104000, 104) = 1000
+    assertEq(lockSlope, 1000);
 
     amount = 104000;
-    slopePeriod = 1;
+    slopePeriod = 24;
     cliff = 103;
     (lockAmount, lockSlope) = locking.getLock(amount, slopePeriod, cliff);
-    assertEq(lockAmount, 104399);
-    assertEq(lockSlope, 104399);
+    // floor ((24 / 104 + 103 / 103) * 104000) = 128000 > 104000
+    assertEq(lockAmount, 104000);
+    // divUp (104000, 1) = 105000
+    assertEq(lockSlope, 4334);
   }
 
   function test_getWeek_shouldReturnCorrectWeekNo() public {
@@ -276,7 +283,7 @@ contract Lock_Locking_Test is Locking_Test {
     vm.prank(alice);
     uint256 availableForWithdraw = locking.getAvailableForWithdraw(alice);
 
-    assertEq(mentoToken.balanceOf(address(locking)), 1000);
+    assertEq(mentoToken.balanceOf(address(locking)), 300);
     assertEq(mentoToken.balanceOf(alice), 700);
     assertEq(availableForWithdraw, 200);
   }
@@ -299,29 +306,30 @@ contract Lock_Locking_Test is Locking_Test {
     lockId = locking.lock(alice, alice, 3000, 3, 0);
     // WEEK 1
     assertEq(mentoToken.balanceOf(address(locking)), 3000);
-    assertEq(locking.balanceOf(alice), 634);
-    assertEq(locking.getVotes(alice), 634);
+    // 3 / 104 * 3000 = 86
+    assertEq(locking.balanceOf(alice), 86);
+    assertEq(locking.getVotes(alice), 86);
 
     // WEEK 2
     _incrementBlock(weekInBlocks / 2 + weekInBlocks / 4);
 
     delegateBlock = locking.blockNumberMocked();
     voteBlock = delegateBlock + weekInBlocks / 4;
-
-    assertEq(locking.balanceOf(alice), 422);
-    assertEq(locking.getVotes(alice), 422);
+    // 86 * 2 / 3 = 57
+    assertEq(locking.balanceOf(alice), 57);
+    assertEq(locking.getVotes(alice), 57);
 
     vm.prank(alice);
     locking.delegateTo(lockId, bob);
 
     assertEq(locking.balanceOf(alice), 0);
     assertEq(locking.getVotes(alice), 0);
-    assertEq(locking.balanceOf(bob), 422);
-    assertEq(locking.getVotes(bob), 422);
+    assertEq(locking.balanceOf(bob), 57);
+    assertEq(locking.getVotes(bob), 57);
 
-    assertEq(locking.getPastVotes(alice, delegateBlock - 1), 422);
+    assertEq(locking.getPastVotes(alice, delegateBlock - 1), 57);
     assertEq(locking.getPastVotes(bob, delegateBlock - 1), 0);
-    assertEq(locking.getPastTotalSupply(delegateBlock - 1), 422);
+    assertEq(locking.getPastTotalSupply(delegateBlock - 1), 57);
 
     _incrementBlock(weekInBlocks / 2);
 
@@ -329,16 +337,16 @@ contract Lock_Locking_Test is Locking_Test {
 
     assertEq(locking.balanceOf(alice), 0);
     assertEq(locking.getVotes(alice), 0);
-    assertEq(locking.balanceOf(bob), 422);
-    assertEq(locking.getVotes(bob), 422);
+    assertEq(locking.balanceOf(bob), 57);
+    assertEq(locking.getVotes(bob), 57);
 
     assertEq(locking.getPastVotes(alice, voteBlock), 0);
-    assertEq(locking.getPastVotes(bob, voteBlock), 422);
-    assertEq(locking.getPastTotalSupply(voteBlock), 422);
+    assertEq(locking.getPastVotes(bob, voteBlock), 57);
+    assertEq(locking.getPastTotalSupply(voteBlock), 57);
 
-    assertEq(locking.getPastVotes(alice, delegateBlock - 1), 422);
+    assertEq(locking.getPastVotes(alice, delegateBlock - 1), 57);
     assertEq(locking.getPastVotes(bob, delegateBlock - 1), 0);
-    assertEq(locking.getPastTotalSupply(delegateBlock - 1), 422);
+    assertEq(locking.getPastTotalSupply(delegateBlock - 1), 57);
 
     vm.prank(alice);
     locking.relock(lockId, charlie, 4000, 4, 0);
@@ -348,20 +356,21 @@ contract Lock_Locking_Test is Locking_Test {
     assertEq(locking.getVotes(alice), 0);
     assertEq(locking.balanceOf(bob), 0);
     assertEq(locking.getVotes(bob), 0);
-    assertEq(locking.balanceOf(charlie), 861);
-    assertEq(locking.getVotes(charlie), 861);
+    // 4 / 104 * 4000 = 153
+    assertEq(locking.balanceOf(charlie), 153);
+    assertEq(locking.getVotes(charlie), 153);
 
     assertEq(locking.getPastVotes(alice, voteBlock), 0);
-    assertEq(locking.getPastVotes(bob, voteBlock), 422);
-    assertEq(locking.getPastTotalSupply(voteBlock), 422);
+    assertEq(locking.getPastVotes(bob, voteBlock), 57);
+    assertEq(locking.getPastTotalSupply(voteBlock), 57);
 
-    assertEq(locking.getPastVotes(alice, delegateBlock - 1), 422);
+    assertEq(locking.getPastVotes(alice, delegateBlock - 1), 57);
     assertEq(locking.getPastVotes(bob, delegateBlock - 1), 0);
-    assertEq(locking.getPastTotalSupply(delegateBlock - 1), 422);
+    assertEq(locking.getPastTotalSupply(delegateBlock - 1), 57);
 
     assertEq(locking.getPastVotes(alice, relockBlock - 1), 0);
-    assertEq(locking.getPastVotes(bob, relockBlock - 1), 422);
-    assertEq(locking.getPastTotalSupply(relockBlock - 1), 422);
+    assertEq(locking.getPastVotes(bob, relockBlock - 1), 57);
+    assertEq(locking.getPastTotalSupply(relockBlock - 1), 57);
 
     // WEEK 3
 
@@ -370,8 +379,9 @@ contract Lock_Locking_Test is Locking_Test {
     assertEq(locking.getVotes(alice), 0);
     assertEq(locking.balanceOf(bob), 0);
     assertEq(locking.getVotes(bob), 0);
-    assertEq(locking.balanceOf(charlie), 645);
-    assertEq(locking.getVotes(charlie), 645);
+    // 153 * 3 / 4 = 114
+    assertEq(locking.balanceOf(charlie), 114);
+    assertEq(locking.getVotes(charlie), 114);
 
     uint256 currentBlock = locking.blockNumberMocked();
 
@@ -394,9 +404,9 @@ contract Lock_Locking_Test is Locking_Test {
 
     vm.prank(owner);
     locking.startMigration(address(mockLockingContract));
-
-    assertEq(locking.balanceOf(alice), 18923);
-    assertEq(locking.totalSupply(), 18923);
+    //  (30/104)*60000 = 17307
+    assertEq(locking.balanceOf(alice), 17307);
+    assertEq(locking.totalSupply(), 17307);
 
     vm.prank(alice);
     locking.migrate(ids);

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -403,7 +403,7 @@ contract Lock_Locking_Test is Locking_Test {
 
     vm.prank(owner);
     locking.startMigration(address(mockLockingContract));
-    //  (30/104)*60000 = 17307
+    // (30 / 104) * 60000 = 17307
     assertEq(locking.balanceOf(alice), 17307);
     assertEq(locking.totalSupply(), 17307);
 

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -243,7 +243,7 @@ contract Lock_Locking_Test is Locking_Test {
     (lockAmount, lockSlope) = locking.getLock(amount, slopePeriod, cliff);
     // floor ((24 / 104 + 103 / 103) * 104000) = 128000 > 104000
     assertEq(lockAmount, 104000);
-    // divUp (104000, 1) = 105000
+    // divUp (104000, 24) = 4334
     assertEq(lockSlope, 4334);
   }
 

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.18;
 // solhint-disable func-name-mixedcase, contract-name-camelcase
 
-import { console } from "forge-std-next/console.sol";
 import { Locking_Test } from "./Base.t.sol";
 import { MockLocking } from "../../mocks/MockLocking.sol";
 

--- a/test/governance/Locking/locking.t.sol
+++ b/test/governance/Locking/locking.t.sol
@@ -128,51 +128,51 @@ contract Lock_Locking_Test is Locking_Test {
   }
 
   function test_withdraw_whenCalledFromAnotherAccount_shouldNotSendTokens() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.prank(alice);
-    locking.lock(alice, alice, 30, 3, 0);
+    locking.lock(alice, alice, 300, 3, 0);
 
     _incrementBlock(weekInBlocks);
 
     vm.prank(bob);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 30);
-    assertEq(mentoToken.balanceOf(alice), 70);
+    assertEq(mentoToken.balanceOf(address(locking)), 300);
+    assertEq(mentoToken.balanceOf(alice), 700);
   }
 
   function test_withdraw_whenTheLockIsCreatedForSomeoneElse_shouldNotReleaseTokens() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.prank(alice);
-    locking.lock(bob, bob, 30, 3, 0);
+    locking.lock(bob, bob, 300, 3, 0);
 
     _incrementBlock(weekInBlocks);
 
     vm.prank(alice);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 30);
-    assertEq(mentoToken.balanceOf(alice), 70);
+    assertEq(mentoToken.balanceOf(address(locking)), 300);
+    assertEq(mentoToken.balanceOf(alice), 700);
   }
 
   function test_withdraw_whenCalledByTheOwnerOfTheLock_shouldReleaseTokens() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.prank(alice);
     console.log(locking.minSlopePeriod());
     console.log(locking.minCliffPeriod());
-    locking.lock(bob, bob, 30, 3, 0);
+    locking.lock(bob, bob, 300, 3, 0);
 
     _incrementBlock(weekInBlocks);
 
     vm.prank(bob);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 20);
-    assertEq(mentoToken.balanceOf(alice), 70);
-    assertEq(mentoToken.balanceOf(bob), 10);
+    assertEq(mentoToken.balanceOf(address(locking)), 200);
+    assertEq(mentoToken.balanceOf(alice), 700);
+    assertEq(mentoToken.balanceOf(bob), 100);
   }
 
   function test_withdraw_whenTailInVeToken_shouldReleaseCorrectAmounts() public {
@@ -266,19 +266,19 @@ contract Lock_Locking_Test is Locking_Test {
   }
 
   function test_getAvailableForWithdraw_shouldReturnCorrectAmount() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.prank(alice);
-    locking.lock(alice, alice, 30, 3, 0);
+    locking.lock(alice, alice, 300, 3, 0);
 
     _incrementBlock(2 * weekInBlocks);
 
     vm.prank(alice);
     uint256 availableForWithdraw = locking.getAvailableForWithdraw(alice);
 
-    assertEq(mentoToken.balanceOf(address(locking)), 30);
-    assertEq(mentoToken.balanceOf(alice), 70);
-    assertEq(availableForWithdraw, 20);
+    assertEq(mentoToken.balanceOf(address(locking)), 1000);
+    assertEq(mentoToken.balanceOf(alice), 700);
+    assertEq(availableForWithdraw, 200);
   }
 
   function test_viewFuctions_shouldReturnCorrectValues() public {

--- a/test/governance/Locking/relock.t.sol
+++ b/test/governance/Locking/relock.t.sol
@@ -103,85 +103,85 @@ contract Relock_Locking_Test is Locking_Test {
   }
 
   function test_relock_wheInSlope_shouldRelockWithNewSchedule() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.startPrank(alice);
-    lockId = locking.lock(alice, alice, 30, 3, 0);
+    lockId = locking.lock(alice, alice, 300, 3, 0);
     _incrementBlock(2 * weekInBlocks);
 
-    locking.relock(lockId, alice, 80, 16, 6);
+    locking.relock(lockId, alice, 800, 16, 6);
 
-    assertEq(mentoToken.balanceOf(address(locking)), 80);
-    assertEq(mentoToken.balanceOf(alice), 20);
+    assertEq(mentoToken.balanceOf(address(locking)), 800);
+    assertEq(mentoToken.balanceOf(alice), 200);
 
     _incrementBlock(6 * weekInBlocks);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 80);
-    assertEq(mentoToken.balanceOf(alice), 20);
+    assertEq(mentoToken.balanceOf(address(locking)), 800);
+    assertEq(mentoToken.balanceOf(alice), 200);
 
     _incrementBlock(16 * weekInBlocks);
     locking.withdraw();
 
     assertEq(mentoToken.balanceOf(address(locking)), 0);
-    assertEq(mentoToken.balanceOf(alice), 100);
+    assertEq(mentoToken.balanceOf(alice), 1000);
 
     vm.stopPrank();
   }
 
   function test_relock_whenRelocked_shouldReleaseByTheNewScheduleAfterWithdraw() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.startPrank(alice);
-    lockId = locking.lock(alice, alice, 30, 3, 0);
+    lockId = locking.lock(alice, alice, 300, 3, 0);
     _incrementBlock(2 * weekInBlocks);
 
-    locking.relock(lockId, alice, 80, 16, 6);
+    locking.relock(lockId, alice, 800, 16, 6);
 
-    assertEq(mentoToken.balanceOf(address(locking)), 80);
-    assertEq(mentoToken.balanceOf(alice), 20);
+    assertEq(mentoToken.balanceOf(address(locking)), 800);
+    assertEq(mentoToken.balanceOf(alice), 200);
 
     _incrementBlock(6 * weekInBlocks);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 80);
-    assertEq(mentoToken.balanceOf(alice), 20);
+    assertEq(mentoToken.balanceOf(address(locking)), 800);
+    assertEq(mentoToken.balanceOf(alice), 200);
 
     _incrementBlock(16 * weekInBlocks);
     locking.withdraw();
 
     assertEq(mentoToken.balanceOf(address(locking)), 0);
-    assertEq(mentoToken.balanceOf(alice), 100);
+    assertEq(mentoToken.balanceOf(alice), 1000);
 
     vm.stopPrank();
   }
 
   function test_relock_whenInTail_shouldRelockWithNewSchedule() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.startPrank(alice);
-    lockId = locking.lock(alice, alice, 37, 4, 3);
+    lockId = locking.lock(alice, alice, 370, 4, 3);
 
     _incrementBlock(6 * weekInBlocks);
 
-    locking.relock(lockId, alice, 10, 2, 2);
+    locking.relock(lockId, alice, 100, 2, 2);
 
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 10);
-    assertEq(mentoToken.balanceOf(alice), 90);
+    assertEq(mentoToken.balanceOf(address(locking)), 100);
+    assertEq(mentoToken.balanceOf(alice), 900);
 
     _incrementBlock(2 * weekInBlocks);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 10);
-    assertEq(mentoToken.balanceOf(alice), 90);
+    assertEq(mentoToken.balanceOf(address(locking)), 100);
+    assertEq(mentoToken.balanceOf(alice), 900);
 
     _incrementBlock(2 * weekInBlocks);
     locking.withdraw();
 
     assertEq(mentoToken.balanceOf(address(locking)), 0);
-    assertEq(mentoToken.balanceOf(alice), 100);
+    assertEq(mentoToken.balanceOf(alice), 1000);
 
     vm.stopPrank();
   }
@@ -263,14 +263,15 @@ contract Relock_Locking_Test is Locking_Test {
 
     vm.prank(alice);
     lockId = locking.lock(alice, bob, 60000, 30, 0);
-
-    assertEq(locking.balanceOf(bob), 18923);
+    // 60000 * 30 / 104 = 17307
+    assertEq(locking.balanceOf(bob), 17307);
     assertEq(mentoToken.balanceOf(address(locking)), 60000);
     assertEq(mentoToken.balanceOf(alice), 40000);
 
     _incrementBlock(29 * weekInBlocks);
-
-    assertEq(locking.balanceOf(bob), 624);
+    // (17307 - 1) / 30 + 1 = 577
+    // 17307 - 29 * 577 = 574
+    assertEq(locking.balanceOf(bob), 574);
 
     vm.prank(alice);
     locking.withdraw();
@@ -294,9 +295,13 @@ contract Relock_Locking_Test is Locking_Test {
     vm.prank(alice);
     lockId = locking.lock(alice, bob, 60000, 30, 0);
 
-    _incrementBlock(20 * weekInBlocks);
+    // 60000 * 30 / 104 = 17307
+    assertEq(locking.balanceOf(bob), 17307);
 
-    assertEq(locking.balanceOf(bob), 6303);
+    _incrementBlock(20 * weekInBlocks);
+    // (17307-1) / 30 + 1 = 577
+    // 17307 - 20 * 577 = 5767
+    assertEq(locking.balanceOf(bob), 5767);
 
     vm.prank(alice);
     locking.withdraw();
@@ -308,7 +313,8 @@ contract Relock_Locking_Test is Locking_Test {
     locking.relock(lockId, charlie, 20000, 10, 0);
 
     assertEq(locking.balanceOf(bob), 0);
-    assertEq(locking.balanceOf(charlie), 4769);
+    // 20000 * 10 / 104 = 1923
+    assertEq(locking.balanceOf(charlie), 1923);
 
     _incrementBlock(10 * weekInBlocks);
 
@@ -329,8 +335,10 @@ contract Relock_Locking_Test is Locking_Test {
     lockId = locking.lock(alice, bob, 60000, 30, 0);
 
     _incrementBlock(20 * weekInBlocks);
-
-    assertEq(locking.balanceOf(bob), 6303);
+    // 60000 * 30 / 104 = 17307
+    // (17307-1) / 30 + 1 = 577
+    // 17307 - 20 * 577 = 5767
+    assertEq(locking.balanceOf(bob), 5767);
 
     vm.prank(alice);
     locking.withdraw();
@@ -423,35 +431,35 @@ contract Relock_Locking_Test is Locking_Test {
   }
 
   function test_relock_whenMultiLinesInSlope_shouldRelockCorrectly() public {
-    mentoToken.mint(alice, 100);
+    mentoToken.mint(alice, 1000);
 
     vm.prank(alice);
-    locking.lock(alice, alice, 30, 3, 0);
+    locking.lock(alice, alice, 300, 3, 0);
 
     vm.prank(alice);
-    uint256 lockId2 = locking.lock(alice, alice, 30, 3, 0);
+    uint256 lockId2 = locking.lock(alice, alice, 300, 3, 0);
 
     _incrementBlock(2 * weekInBlocks);
 
     vm.prank(alice);
-    locking.relock(lockId2, alice, 60, 12, 0);
+    locking.relock(lockId2, alice, 600, 12, 0);
 
-    assertEq(mentoToken.balanceOf(address(locking)), 70);
-    assertEq(mentoToken.balanceOf(alice), 30);
+    assertEq(mentoToken.balanceOf(address(locking)), 700);
+    assertEq(mentoToken.balanceOf(alice), 300);
 
     _incrementBlock(weekInBlocks);
     vm.prank(alice);
     locking.withdraw();
 
-    assertEq(mentoToken.balanceOf(address(locking)), 55);
-    assertEq(mentoToken.balanceOf(alice), 45);
+    assertEq(mentoToken.balanceOf(address(locking)), 550);
+    assertEq(mentoToken.balanceOf(alice), 450);
 
     _incrementBlock(11 * weekInBlocks);
     vm.prank(alice);
     locking.withdraw();
 
     assertEq(mentoToken.balanceOf(address(locking)), 0);
-    assertEq(mentoToken.balanceOf(alice), 100);
+    assertEq(mentoToken.balanceOf(alice), 1000);
   }
 
   function test_relock_whenMultiAccountsInCliff_shouldRelockCorrectly() public {

--- a/test/governance/Locking/relock.t.sol
+++ b/test/governance/Locking/relock.t.sol
@@ -299,7 +299,7 @@ contract Relock_Locking_Test is Locking_Test {
     assertEq(locking.balanceOf(bob), 17307);
 
     _incrementBlock(20 * weekInBlocks);
-    // (17307-1) / 30 + 1 = 577
+    // (17307 - 1) / 30 + 1 = 577
     // 17307 - 20 * 577 = 5767
     assertEq(locking.balanceOf(bob), 5767);
 
@@ -336,7 +336,7 @@ contract Relock_Locking_Test is Locking_Test {
 
     _incrementBlock(20 * weekInBlocks);
     // 60000 * 30 / 104 = 17307
-    // (17307-1) / 30 + 1 = 577
+    // (17307 - 1) / 30 + 1 = 577
     // 17307 - 20 * 577 = 5767
     assertEq(locking.balanceOf(bob), 5767);
 

--- a/test/tokens/StableTokenV2.t.sol
+++ b/test/tokens/StableTokenV2.t.sol
@@ -3,7 +3,6 @@
 // solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
 pragma solidity ^0.8.0;
 
-import { console } from "forge-std-next/console.sol";
 import { Arrays } from "../utils/Arrays.sol";
 import { BaseTest } from "../utils/BaseTest.next.sol";
 


### PR DESCRIPTION
### Description

Currently the voting power formula looks like this (slightly simplified):

```math
P(t,s,c) = t * (0.2 + 0.8 * c / c_{max} + 0.6 * s / s_{max})
```

We want to bring the system closer to the classical veCurve formula, by changing it to:

```math
P(t,s,c) = t * min(s/s_{max} + c/c_{max}, 1)
```

More details can be seen here https://github.com/mento-protocol/mento-core/issues/373

Since this formula sits in the core of the voting power calculations, reviews should be on a broader level. Please go through code changes, test calculations and more importantly how this may affect the whole locking mechanism.

Known issues:
- users can lock with a suboptimal schedule if the summed multiplier goes above 1. 

### Other changes

Updated the tests to use the exact amounts and not approximations
Removed unused imports

### Tested

Fixed the tests related to change. Actual calculations are added as comments.
Some extra fuzz tests are WIP and will be added with a separate PR

### Related issues

- Fixes #373 
