### PR TITLE
feat: update airdrop refund address to Mento Treasury

### DIFF
--- a/contracts/governance/Airgrab.sol
+++ b/contracts/governance/Airgrab.sol
@@ -55,8 +55,8 @@ contract Airgrab is ReentrancyGuard {
   IERC20 public immutable token;
   /// @notice The locking contract for veToken.
   ILocking public immutable locking;
-  /// @notice The Celo community fund address where unclaimed tokens will be refunded to.
-  address payable public immutable celoCommunityFund;
+  /// @notice The Mento Treasury address where unclaimed tokens will be refunded to.
+  address payable public immutable mentoTreasury;
 
   /// @notice The map of addresses that have claimed
   mapping(address => bool) public claimed;
@@ -141,7 +141,7 @@ contract Airgrab is ReentrancyGuard {
    * @param slopePeriod_ The slope period that the airgrab will be locked for.
    * @param token_ The token address in the airgrab.
    * @param locking_ The locking contract for veToken.
-   * @param celoCommunityFund_ The Celo community fund address where unclaimed tokens will be refunded to.
+   * @param mentoTreasury_ The Mento Treasury address where unclaimed tokens will be refunded to.
    */
   constructor(
     bytes32 root_,
@@ -152,7 +152,7 @@ contract Airgrab is ReentrancyGuard {
     uint32 slopePeriod_,
     address token_,
     address locking_,
-    address payable celoCommunityFund_
+    address payable mentoTreasury_
   ) {
     require(root_ != bytes32(0), "Airgrab: invalid root");
     require(fractalSigner_ != address(0), "Airgrab: invalid fractal issuer");
@@ -161,7 +161,7 @@ contract Airgrab is ReentrancyGuard {
     require(slopePeriod_ <= MAX_SLOPE_PERIOD, "Airgrab: slope period too large");
     require(token_ != address(0), "Airgrab: invalid token");
     require(locking_ != address(0), "Airgrab: invalid locking");
-    require(celoCommunityFund_ != address(0), "Airgrab: invalid celo community fund");
+    require(mentoTreasury_ != address(0), "Airgrab: invalid Mento Treasury");
 
     root = root_;
     fractalSigner = fractalSigner_;
@@ -171,7 +171,7 @@ contract Airgrab is ReentrancyGuard {
     slopePeriod = slopePeriod_;
     token = IERC20(token_);
     locking = ILocking(locking_);
-    celoCommunityFund = celoCommunityFund_;
+    mentoTreasury = mentoTreasury_;
 
     require(token.approve(locking_, type(uint256).max), "Airgrab: approval failed");
   }
@@ -212,7 +212,7 @@ contract Airgrab is ReentrancyGuard {
   }
 
   /**
-   * @dev Allows the Celo community fund to reclaim any tokens after the airgrab has ended.
+   * @dev Allows the Mento Treasury to reclaim any tokens after the airgrab has ended.
    * @notice This function can only be called after the airgrab has ended.
    * @param tokenToDrain Token is parameterized in case the contract has been sent
    *  tokens other than the airgrab token.
@@ -221,7 +221,7 @@ contract Airgrab is ReentrancyGuard {
     require(block.timestamp > endTimestamp, "Airgrab: not finished");
     uint256 balance = IERC20(tokenToDrain).balanceOf(address(this));
     require(balance > 0, "Airgrab: nothing to drain");
-    IERC20(tokenToDrain).safeTransfer(celoCommunityFund, balance);
+    IERC20(tokenToDrain).safeTransfer(mentoTreasury, balance);
     emit TokensDrained(tokenToDrain, balance);
   }
 }

--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -61,7 +61,6 @@ contract GovernanceFactory is Ownable {
   Locking public locking;
 
   address public watchdogMultiSig;
-  address public celoCommunityFund;
 
   // Indicates if the governance system has been created
   bool public initialized;
@@ -93,7 +92,6 @@ contract GovernanceFactory is Ownable {
   /**
    * @notice Creates and initializes the governance system contracts
    * @param watchdogMultiSig_ Address of the Mento community's multisig wallet with the veto rights
-   * @param celoCommunityFund_ Address of the Celo community fund that will receive the unclaimed airgrab tokens
    * @param airgrabRoot Root hash for the airgrab Merkle tree
    * @param fractalSigner Signer of fractal kyc
    * @param allocationParams Parameters for the initial token allocation
@@ -102,7 +100,6 @@ contract GovernanceFactory is Ownable {
   // solhint-disable-next-line function-max-lines
   function createGovernance(
     address watchdogMultiSig_,
-    address celoCommunityFund_,
     bytes32 airgrabRoot,
     address fractalSigner,
     MentoTokenAllocationParams calldata allocationParams
@@ -112,8 +109,6 @@ contract GovernanceFactory is Ownable {
 
     // slither-disable-next-line missing-zero-check
     watchdogMultiSig = watchdogMultiSig_;
-    // slither-disable-next-line missing-zero-check
-    celoCommunityFund = celoCommunityFund_;
 
     // Precalculated contract addresses:
     address tokenPrecalculated = addressForNonce(2);
@@ -190,7 +185,7 @@ contract GovernanceFactory is Ownable {
       AIRGRAB_LOCK_SLOPE,
       tokenPrecalculated,
       lockingPrecalculated,
-      payable(celoCommunityFund)
+      payable(governanceTimelockPrecalculated)
     );
     assert(address(airgrab) == airgrabPrecalculated);
 

--- a/contracts/governance/deployers/AirgrabDeployerLib.sol
+++ b/contracts/governance/deployers/AirgrabDeployerLib.sol
@@ -15,7 +15,7 @@ library AirgrabDeployerLib {
    * @param airgrabLockSlope The slope duration for the airgrabed tokens in weeks
    * @param token_ The token address in the airgrab.
    * @param locking_ The locking contract for veToken.
-   * @param celoCommunityFund_ The Celo community fund address where unclaimed tokens will be refunded to.
+   * @param mentoTreasury_ The Mento Treasury address where unclaimed tokens will be refunded to.
    * @return Airgrab The address of the new Airgrab contract
    */
   function deploy(
@@ -27,7 +27,7 @@ library AirgrabDeployerLib {
     uint32 airgrabLockSlope,
     address token_,
     address locking_,
-    address payable celoCommunityFund_
+    address payable mentoTreasury_
   ) external returns (Airgrab) {
     return
       new Airgrab(
@@ -39,7 +39,7 @@ library AirgrabDeployerLib {
         airgrabLockSlope,
         token_,
         locking_,
-        celoCommunityFund_
+        mentoTreasury_
       );
   }
 }

--- a/test/governance/Airgrab.t.sol
+++ b/test/governance/Airgrab.t.sol
@@ -37,7 +37,7 @@ contract AirgrabTest is Test {
   Airgrab public airgrab;
   ERC20 public token;
 
-  address payable public celoCommunityFund = payable(makeAddr("CeloCommunityFund"));
+  address payable public mentoTreasury = payable(makeAddr("MentoTreasury"));
   address public fractalSigner;
   uint256 public fractalSignerPk;
   uint256 public otherSignerPk;
@@ -86,7 +86,7 @@ contract AirgrabTest is Test {
       slopePeriod,
       tokenAddress,
       locking,
-      celoCommunityFund
+      mentoTreasury
     );
   }
 
@@ -112,7 +112,7 @@ contract AirgrabTest is Test {
     assertEq(airgrab.slopePeriod(), slopePeriod);
     assertEq(address(airgrab.token()), tokenAddress);
     assertEq(address(airgrab.locking()), locking);
-    assertEq(address(airgrab.celoCommunityFund()), celoCommunityFund);
+    assertEq(address(airgrab.mentoTreasury()), mentoTreasury);
   }
 
   /// @notice Checks the merke root
@@ -157,10 +157,10 @@ contract AirgrabTest is Test {
     c_subject();
   }
 
-  /// @notice Checks the Celo community fund address
-  function test_Constructor_whenInvalidCeloCommunityFund_reverts() public {
-    celoCommunityFund = payable(address(0));
-    vm.expectRevert("Airgrab: invalid celo community fund");
+  /// @notice Checks the Mento Treasury address
+  function test_Constructor_whenInvalidMentoTreasury_reverts() public {
+    mentoTreasury = payable(address(0));
+    vm.expectRevert("Airgrab: invalid Mento Treasury");
     c_subject();
   }
 
@@ -205,18 +205,18 @@ contract AirgrabTest is Test {
     airgrab.drain(tokenAddress);
   }
 
-  /// @notice Drains all tokens to the community fund if the airgrab has ended
+  /// @notice Drains all tokens to the Mento Treasury if the airgrab has ended
   function test_Drain_drains() public d_setUp {
     vm.warp(airgrab.endTimestamp() + 1);
     deal(tokenAddress, address(airgrab), 100e18);
     vm.expectEmit(true, true, true, true);
     emit TokensDrained(tokenAddress, 100e18);
     airgrab.drain(tokenAddress);
-    assertEq(token.balanceOf(celoCommunityFund), 100e18);
+    assertEq(token.balanceOf(mentoTreasury), 100e18);
     assertEq(token.balanceOf(address(airgrab)), 0);
   }
 
-  /// @notice Drains all arbitrary tokens to the Celo community fund if the airgrab has ended
+  /// @notice Drains all arbitrary tokens to the Mento Treasury fund if the airgrab has ended
   function test_Drain_drainsOtherTokens() public d_setUp {
     ERC20 otherToken = new ERC20("Other Token", "OTT");
 
@@ -227,7 +227,7 @@ contract AirgrabTest is Test {
     emit TokensDrained(address(otherToken), 100e18);
     airgrab.drain(address(otherToken));
 
-    assertEq(otherToken.balanceOf(celoCommunityFund), 100e18);
+    assertEq(otherToken.balanceOf(mentoTreasury), 100e18);
     assertEq(otherToken.balanceOf(address(airgrab)), 0);
   }
 

--- a/test/governance/GovernanceFactory.t.sol
+++ b/test/governance/GovernanceFactory.t.sol
@@ -17,7 +17,6 @@ contract GovernanceFactoryTest is TestSetup {
 
   address public mentoLabsMultiSig = makeAddr("MentoLabsVestingMultisig");
   address public watchdogMultiSig = makeAddr("WatchdogMultisig");
-  address public celoCommunityFund = makeAddr("CeloCommunityFund");
   address public fractalSigner = makeAddr("FractalSigner");
 
   bytes32 public airgrabMerkleRoot = 0x945d83ced94efc822fed712b4c4694b4e1129607ec5bbd2ab971bb08dca4d809; // Mock root
@@ -43,7 +42,7 @@ contract GovernanceFactoryTest is TestSetup {
         additionalAllocationAmounts: Arrays.uints(200)
       });
 
-    factory.createGovernance(watchdogMultiSig, celoCommunityFund, airgrabMerkleRoot, fractalSigner, allocationParams);
+    factory.createGovernance(watchdogMultiSig, airgrabMerkleRoot, fractalSigner, allocationParams);
   }
 
   // ========================================
@@ -112,7 +111,7 @@ contract GovernanceFactoryTest is TestSetup {
       });
 
     vm.prank(owner);
-    factory.createGovernance(watchdogMultiSig, celoCommunityFund, airgrabMerkleRoot, fractalSigner, allocationParams);
+    factory.createGovernance(watchdogMultiSig, airgrabMerkleRoot, fractalSigner, allocationParams);
 
     assertEq(factory.mentoToken().balanceOf(makeAddr("Recipient1")), (supply * 55) / 1000);
     assertEq(factory.mentoToken().balanceOf(makeAddr("Recipient2")), (supply * 50) / 1000);

--- a/test/governance/IntegrationTests/GovernanceIntegration.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.t.sol
@@ -40,7 +40,6 @@ contract GovernanceIntegrationTest is TestSetup {
   Locking public locking;
 
   address public celoGovernance = makeAddr("CeloGovernance");
-  address public celoCommunityFund = makeAddr("CeloCommunityFund");
   address public watchdogMultisig = makeAddr("WatchdogMultisig");
 
   GnosisSafe public safeSingleton;
@@ -135,7 +134,7 @@ contract GovernanceIntegrationTest is TestSetup {
     factory = new GovernanceFactory(celoGovernance);
 
     vm.prank(celoGovernance);
-    factory.createGovernance(watchdogMultisig, celoCommunityFund, merkleRoot, fractalSigner, allocationParams);
+    factory.createGovernance(watchdogMultisig, merkleRoot, fractalSigner, allocationParams);
     proxyAdmin = factory.proxyAdmin();
     mentoToken = factory.mentoToken();
     emission = factory.emission();
@@ -179,7 +178,7 @@ contract GovernanceIntegrationTest is TestSetup {
     assertEq(airgrab.cliffPeriod(), 0);
     assertEq(address(airgrab.token()), address(mentoToken));
     assertEq(address(airgrab.locking()), address(locking));
-    assertEq(address(airgrab.celoCommunityFund()), address(celoCommunityFund));
+    assertEq(address(airgrab.mentoTreasury()), address(governanceTimelockAddress));
 
     bytes32 proposerRole = governanceTimelock.PROPOSER_ROLE();
     bytes32 executorRole = governanceTimelock.EXECUTOR_ROLE();

--- a/test/governance/IntegrationTests/LockingIntegration.fuzz.t.sol
+++ b/test/governance/IntegrationTests/LockingIntegration.fuzz.t.sol
@@ -27,7 +27,6 @@ contract FuzzLockingIntegrationTest is TestSetup {
   Locking public locking;
 
   address public celoGovernance = makeAddr("CeloGovernance");
-  address public celoCommunityFund = makeAddr("CeloCommunityFund");
   address public watchdogMultisig = makeAddr("WatchdogMultisig");
   address public mentoLabsMultisig = makeAddr("MentoLabsMultisig");
   address public fractalSigner = makeAddr("FractalSigner");
@@ -50,7 +49,7 @@ contract FuzzLockingIntegrationTest is TestSetup {
       });
 
     vm.prank(celoGovernance);
-    factory.createGovernance(watchdogMultisig, celoCommunityFund, merkleRoot, fractalSigner, allocationParams);
+    factory.createGovernance(watchdogMultisig, merkleRoot, fractalSigner, allocationParams);
     mentoToken = factory.mentoToken();
     governanceTimelock = factory.governanceTimelock();
     locking = factory.locking();


### PR DESCRIPTION
### Description

this Pr updates the airgrab contract + the GovernanceFactory to use the governanceTimelock(Mento Treasury) instead of the celo community fund for the refund address of unclaimed airgrab tokens.  

Will open a Pr for the deployment repo changes once this Pr is merged. 

### Other changes

updated tests to test the new behavior 

### Tested


### Related issues

- Fixes #401 

### Backwards compatibility


### Documentation

wasn't able to find where the Mento Governance Diagram comes from will update the diagram once i know 
