### PR TITLE
feat: add Broker liquidity check

### DIFF
--- a/contracts/swap/Broker.sol
+++ b/contracts/swap/Broker.sol
@@ -140,6 +140,10 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     uint256 amountOut
   ) external view returns (uint256 amountIn) {
     require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
+    address reserve = exchangeReserve[exchangeProvider];
+    if (IReserve(reserve).isCollateralAsset(tokenOut)) {
+      require(IERC20(tokenOut).balanceOf(reserve) >= amountOut, "Insufficient balance in reserve");
+    }
     amountIn = IExchangeProvider(exchangeProvider).getAmountIn(exchangeId, tokenIn, tokenOut, amountOut);
   }
 
@@ -161,6 +165,10 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
   ) external view returns (uint256 amountOut) {
     require(isExchangeProvider[exchangeProvider], "ExchangeProvider does not exist");
     amountOut = IExchangeProvider(exchangeProvider).getAmountOut(exchangeId, tokenIn, tokenOut, amountIn);
+    address reserve = exchangeReserve[exchangeProvider];
+    if (IReserve(reserve).isCollateralAsset(tokenOut)) {
+      require(IERC20(tokenOut).balanceOf(reserve) >= amountOut, "Insufficient balance in reserve");
+    }
   }
 
   /**

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -225,10 +225,17 @@ contract BrokerTest_getAmounts is BrokerTest {
 
   function test_getAmountIn_whenExchangeProviderWasNotSet_shouldRevert() public {
     vm.expectRevert("ExchangeProvider does not exist");
-    broker.getAmountIn(randomExchangeProvider, exchangeId, address(stableAsset), address(collateralAsset), 1e24);
+    broker.getAmountIn({
+      exchangeProvider: randomExchangeProvider,
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountOut: 1e24
+    });
   }
 
   function test_getAmountIn_whenReserveBalanceIsLessThanAmountOut_shouldRevert() public {
+    assertEq(collateralAsset.balanceOf(address(reserve)), 0);
     vm.expectRevert("Insufficient balance in reserve");
     broker.getAmountIn({
       exchangeProvider: address(exchangeProvider),
@@ -243,13 +250,13 @@ contract BrokerTest_getAmounts is BrokerTest {
     uint256 amountOut = 1e18;
     collateralAsset.mint(address(reserve), amountOut);
 
-    uint256 amountIn = broker.getAmountIn(
-      address(exchangeProvider),
-      exchangeId,
-      address(stableAsset),
-      address(collateralAsset),
-      amountOut
-    );
+    uint256 amountIn = broker.getAmountIn({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountOut: amountOut
+    });
 
     assertEq(amountIn, 25e17);
   }
@@ -258,13 +265,13 @@ contract BrokerTest_getAmounts is BrokerTest {
     uint256 amountOut = 1e18;
     collateralAsset.mint(address(reserve), 1000e18);
 
-    uint256 amountIn = broker.getAmountIn(
-      address(exchangeProvider),
-      exchangeId,
-      address(stableAsset),
-      address(collateralAsset),
-      amountOut
-    );
+    uint256 amountIn = broker.getAmountIn({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountOut: amountOut
+    });
 
     assertEq(amountIn, 25e17);
   }
@@ -281,38 +288,51 @@ contract BrokerTest_getAmounts is BrokerTest {
         1e18
       )
     );
-    uint256 amountIn = broker.getAmountIn(
-      address(exchangeProvider),
-      exchangeId,
-      address(stableAsset),
-      address(collateralAsset),
-      1e18
-    );
+    uint256 amountIn = broker.getAmountIn({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountOut: 1e18
+    });
 
     assertEq(amountIn, 25e17);
   }
 
   function test_getAmountOut_whenExchangeProviderWasNotSet_shouldRevert() public {
     vm.expectRevert("ExchangeProvider does not exist");
-    broker.getAmountOut(randomExchangeProvider, exchangeId, randomAsset, randomAsset, 1e24);
+    broker.getAmountOut({
+      exchangeProvider: randomExchangeProvider,
+      exchangeId: exchangeId,
+      tokenIn: randomAsset,
+      tokenOut: randomAsset,
+      amountIn: 1e24
+    });
   }
 
   function test_getAmountOut_whenReserveBalanceIsLessThanAmountOut_shouldRevert() public {
+    assertEq(collateralAsset.balanceOf(address(reserve)), 0);
     vm.expectRevert("Insufficient balance in reserve");
-    broker.getAmountOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 1e24);
+    broker.getAmountOut({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountIn: 1e24
+    });
   }
 
   function test_getAmountOut_whenReserveBalanceIsEqualAmountOut_shouldReturnAmountIn() public {
     uint256 amountIn = 1e18;
     collateralAsset.mint(address(reserve), amountIn);
 
-    uint256 amountOut = broker.getAmountOut(
-      address(exchangeProvider),
-      exchangeId,
-      address(stableAsset),
-      address(collateralAsset),
-      amountIn
-    );
+    uint256 amountOut = broker.getAmountOut({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountIn: amountIn
+    });
 
     assertEq(amountOut, 4e17);
   }
@@ -321,13 +341,13 @@ contract BrokerTest_getAmounts is BrokerTest {
     uint256 amountIn = 1e18;
     collateralAsset.mint(address(reserve), 1000e18);
 
-    uint256 amountOut = broker.getAmountOut(
-      address(exchangeProvider),
-      exchangeId,
-      address(stableAsset),
-      address(collateralAsset),
-      1e18
-    );
+    uint256 amountOut = broker.getAmountOut({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountIn: amountIn
+    });
 
     assertEq(amountOut, 4e17);
   }
@@ -345,13 +365,13 @@ contract BrokerTest_getAmounts is BrokerTest {
       )
     );
 
-    uint256 amountOut = broker.getAmountOut(
-      address(exchangeProvider),
-      exchangeId,
-      address(stableAsset),
-      address(collateralAsset),
-      1e18
-    );
+    uint256 amountOut = broker.getAmountOut({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountIn: 1e18
+    });
     assertEq(amountOut, 4e17);
   }
 }

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -230,10 +230,16 @@ contract BrokerTest_getAmounts is BrokerTest {
 
   function test_getAmountIn_whenReserveBalanceIsLessThanAmountOut_shouldRevert() public {
     vm.expectRevert("Insufficient balance in reserve");
-    broker.getAmountIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 1e24);
+    broker.getAmountIn({
+      exchangeProvider: address(exchangeProvider),
+      exchangeId: exchangeId,
+      tokenIn: address(stableAsset),
+      tokenOut: address(collateralAsset),
+      amountOut: 1e24
+    });
   }
 
-  function test_getAmountIn_whenReserveBalanceIsEqualAmountOut_shouldReturnAmountIn() public {
+  function test_getAmountIn_whenReserveBalanceIsEqualToAmountOut_shouldReturnAmountIn() public {
     uint256 amountOut = 1e18;
     collateralAsset.mint(address(reserve), amountOut);
 


### PR DESCRIPTION
### Description

This Pr adds a check on Broker quotes ensuring that if the TokenOut is a collateral asset the reserve can match the amountOut if not the call reverts. 

### Other changes



### Tested

fixed the test + added additional unit tests 

### Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/554

### Backwards compatibility



### Documentation


