### PR TITLE
chore: reduce CI foundry test verbosity

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,7 @@ via_ir = true
 
 [profile.ci]
 fuzz_runs = 1_000
-verbosity = 4
+verbosity = 3
 
 [profile.fork-tests]
 no_match_contract = "_random" # in order to reset the no_match_contract


### PR DESCRIPTION
### Description

The verbosity setting for CI tests was set to `4`, which outputs full stack traces for all (even passed) tests. This leads to extremely verbose output that doesn't get fully displayed in GitHub UI (need to download a 52MB, 350k line log file). This makes it more time consuming to pinpoint what specific tests are causing the workflow to fail. [Example](https://github.com/mento-protocol/mento-core/actions/runs/9779856065/job/27000074200?pr=456).

I propose we set verbosity to `3`, which should still output stack traces for failing tests. The one thing missing will be setup traces for failing tests, but this should still be a quality of life improvement.

### Other changes

Nothing, this is a one byte change.

### Tested

Will need to look at CI output for this PR.