### PR TITLE
fix: remove setStartingPointWeek

### DIFF
--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -137,10 +137,6 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    * @dev set newMinSlopePeriod
    */
   event SetMinSlopePeriod(uint256 indexed newMinSlopePeriod);
-  /**
-   * @dev set startingPointWeek
-   */
-  event SetStartingPointWeek(uint256 indexed newStartingPointWeek);
 
   /**
    * @dev Initializes the contract with token, starting point week, and minimum cliff and slope periods.
@@ -311,17 +307,6 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    */
   function getBlockNumber() internal view virtual returns (uint32) {
     return uint32(block.number);
-  }
-
-  /**
-   * @notice Sets the starting point for the week-based time system
-   * @param newStartingPointWeek new starting point
-   */
-  function setStartingPointWeek(uint32 newStartingPointWeek) public notStopped onlyOwner {
-    require(newStartingPointWeek < roundTimestamp(getBlockNumber()), "wrong newStartingPointWeek");
-    startingPointWeek = newStartingPointWeek;
-
-    emit SetStartingPointWeek(newStartingPointWeek);
   }
 
   /**


### PR DESCRIPTION
### Description

This removes the `setStartingPointWeek` function since it no longer will be used anyhow after we removed the migration related code.

### Related issues

- Fixes https://github.com/mento-protocol/mento-core/issues/408
