### PR TITLE
fix: update airgrab duration to 10 weeks

### DIFF
--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -68,7 +68,7 @@ contract GovernanceFactory is Ownable {
   // Airgrab configuration
   uint32 public constant AIRGRAB_LOCK_SLOPE = 104; // Slope duration for the airgrabbed tokens in weeks
   uint32 public constant AIRGRAB_LOCK_CLIFF = 0; // Cliff duration for the airgrabbed tokens in weeks
-  uint256 public constant AIRGRAB_DURATION = 8 weeks;
+  uint256 public constant AIRGRAB_DURATION = 10 weeks;
   uint256 public constant FRACTAL_MAX_AGE = 180 days; // Maximum age of the kyc for the airgrab
   uint256 public airgrabEnds;
 

--- a/test/governance/IntegrationTests/GovernanceIntegration.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.t.sol
@@ -174,7 +174,7 @@ contract GovernanceIntegrationTest is TestSetup {
     assertEq(airgrab.root(), merkleRoot);
     assertEq(airgrab.fractalSigner(), fractalSigner);
     assertEq(airgrab.fractalMaxAge(), 180 days);
-    assertEq(airgrab.endTimestamp(), block.timestamp + 8 weeks);
+    assertEq(airgrab.endTimestamp(), block.timestamp + 10 weeks);
     assertEq(airgrab.slopePeriod(), 104);
     assertEq(airgrab.cliffPeriod(), 0);
     assertEq(address(airgrab.token()), address(mentoToken));


### PR DESCRIPTION
### Description

There was a bit of back and forth on this and at the end it was decided that the airgrab duration will be increased to 10 weeks (from the current 8 weeks).

### Tested

Updated the existing unit tests

### Related issues

- Fixes https://github.com/mento-protocol/mento-core/issues/417

### Backwards compatibility