### PR TITLE
fix: gas tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,9 @@ fuzz_runs = 256
 gas_reports = ["*"]
 optimizer = false
 legacy = true
-no_match_contract = "(ForkTest)|(GovernanceGasTest)"
+no_match_contract = "ForkTest"
+gas_limit = 9223372036854775807
+
 
 allow_paths = [
   "node_modules/@celo"

--- a/test/integration/governance/GovernanceIntegration.gas.t.sol
+++ b/test/integration/governance/GovernanceIntegration.gas.t.sol
@@ -40,6 +40,7 @@ contract GovernanceGasTest is GovernanceTest {
 
   bytes32 public merkleRoot = 0x945d83ced94efc822fed712b4c4694b4e1129607ec5bbd2ab971bb08dca4d809;
 
+  uint256 public viewCallGas = 30_000;
   uint256 public proposalCreationGas = 500_000;
   uint256 public proposalQueueGas = 200_000;
   uint256 public proposalExecutionGas = 200_000;
@@ -104,11 +105,9 @@ contract GovernanceGasTest is GovernanceTest {
 
   // PoC from: https://github.com/sherlock-audit/2024-02-mento-judging/issues/4
   function test_totalSupply_whenUsedWith50_000Locks_shouldCostReasonableGas() public s_attack {
-    uint256 totalSupplyGas = 20_000;
-
     uint256 gasLeftBefore = gasleft();
     locking.totalSupply();
-    assertLt(gasLeftBefore - gasleft(), totalSupplyGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.startPrank(alice);
     mentoToken.approve(address(locking), type(uint256).max);
@@ -119,7 +118,7 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.totalSupply();
-    assertLt(gasLeftBefore - gasleft(), totalSupplyGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.startPrank(alice);
     mentoToken.approve(address(locking), type(uint256).max);
@@ -130,16 +129,14 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.totalSupply();
-    assertLt(gasLeftBefore - gasleft(), totalSupplyGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
   }
 
   // PoC from https://github.com/sherlock-audit/2024-02-mento-judging/issues/2
   function test_getVotes_whenUsedWith50_000Locks_shouldCostReasonableGas() public s_attack {
-    uint256 getVotesGas = 20_000;
-
     uint256 gasLeftBefore = gasleft();
     locking.getVotes(bob);
-    assertLt(gasLeftBefore - gasleft(), getVotesGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.startPrank(alice);
     mentoToken.approve(address(locking), type(uint256).max);
@@ -150,7 +147,7 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.getVotes(bob);
-    assertLt(gasLeftBefore - gasleft(), getVotesGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.startPrank(alice);
     mentoToken.approve(address(locking), type(uint256).max);
@@ -161,15 +158,13 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.getVotes(bob);
-    assertLt(gasLeftBefore - gasleft(), getVotesGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
   }
 
   function test_getPastVotes_whenUsedWith50_000Locks_shouldCostReasonableGas() public s_attack {
-    uint256 getPastVotesGas = 20_000;
-
     uint256 gasLeftBefore = gasleft();
     locking.getPastVotes(bob, block.number - BLOCKS_DAY);
-    assertLt(gasLeftBefore - gasleft(), getPastVotesGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.startPrank(alice);
     mentoToken.approve(address(locking), type(uint256).max);
@@ -182,7 +177,7 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.getPastVotes(bob, block.number - 3 * BLOCKS_DAY);
-    assertLt(gasLeftBefore - gasleft(), getPastVotesGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.timeTravel(BLOCKS_DAY);
 
@@ -197,15 +192,13 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.getPastVotes(bob, block.number - 2 * BLOCKS_WEEK);
-    assertLt(gasLeftBefore - gasleft(), getPastVotesGas);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
   }
 
   function test_getPastTotalSupply_whenUsedWith50_000Locks_shouldCostReasonableGas() public s_attack {
-    uint256 getPastTotalSupply = 20_000;
-
     uint256 gasLeftBefore = gasleft();
     locking.getPastTotalSupply(block.number - BLOCKS_DAY);
-    assertLt(gasLeftBefore - gasleft(), getPastTotalSupply);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.startPrank(alice);
     mentoToken.approve(address(locking), type(uint256).max);
@@ -218,7 +211,7 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.getPastTotalSupply(block.number - 3 * BLOCKS_DAY);
-    assertLt(gasLeftBefore - gasleft(), getPastTotalSupply);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
 
     vm.timeTravel(BLOCKS_DAY);
 
@@ -233,7 +226,7 @@ contract GovernanceGasTest is GovernanceTest {
 
     gasLeftBefore = gasleft();
     locking.getPastTotalSupply(block.number - 2 * BLOCKS_WEEK);
-    assertLt(gasLeftBefore - gasleft(), getPastTotalSupply);
+    assertLt(gasLeftBefore - gasleft(), viewCallGas);
   }
 
   function test_queueAndExecute_whenUsedWith50_000LocksAndNewLocksInSameBlock_shouldCostReasonableGas()


### PR DESCRIPTION
### Description

Context: We create 50k locks to check how much gas is used by governance and locking operations for users with high number of locks. It was working fine until a couple of weeks ago. Then we disabled the gas tests to make CI happy.

The problem was related to a [recent change on foundry](https://github.com/foundry-rs/foundry/pull/8274/files). They reduced the default gas limit for tests from `9223372036854775807` to `1073741824` which is not enough to create as many locks as we want.

This PR fixes the issue by setting the gas limit to the previous default value of `9223372036854775807` or `i64::MAX / 2` and re-enables the gas tests. I don't think this will cause any problems as the only downside of this is if we have an infinite loop in our tests, it will take some time to consume all the available gas before the test fails.


### Other changes

- Used a common var `viewCallGas` instead of creating one for each test
- Increased the expected view call gas usages from 20k to 30k as they consume slightly higher gas now, probably thats because we removed the gas optimization across repo recently

### Tested

✅ 

### Related issues

- Fixes [#495](https://github.com/mento-protocol/mento-general/issues/495)

