### PR TITLE
fix: update airgrab duration

### DIFF
--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -68,7 +68,7 @@ contract GovernanceFactory is Ownable {
   // Airgrab configuration
   uint32 public constant AIRGRAB_LOCK_SLOPE = 104; // Slope duration for the airgrabbed tokens in weeks
   uint32 public constant AIRGRAB_LOCK_CLIFF = 0; // Cliff duration for the airgrabbed tokens in weeks
-  uint256 public constant AIRGRAB_DURATION = 365 days;
+  uint256 public constant AIRGRAB_DURATION = 8 weeks;
   uint256 public constant FRACTAL_MAX_AGE = 180 days; // Maximum age of the kyc for the airgrab
   uint256 public airgrabEnds;
 

--- a/test/governance/IntegrationTests/GovernanceIntegration.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.t.sol
@@ -174,7 +174,7 @@ contract GovernanceIntegrationTest is TestSetup {
     assertEq(airgrab.root(), merkleRoot);
     assertEq(airgrab.fractalSigner(), fractalSigner);
     assertEq(airgrab.fractalMaxAge(), 180 days);
-    assertEq(airgrab.endTimestamp(), block.timestamp + 365 days);
+    assertEq(airgrab.endTimestamp(), block.timestamp + 8 weeks);
     assertEq(airgrab.slopePeriod(), 104);
     assertEq(airgrab.cliffPeriod(), 0);
     assertEq(address(airgrab.token()), address(mentoToken));


### PR DESCRIPTION
### Description

This updates the airgrab duration to `8 weeks` (confirmed with @olenovyk that this will be exactly 56 days).

Note: the slither issues are not from this PR so please ignore those in the meantime. We'll fix those once we merge https://github.com/mento-protocol/mento-core/tree/fix-contest-findings-fixes-review into develop.

### Tested

Updated the existing unit tests and it will also be covered by integration tests + deployment checks 

### Related issues

Related to https://github.com/mento-protocol/mento-core/issues/405