### PR TITLE
feat: Add relayerDeployer ACL role to the factory

### DIFF
--- a/contracts/interfaces/IChainlinkRelayerFactory.sol
+++ b/contracts/interfaces/IChainlinkRelayerFactory.sol
@@ -20,15 +20,26 @@ interface IChainlinkRelayerFactory {
   );
 
   /**
+   * @notice Emitted when the relayer deployer is updated.
+   * @param newRelayerDeployer Address of the new relayer deployer.
+   * @param oldRelayerDeployer Address of the old relayer deployer.
+   */
+  event RelayerDeployerUpdated(address indexed newRelayerDeployer, address indexed oldRelayerDeployer);
+
+  /**
    * @notice Emitted when a relayer is removed.
    * @param relayerAddress Address of the removed relayer.
    * @param rateFeedId Rate feed ID for which the relayer reported.
    */
   event RelayerRemoved(address indexed relayerAddress, address indexed rateFeedId);
 
-  function initialize(address _sortedOracles) external;
+  function initialize(address _sortedOracles, address _relayerDeployer) external;
 
   function sortedOracles() external returns (address);
+
+  function setRelayerDeployer(address _relayerDeployer) external;
+
+  function relayerDeployer() external returns (address);
 
   function deployRelayer(
     address rateFeedId,

--- a/contracts/oracles/ChainlinkRelayerFactory.sol
+++ b/contracts/oracles/ChainlinkRelayerFactory.sol
@@ -61,7 +61,7 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
 
   /// @notice Modifier to restrict a function to the deployer.
   modifier onlyDeployer() {
-    if (msg.sender != relayerDeployer) {
+    if (msg.sender != relayerDeployer && msg.sender != owner()) {
       revert NotAllowed();
     }
     _;
@@ -93,11 +93,12 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
 
   /**
    * @notice Sets the address of the relayer deployer.
-   * @param _relayerDeployer The address of the relayer deployer.
+   * @param newRelayerDeployer The address of the relayer deployer.
    */
-  function setRelayerDeployer(address _relayerDeployer) external onlyOwner {
-    emit RelayerDeployerUpdated(_relayerDeployer, relayerDeployer);
-    relayerDeployer = _relayerDeployer;
+  function setRelayerDeployer(address newRelayerDeployer) external onlyOwner {
+    address oldRelayerDeployer = relayerDeployer;
+    relayerDeployer = newRelayerDeployer;
+    emit RelayerDeployerUpdated(newRelayerDeployer, oldRelayerDeployer);
   }
 
   /**

--- a/contracts/oracles/ChainlinkRelayerFactory.sol
+++ b/contracts/oracles/ChainlinkRelayerFactory.sol
@@ -24,6 +24,11 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
   address[] public rateFeeds;
 
   /**
+   * @notice Account that is allowed to deploy relayers.
+   */
+  address public relayerDeployer;
+
+  /**
    * @notice Thrown when trying to deploy a relayer to an address that already has code.
    * @param contractAddress Address at which the relayer could not be deployed.
    * @param rateFeedId Rate feed ID for which the relayer would have reported.
@@ -51,6 +56,17 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
    */
   error NoRelayerForRateFeedId(address rateFeedId);
 
+  /// @notice Thrown when a non-deployer tries to call a deployer-only function.
+  error NotAllowed();
+
+  /// @notice Modifier to restrict a function to the deployer.
+  modifier onlyDeployer() {
+    if (msg.sender != relayerDeployer) {
+      revert NotAllowed();
+    }
+    _;
+  }
+
   /**
    * @notice Constructor for the logic contract.
    * @param disable If `true`, disables the initializer.
@@ -69,9 +85,19 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
    * @notice Initializes the factory.
    * @param _sortedOracles The SortedOracles instance deployed relayers should report to.
    */
-  function initialize(address _sortedOracles) external initializer {
+  function initialize(address _sortedOracles, address _relayerDeployer) external initializer {
     __Ownable_init();
     sortedOracles = _sortedOracles;
+    relayerDeployer = _relayerDeployer;
+  }
+
+  /**
+   * @notice Sets the address of the relayer deployer.
+   * @param _relayerDeployer The address of the relayer deployer.
+   */
+  function setRelayerDeployer(address _relayerDeployer) external onlyOwner {
+    emit RelayerDeployerUpdated(_relayerDeployer, relayerDeployer);
+    relayerDeployer = _relayerDeployer;
   }
 
   /**
@@ -87,7 +113,7 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
     address rateFeedId,
     string calldata rateFeedDescription,
     IChainlinkRelayer.ChainlinkAggregator[] calldata aggregators
-  ) public onlyOwner returns (address relayerAddress) {
+  ) public onlyDeployer returns (address relayerAddress) {
     if (address(deployedRelayers[rateFeedId]) != address(0)) {
       revert RelayerForFeedExists(rateFeedId);
     }
@@ -121,7 +147,7 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
    * @notice Removes a relayer from the list of deployed relayers.
    * @param rateFeedId The rate feed whose relayer should be removed.
    */
-  function removeRelayer(address rateFeedId) public onlyOwner {
+  function removeRelayer(address rateFeedId) public onlyDeployer {
     address relayerAddress = address(deployedRelayers[rateFeedId]);
 
     if (relayerAddress == address(0)) {
@@ -156,7 +182,7 @@ contract ChainlinkRelayerFactory is IChainlinkRelayerFactory, OwnableUpgradeable
     address rateFeedId,
     string calldata rateFeedDescription,
     IChainlinkRelayer.ChainlinkAggregator[] calldata aggregators
-  ) external onlyOwner returns (address relayerAddress) {
+  ) external onlyDeployer returns (address relayerAddress) {
     removeRelayer(rateFeedId);
     return deployRelayer(rateFeedId, rateFeedDescription, aggregators);
   }

--- a/test/integration/ChainlinkRelayerIntegration.t.sol
+++ b/test/integration/ChainlinkRelayerIntegration.t.sol
@@ -35,7 +35,7 @@ contract ChainlinkRelayerIntegration is IntegrationTest {
         abi.encode(
           address(relayerFactoryImplementation),
           address(proxyAdmin),
-          abi.encodeWithSignature("initialize(address)", address(sortedOracles))
+          abi.encodeWithSignature("initialize(address,address)", address(sortedOracles), owner)
         )
       )
     );
@@ -82,7 +82,7 @@ contract ChainlinkRelayerIntegration_ProxySetup is ChainlinkRelayerIntegration {
 
   function test_implementationNotInitializable() public {
     vm.expectRevert("Initializable: contract is already initialized");
-    relayerFactoryImplementation.initialize(address(sortedOracles));
+    relayerFactoryImplementation.initialize(address(sortedOracles), address(this));
   }
 }
 
@@ -180,11 +180,11 @@ contract ChainlinkRelayerIntegration_CircuitBreakerInteraction is ChainlinkRelay
     address[] memory rateFeeds = new address[](1);
     rateFeeds[0] = rateFeedId;
     uint256[] memory thresholds = new uint256[](1);
-    thresholds[0] = 10**23; // 10%
+    thresholds[0] = 10 ** 23; // 10%
     uint256[] memory cooldownTimes = new uint256[](1);
     cooldownTimes[0] = 1 minutes;
     uint256[] memory referenceValues = new uint256[](1);
-    referenceValues[0] = 10**24;
+    referenceValues[0] = 10 ** 24;
 
     vm.startPrank(deployer);
     valueDeltaBreaker.setRateChangeThresholds(rateFeeds, thresholds);
@@ -202,56 +202,56 @@ contract ChainlinkRelayerIntegration_CircuitBreakerInteraction is ChainlinkRelay
   }
 
   function test_passesPriceFromAggregatorToSortedOracles() public {
-    chainlinkAggregator.setRoundData(10**8, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(10 ** 8, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 10**24);
-    assertEq(denominator, 10**24);
+    assertEq(price, 10 ** 24);
+    assertEq(denominator, 10 ** 24);
     assertEq(uint256(tradingMode), 0);
   }
 
   function test_whenPriceBeyondThresholdIsRelayed_breakerShouldTrigger() public {
-    chainlinkAggregator.setRoundData(12 * 10**7, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(12 * 10 ** 7, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 12 * 10**23);
-    assertEq(denominator, 10**24);
+    assertEq(price, 12 * 10 ** 23);
+    assertEq(denominator, 10 ** 24);
     assertEq(uint256(tradingMode), 3);
   }
 
   function test_whenPriceBeyondThresholdIsRelayedThenRecovers_breakerShouldTriggerThenRecover() public {
-    chainlinkAggregator.setRoundData(12 * 10**7, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(12 * 10 ** 7, block.timestamp - 1);
     chainlinkRelayer.relay();
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
     assertEq(uint256(tradingMode), 3);
 
     vm.warp(now + 1 minutes + 1);
 
-    chainlinkAggregator.setRoundData(105 * 10**6, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(105 * 10 ** 6, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 105 * 10**22);
-    assertEq(denominator, 10**24);
+    assertEq(price, 105 * 10 ** 22);
+    assertEq(denominator, 10 ** 24);
     assertEq(uint256(tradingMode), 0);
   }
 
   function test_whenPriceBeyondThresholdIsRelayedAndCooldownIsntReached_breakerShouldTriggerAndNotRecover() public {
-    chainlinkAggregator.setRoundData(12 * 10**7, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(12 * 10 ** 7, block.timestamp - 1);
     chainlinkRelayer.relay();
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
     assertEq(uint256(tradingMode), 3);
 
     vm.warp(now + 1 minutes - 1);
 
-    chainlinkAggregator.setRoundData(105 * 10**6, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(105 * 10 ** 6, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 105 * 10**22);
-    assertEq(denominator, 10**24);
+    assertEq(price, 105 * 10 ** 22);
+    assertEq(denominator, 10 ** 24);
     assertEq(uint256(tradingMode), 3);
   }
 }

--- a/test/integration/ChainlinkRelayerIntegration.t.sol
+++ b/test/integration/ChainlinkRelayerIntegration.t.sol
@@ -180,11 +180,11 @@ contract ChainlinkRelayerIntegration_CircuitBreakerInteraction is ChainlinkRelay
     address[] memory rateFeeds = new address[](1);
     rateFeeds[0] = rateFeedId;
     uint256[] memory thresholds = new uint256[](1);
-    thresholds[0] = 10 ** 23; // 10%
+    thresholds[0] = 10**23; // 10%
     uint256[] memory cooldownTimes = new uint256[](1);
     cooldownTimes[0] = 1 minutes;
     uint256[] memory referenceValues = new uint256[](1);
-    referenceValues[0] = 10 ** 24;
+    referenceValues[0] = 10**24;
 
     vm.startPrank(deployer);
     valueDeltaBreaker.setRateChangeThresholds(rateFeeds, thresholds);
@@ -202,56 +202,56 @@ contract ChainlinkRelayerIntegration_CircuitBreakerInteraction is ChainlinkRelay
   }
 
   function test_passesPriceFromAggregatorToSortedOracles() public {
-    chainlinkAggregator.setRoundData(10 ** 8, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(10**8, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 10 ** 24);
-    assertEq(denominator, 10 ** 24);
+    assertEq(price, 10**24);
+    assertEq(denominator, 10**24);
     assertEq(uint256(tradingMode), 0);
   }
 
   function test_whenPriceBeyondThresholdIsRelayed_breakerShouldTrigger() public {
-    chainlinkAggregator.setRoundData(12 * 10 ** 7, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(12 * 10**7, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 12 * 10 ** 23);
-    assertEq(denominator, 10 ** 24);
+    assertEq(price, 12 * 10**23);
+    assertEq(denominator, 10**24);
     assertEq(uint256(tradingMode), 3);
   }
 
   function test_whenPriceBeyondThresholdIsRelayedThenRecovers_breakerShouldTriggerThenRecover() public {
-    chainlinkAggregator.setRoundData(12 * 10 ** 7, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(12 * 10**7, block.timestamp - 1);
     chainlinkRelayer.relay();
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
     assertEq(uint256(tradingMode), 3);
 
     vm.warp(now + 1 minutes + 1);
 
-    chainlinkAggregator.setRoundData(105 * 10 ** 6, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(105 * 10**6, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 105 * 10 ** 22);
-    assertEq(denominator, 10 ** 24);
+    assertEq(price, 105 * 10**22);
+    assertEq(denominator, 10**24);
     assertEq(uint256(tradingMode), 0);
   }
 
   function test_whenPriceBeyondThresholdIsRelayedAndCooldownIsntReached_breakerShouldTriggerAndNotRecover() public {
-    chainlinkAggregator.setRoundData(12 * 10 ** 7, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(12 * 10**7, block.timestamp - 1);
     chainlinkRelayer.relay();
     uint8 tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
     assertEq(uint256(tradingMode), 3);
 
     vm.warp(now + 1 minutes - 1);
 
-    chainlinkAggregator.setRoundData(105 * 10 ** 6, block.timestamp - 1);
+    chainlinkAggregator.setRoundData(105 * 10**6, block.timestamp - 1);
     chainlinkRelayer.relay();
     (uint256 price, uint256 denominator) = sortedOracles.medianRate(rateFeedId);
     tradingMode = breakerBox.getRateFeedTradingMode(rateFeedId);
-    assertEq(price, 105 * 10 ** 22);
-    assertEq(denominator, 10 ** 24);
+    assertEq(price, 105 * 10**22);
+    assertEq(denominator, 10**24);
     assertEq(uint256(tradingMode), 3);
   }
 }

--- a/test/oracles/ChainlinkRelayerFactory.t.sol
+++ b/test/oracles/ChainlinkRelayerFactory.t.sol
@@ -37,9 +37,11 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
   event RelayerRemoved(address indexed relayerAddress, address indexed rateFeedId);
   event RelayerDeployerUpdated(address indexed newRelayerDeployer, address indexed oldRelayerDeployer);
 
-  function oneAggregator(
-    uint256 aggregatorIndex
-  ) internal view returns (IChainlinkRelayer.ChainlinkAggregator[] memory aggregators) {
+  function oneAggregator(uint256 aggregatorIndex)
+    internal
+    view
+    returns (IChainlinkRelayer.ChainlinkAggregator[] memory aggregators)
+  {
     aggregators = new IChainlinkRelayer.ChainlinkAggregator[](1);
     aggregators[0] = IChainlinkRelayer.ChainlinkAggregator(mockAggregators[aggregatorIndex], false);
   }
@@ -88,10 +90,11 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
       );
   }
 
-  function contractAlreadyExistsError(
-    address relayerAddress,
-    address rateFeedId
-  ) public pure returns (bytes memory ContractAlreadyExistsError) {
+  function contractAlreadyExistsError(address relayerAddress, address rateFeedId)
+    public
+    pure
+    returns (bytes memory ContractAlreadyExistsError)
+  {
     return abi.encodeWithSignature("ContractAlreadyExists(address,address)", relayerAddress, rateFeedId);
   }
 

--- a/test/oracles/ChainlinkRelayerFactory.t.sol
+++ b/test/oracles/ChainlinkRelayerFactory.t.sol
@@ -12,7 +12,9 @@ import { ChainlinkRelayerFactory } from "contracts/oracles/ChainlinkRelayerFacto
 contract ChainlinkRelayerFactoryTest is BaseTest {
   IChainlinkRelayerFactory relayerFactory;
   address owner = makeAddr("owner");
+  address relayerDeployer = makeAddr("relayerDeployer");
   address nonOwner = makeAddr("nonOwner");
+  address nonDeployer = makeAddr("nonDeployer");
   address mockSortedOracles = makeAddr("sortedOracles");
   address[4] mockAggregators = [
     makeAddr("aggregator1"),
@@ -24,6 +26,8 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
   address aRateFeed = rateFeeds[0];
   string aRateFeedDescription = "CELO/USD";
 
+  bytes constant NOT_ALLOWED = abi.encodeWithSignature("NotAllowed()");
+
   event RelayerDeployed(
     address indexed relayerAddress,
     address indexed rateFeedId,
@@ -31,12 +35,11 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
     IChainlinkRelayer.ChainlinkAggregator[] aggregators
   );
   event RelayerRemoved(address indexed relayerAddress, address indexed rateFeedId);
+  event RelayerDeployerUpdated(address indexed newRelayerDeployer, address indexed oldRelayerDeployer);
 
-  function oneAggregator(uint256 aggregatorIndex)
-    internal
-    view
-    returns (IChainlinkRelayer.ChainlinkAggregator[] memory aggregators)
-  {
+  function oneAggregator(
+    uint256 aggregatorIndex
+  ) internal view returns (IChainlinkRelayer.ChainlinkAggregator[] memory aggregators) {
     aggregators = new IChainlinkRelayer.ChainlinkAggregator[](1);
     aggregators[0] = IChainlinkRelayer.ChainlinkAggregator(mockAggregators[aggregatorIndex], false);
   }
@@ -52,7 +55,7 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
   function setUp() public virtual {
     relayerFactory = IChainlinkRelayerFactory(new ChainlinkRelayerFactory(false));
     vm.prank(owner);
-    relayerFactory.initialize(mockSortedOracles);
+    relayerFactory.initialize(mockSortedOracles, relayerDeployer);
   }
 
   function expectedRelayerAddress(
@@ -85,11 +88,10 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
       );
   }
 
-  function contractAlreadyExistsError(address relayerAddress, address rateFeedId)
-    public
-    pure
-    returns (bytes memory ContractAlreadyExistsError)
-  {
+  function contractAlreadyExistsError(
+    address relayerAddress,
+    address rateFeedId
+  ) public pure returns (bytes memory ContractAlreadyExistsError) {
     return abi.encodeWithSignature("ContractAlreadyExists(address,address)", relayerAddress, rateFeedId);
   }
 
@@ -129,6 +131,25 @@ contract ChainlinkRelayerFactoryTest_transferOwnership is ChainlinkRelayerFactor
   }
 }
 
+contract ChainlinkRelayerFactoryTest_setRelayerDeployer is ChainlinkRelayerFactoryTest {
+  function test_setRelayerDeployer() public {
+    address newDeployer = makeAddr("newDeployer");
+    vm.expectEmit(true, true, false, false, address(relayerFactory));
+    emit RelayerDeployerUpdated({ newRelayerDeployer: newDeployer, oldRelayerDeployer: relayerDeployer });
+    vm.prank(owner);
+    relayerFactory.setRelayerDeployer(newDeployer);
+    address realRelayerDeployer = relayerFactory.relayerDeployer();
+    assertEq(realRelayerDeployer, newDeployer);
+  }
+
+  function test_failsWhenCalledByNonOwner() public {
+    address newDeployer = makeAddr("newDeployer");
+    vm.prank(nonOwner);
+    vm.expectRevert("Ownable: caller is not the owner");
+    relayerFactory.setRelayerDeployer(newDeployer);
+  }
+}
+
 contract ChainlinkRelayerFactoryTest_renounceOwnership is ChainlinkRelayerFactoryTest {
   function test_setsOwnerToZeroAddress() public {
     vm.prank(owner);
@@ -148,21 +169,21 @@ contract ChainlinkRelayerFactoryTest_deployRelayer is ChainlinkRelayerFactoryTes
   IChainlinkRelayer relayer;
 
   function test_setsRateFeed() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     address rateFeed = relayer.rateFeedId();
     assertEq(rateFeed, aRateFeed);
   }
 
   function test_setsRateFeedDescription() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     string memory rateFeedDescription = relayer.rateFeedDescription();
     assertEq(rateFeedDescription, aRateFeedDescription);
   }
 
   function test_setsAggregators() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     IChainlinkRelayer.ChainlinkAggregator[] memory expectedAggregators = fourAggregators();
     IChainlinkRelayer.ChainlinkAggregator[] memory actualAggregators = relayer.getAggregators();
@@ -174,14 +195,14 @@ contract ChainlinkRelayerFactoryTest_deployRelayer is ChainlinkRelayerFactoryTes
   }
 
   function test_setsSortedOracles() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     address sortedOracles = relayer.sortedOracles();
     assertEq(sortedOracles, mockSortedOracles);
   }
 
   function test_deploysToTheCorrectAddress() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     address expectedAddress = expectedRelayerAddress({
       rateFeedId: aRateFeed,
@@ -210,19 +231,19 @@ contract ChainlinkRelayerFactoryTest_deployRelayer is ChainlinkRelayerFactoryTes
       rateFeedDescription: aRateFeedDescription,
       aggregators: fourAggregators()
     });
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators());
   }
 
   function test_remembersTheRelayerAddress() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     address storedAddress = relayerFactory.getRelayer(aRateFeed);
     assertEq(storedAddress, address(relayer));
   }
 
   function test_revertsWhenDeployingToAddressWithCode() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address futureAddress = expectedRelayerAddress(
       aRateFeed,
       aRateFeedDescription,
@@ -232,29 +253,29 @@ contract ChainlinkRelayerFactoryTest_deployRelayer is ChainlinkRelayerFactoryTes
     );
     vm.etch(futureAddress, abi.encode("This is a great contract's bytecode"));
     vm.expectRevert(contractAlreadyExistsError(address(futureAddress), aRateFeed));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators());
   }
 
   function test_revertsWhenDeployingTheSameRelayer() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     vm.expectRevert(relayerForFeedExistsError(aRateFeed));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators());
   }
 
   function test_revertsWhenDeployingForTheSameRateFeed() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayer = IChainlinkRelayer(relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators()));
     vm.expectRevert(relayerForFeedExistsError(aRateFeed));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, oneAggregator(0));
   }
 
-  function test_revertsWhenCalledByNonOwner() public {
-    vm.expectRevert("Ownable: caller is not the owner");
-    vm.prank(nonOwner);
+  function test_revertsWhenCalledByNonDeployer() public {
+    vm.expectRevert(NOT_ALLOWED);
+    vm.prank(nonDeployer);
     relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators());
   }
 }
@@ -266,7 +287,7 @@ contract ChainlinkRelayerFactoryTest_getRelayers is ChainlinkRelayerFactoryTest 
   }
 
   function test_returnsRelayerWhenThereIsOne() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress = relayerFactory.deployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(0));
     address[] memory relayers = relayerFactory.getRelayers();
     assertEq(relayers.length, 1);
@@ -274,11 +295,11 @@ contract ChainlinkRelayerFactoryTest_getRelayers is ChainlinkRelayerFactoryTest 
   }
 
   function test_returnsMultipleRelayersWhenThereAreMore() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress1 = relayerFactory.deployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(0));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress2 = relayerFactory.deployRelayer(rateFeeds[1], aRateFeedDescription, oneAggregator(1));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress3 = relayerFactory.deployRelayer(rateFeeds[2], aRateFeedDescription, oneAggregator(2));
     address[] memory relayers = relayerFactory.getRelayers();
     assertEq(relayers.length, 3);
@@ -288,11 +309,11 @@ contract ChainlinkRelayerFactoryTest_getRelayers is ChainlinkRelayerFactoryTest 
   }
 
   function test_returnsADifferentRelayerAfterRedeployment() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress1 = relayerFactory.deployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(0));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.deployRelayer(rateFeeds[1], aRateFeedDescription, oneAggregator(1));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress2 = relayerFactory.redeployRelayer(rateFeeds[1], aRateFeedDescription, oneAggregator(2));
     address[] memory relayers = relayerFactory.getRelayers();
     assertEq(relayers.length, 2);
@@ -301,13 +322,13 @@ contract ChainlinkRelayerFactoryTest_getRelayers is ChainlinkRelayerFactoryTest 
   }
 
   function test_doesntReturnARemovedRelayer() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress1 = relayerFactory.deployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(0));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayerAddress2 = relayerFactory.deployRelayer(rateFeeds[1], aRateFeedDescription, oneAggregator(1));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.deployRelayer(rateFeeds[2], aRateFeedDescription, oneAggregator(2));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.removeRelayer(rateFeeds[2]);
     address[] memory relayers = relayerFactory.getRelayers();
     assertEq(relayers.length, 2);
@@ -322,14 +343,14 @@ contract ChainlinkRelayerFactoryTest_removeRelayer is ChainlinkRelayerFactoryTes
   function setUp() public override {
     super.setUp();
 
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerAddress = relayerFactory.deployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(0));
   }
 
   function test_removesTheRelayer() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.removeRelayer(aRateFeed);
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayer = relayerFactory.getRelayer(aRateFeed);
     assertEq(relayer, address(0));
   }
@@ -338,14 +359,14 @@ contract ChainlinkRelayerFactoryTest_removeRelayer is ChainlinkRelayerFactoryTes
     // solhint-disable-next-line func-named-parameters
     vm.expectEmit(true, true, true, false, address(relayerFactory));
     emit RelayerRemoved({ relayerAddress: relayerAddress, rateFeedId: aRateFeed });
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.removeRelayer(aRateFeed);
   }
 
   function test_doesntRemoveOtherRelayers() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address newRelayerAddress = relayerFactory.deployRelayer(rateFeeds[1], aRateFeedDescription, oneAggregator(1));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.removeRelayer(aRateFeed);
     address[] memory relayers = relayerFactory.getRelayers();
 
@@ -355,13 +376,13 @@ contract ChainlinkRelayerFactoryTest_removeRelayer is ChainlinkRelayerFactoryTes
 
   function test_revertsOnNonexistentRelayer() public {
     vm.expectRevert(noRelayerForRateFeedId(rateFeeds[1]));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.removeRelayer(rateFeeds[1]);
   }
 
-  function test_revertsWhenCalledByNonOwner() public {
-    vm.expectRevert("Ownable: caller is not the owner");
-    vm.prank(nonOwner);
+  function test_revertsWhenCalledByNonDeployer() public {
+    vm.expectRevert(NOT_ALLOWED);
+    vm.prank(nonDeployer);
     relayerFactory.removeRelayer(aRateFeed);
   }
 }
@@ -371,12 +392,12 @@ contract ChainlinkRelayerFactoryTest_redeployRelayer is ChainlinkRelayerFactoryT
 
   function setUp() public override {
     super.setUp();
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     oldAddress = relayerFactory.deployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(0));
   }
 
   function test_setsRateFeedOnNewRelayer() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     IChainlinkRelayer relayer = IChainlinkRelayer(
       relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1))
     );
@@ -386,7 +407,7 @@ contract ChainlinkRelayerFactoryTest_redeployRelayer is ChainlinkRelayerFactoryT
   }
 
   function test_setsAggregatorOnNewRelayer() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     IChainlinkRelayer relayer = IChainlinkRelayer(
       relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1))
     );
@@ -401,7 +422,7 @@ contract ChainlinkRelayerFactoryTest_redeployRelayer is ChainlinkRelayerFactoryT
   }
 
   function test_setsSortedOraclesOnNewRelayer() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     IChainlinkRelayer relayer = IChainlinkRelayer(
       relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1))
     );
@@ -411,7 +432,7 @@ contract ChainlinkRelayerFactoryTest_redeployRelayer is ChainlinkRelayerFactoryT
   }
 
   function test_deploysToTheCorrectNewAddress() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     IChainlinkRelayer relayer = IChainlinkRelayer(
       relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1))
     );
@@ -446,12 +467,12 @@ contract ChainlinkRelayerFactoryTest_redeployRelayer is ChainlinkRelayerFactoryT
       rateFeedDescription: aRateFeedDescription,
       aggregators: oneAggregator(1)
     });
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1));
   }
 
   function test_remembersTheNewRelayerAddress() public {
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     address relayer = relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1));
     address storedAddress = relayerFactory.getRelayer(aRateFeed);
     assertEq(storedAddress, relayer);
@@ -459,13 +480,13 @@ contract ChainlinkRelayerFactoryTest_redeployRelayer is ChainlinkRelayerFactoryT
 
   function test_revertsWhenDeployingTheSameExactRelayer() public {
     vm.expectRevert(contractAlreadyExistsError(oldAddress, aRateFeed));
-    vm.prank(owner);
+    vm.prank(relayerDeployer);
     relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(0));
   }
 
-  function test_revertsWhenCalledByNonOwner() public {
-    vm.expectRevert("Ownable: caller is not the owner");
-    vm.prank(nonOwner);
+  function test_revertsWhenCalledByNonDeployer() public {
+    vm.expectRevert(NOT_ALLOWED);
+    vm.prank(nonDeployer);
     relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1));
   }
 }

--- a/test/oracles/ChainlinkRelayerFactory.t.sol
+++ b/test/oracles/ChainlinkRelayerFactory.t.sol
@@ -26,7 +26,7 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
   address aRateFeed = rateFeeds[0];
   string aRateFeedDescription = "CELO/USD";
 
-  bytes constant NOT_ALLOWED = abi.encodeWithSignature("NotAllowed()");
+  bytes constant NOT_ALLOWED_ERROR = abi.encodeWithSignature("NotAllowed()");
 
   event RelayerDeployed(
     address indexed relayerAddress,
@@ -37,11 +37,9 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
   event RelayerRemoved(address indexed relayerAddress, address indexed rateFeedId);
   event RelayerDeployerUpdated(address indexed newRelayerDeployer, address indexed oldRelayerDeployer);
 
-  function oneAggregator(uint256 aggregatorIndex)
-    internal
-    view
-    returns (IChainlinkRelayer.ChainlinkAggregator[] memory aggregators)
-  {
+  function oneAggregator(
+    uint256 aggregatorIndex
+  ) internal view returns (IChainlinkRelayer.ChainlinkAggregator[] memory aggregators) {
     aggregators = new IChainlinkRelayer.ChainlinkAggregator[](1);
     aggregators[0] = IChainlinkRelayer.ChainlinkAggregator(mockAggregators[aggregatorIndex], false);
   }
@@ -90,11 +88,10 @@ contract ChainlinkRelayerFactoryTest is BaseTest {
       );
   }
 
-  function contractAlreadyExistsError(address relayerAddress, address rateFeedId)
-    public
-    pure
-    returns (bytes memory ContractAlreadyExistsError)
-  {
+  function contractAlreadyExistsError(
+    address relayerAddress,
+    address rateFeedId
+  ) public pure returns (bytes memory ContractAlreadyExistsError) {
     return abi.encodeWithSignature("ContractAlreadyExists(address,address)", relayerAddress, rateFeedId);
   }
 
@@ -277,8 +274,13 @@ contract ChainlinkRelayerFactoryTest_deployRelayer is ChainlinkRelayerFactoryTes
   }
 
   function test_revertsWhenCalledByNonDeployer() public {
-    vm.expectRevert(NOT_ALLOWED);
+    vm.expectRevert(NOT_ALLOWED_ERROR);
     vm.prank(nonDeployer);
+    relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators());
+  }
+
+  function test_worksWhenCalledByOwner() public {
+    vm.prank(owner);
     relayerFactory.deployRelayer(aRateFeed, aRateFeedDescription, fourAggregators());
   }
 }
@@ -384,8 +386,13 @@ contract ChainlinkRelayerFactoryTest_removeRelayer is ChainlinkRelayerFactoryTes
   }
 
   function test_revertsWhenCalledByNonDeployer() public {
-    vm.expectRevert(NOT_ALLOWED);
+    vm.expectRevert(NOT_ALLOWED_ERROR);
     vm.prank(nonDeployer);
+    relayerFactory.removeRelayer(aRateFeed);
+  }
+
+  function test_worksWhenCalledByOwner() public {
+    vm.prank(owner);
     relayerFactory.removeRelayer(aRateFeed);
   }
 }
@@ -488,8 +495,13 @@ contract ChainlinkRelayerFactoryTest_redeployRelayer is ChainlinkRelayerFactoryT
   }
 
   function test_revertsWhenCalledByNonDeployer() public {
-    vm.expectRevert(NOT_ALLOWED);
+    vm.expectRevert(NOT_ALLOWED_ERROR);
     vm.prank(nonDeployer);
+    relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1));
+  }
+
+  function test_worksWhenCalledByOwner() public {
+    vm.prank(owner);
     relayerFactory.redeployRelayer(rateFeeds[0], aRateFeedDescription, oneAggregator(1));
   }
 }


### PR DESCRIPTION
### Description

We realised that it would be better operationally to separate the proxy ownership ACL from the deployer ACL, that way we can keep using the `mento-deployer` account for relayer deploy, and use the multisig only for proxy updates.

### Other changes

N/A

### Tested

Tests added

### Related issues

N/A

### Backwards compatibility

No, but no mainnet deployment yet.

### Documentation

N/A