### PR TITLE
fix: add nativeUSDT to collateral assets

### DIFF
--- a/test/fork-tests/BaseForkTest.t.sol
+++ b/test/fork-tests/BaseForkTest.t.sol
@@ -126,8 +126,8 @@ contract BaseForkTest is Test, TokenHelpers, TestAsserts {
     }
     require(exchanges.length > 0, "No exchanges found");
 
-    // The number of collateral assets 4 is hardcoded here [CELO, AxelarUSDC, EUROC, NativeUSDC]
-    for (uint256 i = 0; i < 4; i++) {
+    // The number of collateral assets 5 is hardcoded here [CELO, AxelarUSDC, EUROC, NativeUSDC, NativeUSDT]
+    for (uint256 i = 0; i < 5; i++) {
       address collateralAsset = reserve.collateralAssets(i);
       mint(collateralAsset, address(reserve), Utils.toSubunits(25_000_000, collateralAsset));
       console.log("Minting 25mil %s to reserve", IERC20Metadata(collateralAsset).symbol());


### PR DESCRIPTION
### Description

This modifies the list of hardcoded collateral assets to add USDT so that the fork-tests pass after MU06.

### Other changes

N/A

### Tested

MU06 is deployed on Baklava and fork tests are green
```bash
Ran 18 tests for test/fork-tests/EnvForkTest.t.sol:BaklavaForkTest
[PASS] test_biPoolManagerCanNotBeReinitialized() (gas: 38850)
[PASS] test_brokerCanNotBeReinitialized() (gas: 19360)
[PASS] test_circuitBreaker_breaks() (gas: 120622552)
[PASS] test_circuitBreaker_haltsTrading() (gas: 132297226)
[PASS] test_circuitBreaker_rateFeedsAreProtected() (gas: 1152356)
[PASS] test_circuitBreaker_recovers() (gas: 42665936)
[PASS] test_rateFeedDependencies_haltsDependantTrading() (gas: 52617076)
[PASS] test_reserveCanNotBeReinitialized() (gas: 19309)
[PASS] test_sortedOraclesCanNotBeReinitialized() (gas: 16489)
[PASS] test_stableTokensCanNotBeReinitialized() (gas: 107759)
[PASS] test_swapsHappenInBothDirections() (gas: 8191594)
[PASS] test_tradingLimitsAreConfigured() (gas: 830239)
[PASS] test_tradingLimitsAreEnforced_0to1_L0() (gas: 7855300)
[PASS] test_tradingLimitsAreEnforced_0to1_L1() (gas: 62302065)
[PASS] test_tradingLimitsAreEnforced_0to1_LG() (gas: 83788067)
[PASS] test_tradingLimitsAreEnforced_1to0_L0() (gas: 7518865)
[PASS] test_tradingLimitsAreEnforced_1to0_L1() (gas: 60619063)
[PASS] test_tradingLimitsAreEnforced_1to0_LG() (gas: 67033544)
Suite result: ok. 18 passed; 0 failed; 0 skipped; finished in 117.52s (689.71s CPU time)

Ran 1 test suite in 117.67s (117.52s CPU time): 18 tests passed, 0 failed, 0 skipped (18 total tests)
✨  Done in 143.50s.
```
