### PR TITLE
feat: update proposal threshold

### DIFF
--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -78,7 +78,7 @@ contract GovernanceFactory is Ownable {
   // Governor configuration
   uint256 public constant GOVERNOR_VOTING_DELAY = 0; // Delay time in blocks between proposal creation and the start of voting.
   uint256 public constant GOVERNOR_VOTING_PERIOD = 120_960; // Voting period in blocks for the governor (7 days in blocks CELO)
-  uint256 public constant GOVERNOR_PROPOSAL_THRESHOLD = 1_000e18;
+  uint256 public constant GOVERNOR_PROPOSAL_THRESHOLD = 10_000e18;
   uint256 public constant GOVERNOR_QUORUM = 2; // Quorum percentage for the governor
 
   /**

--- a/test/governance/IntegrationTests/GovernanceIntegration.gas.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.gas.t.sol
@@ -53,7 +53,7 @@ contract GovernanceGasTest is TestSetup {
     mentoToken.transfer(bob, 100_000e18);
 
     vm.prank(alice);
-    locking.lock(alice, alice, 2000e18, 1, 103);
+    locking.lock(alice, alice, 20_000e18, 1, 103);
 
     vm.prank(bob);
     locking.lock(bob, bob, 1500e18, 1, 103);

--- a/test/governance/IntegrationTests/GovernanceIntegration.t.sol
+++ b/test/governance/IntegrationTests/GovernanceIntegration.t.sol
@@ -74,7 +74,7 @@ contract GovernanceIntegrationTest is TestSetup {
     mentoToken.transfer(bob, 10_000e18);
 
     vm.prank(alice);
-    locking.lock(alice, alice, 2000e18, 1, 103);
+    locking.lock(alice, alice, 10_000e18, 1, 103);
 
     vm.prank(bob);
     locking.lock(bob, bob, 1500e18, 1, 103);
@@ -194,7 +194,7 @@ contract GovernanceIntegrationTest is TestSetup {
     assertEq(address(mentoGovernor.token()), address(locking));
     assertEq(mentoGovernor.votingDelay(), 0);
     assertEq(mentoGovernor.votingPeriod(), BLOCKS_WEEK);
-    assertEq(mentoGovernor.proposalThreshold(), 1_000e18);
+    assertEq(mentoGovernor.proposalThreshold(), 10_000e18);
     assertEq(mentoGovernor.quorumNumerator(), 2);
     assertEq(mentoGovernor.timelock(), governanceTimelockAddress);
 
@@ -281,7 +281,7 @@ contract GovernanceIntegrationTest is TestSetup {
   function test_governor_whenUsedByLockedAccounts_shouldUpdateSettings() public s_governance {
     uint256 newVotingDelay = BLOCKS_DAY;
     uint256 newVotingPeriod = 2 * BLOCKS_WEEK;
-    uint256 newThreshold = 5000e18;
+    uint256 newThreshold = 50_000e18;
     uint256 newQuorum = 10; //10%
     uint256 newMinDelay = 3 days;
     uint32 newMinCliff = 6;
@@ -468,7 +468,7 @@ contract GovernanceIntegrationTest is TestSetup {
 
     // governanceTimelockAddress distrubutes tokens to users
     vm.prank(governanceTimelockAddress);
-    mentoToken.transfer(alice, 5000e18);
+    mentoToken.transfer(alice, 50_000e18);
 
     vm.prank(governanceTimelockAddress);
     mentoToken.transfer(bob, 5000e18);
@@ -478,7 +478,7 @@ contract GovernanceIntegrationTest is TestSetup {
 
     // users lock tokens
     vm.prank(alice);
-    locking.lock(alice, alice, 5000e18, 20, 10);
+    locking.lock(alice, alice, 50_000e18, 20, 10);
 
     vm.prank(bob);
     locking.lock(bob, bob, 5000e18, 40, 10);


### PR DESCRIPTION
### Description

While going through governance config, we decided it will be better to start with a higher proposal threshold to prevent spam and decided 10_000 veMENTO would be a good start.

There is another PR that updates the threshold in post deployment checks:
https://github.com/mento-protocol/mento-deployment/pull/183

Fork tests will be fixed once we have a new deployment.

### Other changes

No

### Tested

Updated some tests with larger lock amounts to pass the new threshold

### Related issues

- Fixes #430 
