### PR TITLE
fix: hardcoded emission supply

### DIFF
--- a/contracts/governance/Emission.sol
+++ b/contracts/governance/Emission.sol
@@ -10,9 +10,6 @@ import { MentoToken } from "./MentoToken.sol";
  * @notice This contract handles the emission of Mento Tokens in an exponentially decaying manner.
  */
 contract Emission is OwnableUpgradeable {
-  /// @notice The max amount that will be minted through emission
-  uint256 public constant TOTAL_EMISSION_SUPPLY = 650_000_000 * 10**18;
-
   /// @notice Pre-calculated constant = EMISSION_HALF_LIFE / LN2.
   uint256 public constant A = 454968308;
 
@@ -24,6 +21,9 @@ contract Emission is OwnableUpgradeable {
 
   /// @notice The MentoToken contract reference.
   MentoToken public mentoToken;
+
+  /// @notice The max amount that will be minted through emission
+  uint256 public emissionSupply;
 
   /// @notice The target address where emitted tokens are sent.
   address public emissionTarget;
@@ -52,12 +52,18 @@ contract Emission is OwnableUpgradeable {
    * @notice Initialize the Emission contract.
    * @param mentoToken_ The address of the MentoToken contract.
    * @param emissionTarget_ The address of the emission target.
+   * @param emissionSupply_ The total amount of tokens that can be emitted.
    */
-  function initialize(address mentoToken_, address emissionTarget_) public initializer {
+  function initialize(
+    address mentoToken_,
+    address emissionTarget_,
+    uint256 emissionSupply_
+  ) public initializer {
     emissionStartTime = block.timestamp;
     mentoToken = MentoToken(mentoToken_);
     // slither-disable-next-line missing-zero-check
     emissionTarget = emissionTarget_;
+    emissionSupply = emissionSupply_;
     __Ownable_init();
   }
 
@@ -110,11 +116,11 @@ contract Emission is OwnableUpgradeable {
 
     // Avoiding underflow in case the scheduled amount is bigger than the total supply
     if (positiveAggregate < negativeAggregate) {
-      return TOTAL_EMISSION_SUPPLY - totalEmittedAmount;
+      return emissionSupply - totalEmittedAmount;
     }
 
-    uint256 scheduledRemainingSupply = (TOTAL_EMISSION_SUPPLY * (positiveAggregate - negativeAggregate)) / SCALER;
+    uint256 scheduledRemainingSupply = (emissionSupply * (positiveAggregate - negativeAggregate)) / SCALER;
 
-    amount = TOTAL_EMISSION_SUPPLY - scheduledRemainingSupply - totalEmittedAmount;
+    amount = emissionSupply - scheduledRemainingSupply - totalEmittedAmount;
   }
 }

--- a/test/governance/Emission.t.sol
+++ b/test/governance/Emission.t.sol
@@ -13,7 +13,6 @@ contract EmissionTest is TestSetup {
   address public emissionTarget;
 
   uint256 public constant NEGLIGIBLE_AMOUNT = 2e18;
-  uint256 public constant TOTAL_EMISSION_SUPPLY = 650_000_000e18;
 
   event TokenContractSet(address newTokenAddress);
   event EmissionTargetSet(address newTargetAddress);
@@ -25,7 +24,7 @@ contract EmissionTest is TestSetup {
 
     emission = new Emission(false);
     vm.prank(owner);
-    emission.initialize(address(mentoToken), emissionTarget, TOTAL_EMISSION_SUPPLY);
+    emission.initialize(address(mentoToken), emissionTarget, EMISSION_SUPPLY);
   }
 
   function test_initialize_shouldSetOwner() public {

--- a/test/governance/Emission.t.sol
+++ b/test/governance/Emission.t.sol
@@ -13,6 +13,7 @@ contract EmissionTest is TestSetup {
   address public emissionTarget;
 
   uint256 public constant NEGLIGIBLE_AMOUNT = 2e18;
+  uint256 public constant TOTAL_EMISSION_SUPPLY = 650_000_000e18;
 
   event TokenContractSet(address newTokenAddress);
   event EmissionTargetSet(address newTargetAddress);
@@ -24,7 +25,7 @@ contract EmissionTest is TestSetup {
 
     emission = new Emission(false);
     vm.prank(owner);
-    emission.initialize(address(mentoToken), emissionTarget);
+    emission.initialize(address(mentoToken), emissionTarget, TOTAL_EMISSION_SUPPLY);
   }
 
   function test_initialize_shouldSetOwner() public {

--- a/test/governance/IntegrationTests/GovernanceIntegration.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.t.sol
@@ -168,6 +168,7 @@ contract GovernanceIntegrationTest is TestSetup {
     assertEq(emission.emissionStartTime(), block.timestamp);
     assertEq(address(emission.mentoToken()), address(mentoToken));
     assertEq(emission.emissionTarget(), address(governanceTimelockAddress));
+    assertEq(emission.emissionSupply(), 650_000_000 * 10**18);
     assertEq(emission.owner(), governanceTimelockAddress);
 
     assertEq(airgrab.root(), merkleRoot);


### PR DESCRIPTION
### Description

We forgot to update hardcoded emission supply in the emission contract after making allocations parametrised. This may cause issues with the emission calculation when the emission supply in the token contract is not equal to the hardcoded emission supply in the emission contract.

This fix removes the hardcoded emission supply, and sets it through init call from the governance factory.

### Other changes

No

### Tested

Fixed unit tests

### Related issues

- Fixes #395 

