### PR TITLE
chore: fix path to sorted oracles

### DIFF
--- a/.github/workflows/storage-layout.yaml
+++ b/.github/workflows/storage-layout.yaml
@@ -22,7 +22,7 @@ jobs:
           - contracts/swap/BiPoolManager.sol:BiPoolManager
           - contracts/swap/Reserve.sol:Reserve
           - contracts/oracles/BreakerBox.sol:BreakerBox
-          - contracts/oracles/SortedOracles.sol:SortedOracles
+          - contracts/common/SortedOracles.sol:SortedOracles
           - contracts/tokens/StableTokenV2.sol:StableTokenV2
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Description

CI job that checks storage layouts are failing because we moved SortedOracles to common directory but did not update the path in the job.
This PR aims to fix that by updating the path

### Other changes

no

### Tested

N/A

### Related issues

- Issue not tracked

