### PR TITLE
chore: remove contracts that we no longer manage from storage-layout checks

### DIFF
--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -34,16 +34,7 @@ jobs:
         with:
           sarif: results.sarif
           fail-on: "low"
-        # continue-on-error: true
-        # -----------------------
-        # Ideally, we'd like to continue on error to allow uploading the SARIF file here.
-        # But we're often running into GitHub's API Rate Limit when uploading the SARIF file
-        # which would lead to lots of failed pipelines even if slither works fine:
-        # https://github.com/mento-protocol/mento-core/actions/runs/7167865576/job/19514794782
-        #
-        # So for now it's better to just let the slither task fail directly so we at least
-        # know it failed.
-        # -----------------------
+          continue-on-error: true
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/storage-layout.yaml
+++ b/.github/workflows/storage-layout.yaml
@@ -18,15 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         contract:
-          - contracts/legacy/ReserveSpenderMultiSig.sol:ReserveSpenderMultiSig
-          - contracts/legacy/StableToken.sol:StableToken
-          - contracts/legacy/Exchange.sol:Exchange
-          - contracts/legacy/GrandaMento.sol:GrandaMento
           - contracts/swap/Broker.sol:Broker
           - contracts/swap/BiPoolManager.sol:BiPoolManager
           - contracts/swap/Reserve.sol:Reserve
           - contracts/oracles/BreakerBox.sol:BreakerBox
-          - contracts/common/SortedOracles.sol:SortedOracles
           - contracts/tokens/StableTokenV2.sol:StableTokenV2
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Description

CI is currently red on `develop` because I forgot to remove these old contracts from the storage-layout check in CI, and that only happens on push to develop and PR to main (for artifact rate limiting reasons). This PR removes them from the job.

### Other changes

I've also reenabled `continue-on-error` on slither because it makes it nicer to work with via the sarif file. In the past we've disabled it because we were hitting the rate-limit on artifact upload and that ended up being a false-nagative failure mode, but that was before we moved the storage-layout check to develop and main only and that was the main hog. We didn't reenable it after doing that but I think now would be a good time to see if it works.

If you need to bring it back revert this commit: 754c8be

### Tested

Yes

### Related issues

N/A

### Backwards compatibility

YES

### Documentation

N/A