### PR TITLE
Streamline comments and errors

### DIFF
--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -73,7 +73,11 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     _;
   }
 
-  modifier verifyExchangeTokens(address tokenIn, address tokenOut, PoolExchange memory exchange) {
+  modifier verifyExchangeTokens(
+    address tokenIn,
+    address tokenOut,
+    PoolExchange memory exchange
+  ) {
     require(
       (tokenIn == exchange.reserveAsset && tokenOut == exchange.tokenAddress) ||
         (tokenIn == exchange.tokenAddress && tokenOut == exchange.reserveAsset),

--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -72,11 +72,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     _;
   }
 
-  modifier verifyExchangeTokens(
-    address tokenIn,
-    address tokenOut,
-    PoolExchange memory exchange
-  ) {
+  modifier verifyExchangeTokens(address tokenIn, address tokenOut, PoolExchange memory exchange) {
     require(
       (tokenIn == exchange.reserveAsset && tokenOut == exchange.tokenAddress) ||
         (tokenIn == exchange.tokenAddress && tokenOut == exchange.reserveAsset),

--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -92,7 +92,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
   /// @inheritdoc IBancorExchangeProvider
   function getPoolExchange(bytes32 exchangeId) public view returns (PoolExchange memory exchange) {
     exchange = exchanges[exchangeId];
-    require(exchange.tokenAddress != address(0), "An exchange with the specified id does not exist");
+    require(exchange.tokenAddress != address(0), "Exchange does not exist");
     return exchange;
   }
 
@@ -240,8 +240,8 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
 
     uint256 reserveAssetDecimals = IERC20(exchange.reserveAsset).decimals();
     uint256 tokenDecimals = IERC20(exchange.tokenAddress).decimals();
-    require(reserveAssetDecimals <= 18, "reserve token decimals must be <= 18");
-    require(tokenDecimals <= 18, "token decimals must be <= 18");
+    require(reserveAssetDecimals <= 18, "Reserve asset decimals must be <= 18");
+    require(tokenDecimals <= 18, "Token decimals must be <= 18");
 
     tokenPrecisionMultipliers[exchange.reserveAsset] = 10 ** (18 - uint256(reserveAssetDecimals));
     tokenPrecisionMultipliers[exchange.tokenAddress] = 10 ** (18 - uint256(tokenDecimals));
@@ -363,12 +363,12 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     require(exchange.reserveAsset != address(0), "Invalid reserve asset");
     require(
       reserve.isCollateralAsset(exchange.reserveAsset),
-      "reserve asset must be a collateral registered with the reserve"
+      "Reserve asset must be a collateral registered with the reserve"
     );
     require(exchange.tokenAddress != address(0), "Invalid token address");
-    require(reserve.isStableAsset(exchange.tokenAddress), "token must be a stable registered with the reserve");
-    require(exchange.reserveRatio > 1, "Invalid reserve ratio");
-    require(exchange.reserveRatio <= MAX_WEIGHT, "Invalid reserve ratio");
-    require(exchange.exitContribution <= MAX_WEIGHT, "Invalid exit contribution");
+    require(reserve.isStableAsset(exchange.tokenAddress), "Token must be a stable registered with the reserve");
+    require(exchange.reserveRatio > 1, "Reserve ratio is too low");
+    require(exchange.reserveRatio <= MAX_WEIGHT, "Reserve ratio is too high");
+    require(exchange.exitContribution <= MAX_WEIGHT, "Exit contribution is too high");
   }
 }

--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -266,7 +266,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
 
   function _setExitContribution(bytes32 exchangeId, uint32 exitContribution) internal {
     require(exchanges[exchangeId].reserveAsset != address(0), "Exchange does not exist");
-    require(exitContribution <= MAX_WEIGHT, "Invalid exit contribution");
+    require(exitContribution <= MAX_WEIGHT, "Exit contribution is too high");
 
     PoolExchange storage exchange = exchanges[exchangeId];
     exchange.exitContribution = exitContribution;

--- a/contracts/goodDollar/GoodDollarExchangeProvider.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProvider.sol
@@ -157,6 +157,7 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
 
     amountToMint = scaledAmountToMint / tokenPrecisionMultipliers[exchange.tokenAddress];
     emit ReserveRatioUpdated(exchangeId, newRatioUint);
+
     return amountToMint;
   }
 

--- a/contracts/goodDollar/GoodDollarExchangeProvider.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProvider.sol
@@ -14,7 +14,9 @@ import { UD60x18, unwrap, wrap } from "prb/math/UD60x18.sol";
  * @notice Provides exchange functionality for the GoodDollar system.
  */
 contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchangeProvider, PausableUpgradeable {
+  /* ========================================================= */
   /* ==================== State Variables ==================== */
+  /* ========================================================= */
 
   // Address of the Expansion Controller contract.
   IGoodDollarExpansionController public expansionController;
@@ -23,25 +25,19 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   // solhint-disable-next-line var-name-mixedcase
   address public AVATAR;
 
+  /* ===================================================== */
   /* ==================== Constructor ==================== */
+  /* ===================================================== */
 
   /**
-   * @dev Should be called with disable=true in deployments when
-   * it's accessed through a Proxy.
-   * Call this with disable=false during testing, when used
-   * without a proxy.
+   * @dev Should be called with disable=true in deployments when it's accessed through a Proxy.
+   * Call this with disable=false during testing, when used without a proxy.
    * @param disable Set to true to run `_disableInitializers()` inherited from
    * openzeppelin-contracts-upgradeable/Initializable.sol
    */
   constructor(bool disable) BancorExchangeProvider(disable) {}
 
-  /**
-   * @notice Initializes the contract with the given parameters.
-   * @param _broker The address of the Broker contract.
-   * @param _reserve The address of the Reserve contract.
-   * @param _expansionController The address of the ExpansionController contract.
-   * @param _avatar The address of the GoodDollar DAO contract.
-   */
+  /// @inheritdoc IGoodDollarExchangeProvider
   function initialize(
     address _broker,
     address _reserve,
@@ -55,7 +51,9 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
     setAvatar(_avatar);
   }
 
+  /* =================================================== */
   /* ==================== Modifiers ==================== */
+  /* =================================================== */
 
   modifier onlyAvatar() {
     require(msg.sender == AVATAR, "Only Avatar can call this function");
@@ -67,22 +65,18 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
     _;
   }
 
+  /* ============================================================ */
   /* ==================== Mutative Functions ==================== */
+  /* ============================================================ */
 
-  /**
-   * @notice Sets the address of the GoodDollar DAO contract.
-   * @param _avatar The address of the DAO contract.
-   */
+  /// @inheritdoc IGoodDollarExchangeProvider
   function setAvatar(address _avatar) public onlyOwner {
     require(_avatar != address(0), "Avatar address must be set");
     AVATAR = _avatar;
     emit AvatarUpdated(_avatar);
   }
 
-  /**
-   * @notice Sets the address of the Expansion Controller contract.
-   * @param _expansionController The address of the Expansion Controller contract.
-   */
+  /// @inheritdoc IGoodDollarExchangeProvider
   function setExpansionController(address _expansionController) public onlyOwner {
     require(_expansionController != address(0), "ExpansionController address must be set");
     expansionController = IGoodDollarExpansionController(_expansionController);
@@ -90,24 +84,24 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   }
 
   /**
-   * @notice Sets the exit contribution for a pool. Only callable by the Avatar.
    * @inheritdoc BancorExchangeProvider
+   * @dev Only callable by the GoodDollar DAO contract.
    */
   function setExitContribution(bytes32 exchangeId, uint32 exitContribution) external override onlyAvatar {
     return _setExitContribution(exchangeId, exitContribution);
   }
 
   /**
-   * @notice Creates a new exchange. Only callable by the Avatar.
    * @inheritdoc BancorExchangeProvider
+   * @dev Only callable by the GoodDollar DAO contract.
    */
   function createExchange(PoolExchange calldata _exchange) external override onlyAvatar returns (bytes32 exchangeId) {
     return _createExchange(_exchange);
   }
 
   /**
-   * @notice Destroys an exchange. Only callable by the Avatar.
    * @inheritdoc BancorExchangeProvider
+   * @dev Only callable by the GoodDollar DAO contract.
    */
   function destroyExchange(
     bytes32 exchangeId,
@@ -116,14 +110,7 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
     return _destroyExchange(exchangeId, exchangeIdIndex);
   }
 
-  /**
-   * @notice Execute a token swap with fixed amountIn
-   * @param exchangeId The id of exchange, i.e. PoolExchange to use
-   * @param tokenIn The token to be sold
-   * @param tokenOut The token to be bought
-   * @param amountIn The amount of tokenIn to be sold
-   * @return amountOut The amount of tokenOut to be bought
-   */
+  /// @inheritdoc BancorExchangeProvider
   function swapIn(
     bytes32 exchangeId,
     address tokenIn,
@@ -133,14 +120,7 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
     amountOut = BancorExchangeProvider.swapIn(exchangeId, tokenIn, tokenOut, amountIn);
   }
 
-  /**
-   * @notice Execute a token swap with fixed amountOut
-   * @param exchangeId The id of exchange, i.e. PoolExchange to use
-   * @param tokenIn The token to be sold
-   * @param tokenOut The token to be bought
-   * @param amountOut The amount of tokenOut to be bought
-   * @return amountIn The amount of tokenIn to be sold
-   */
+  /// @inheritdoc BancorExchangeProvider
   function swapOut(
     bytes32 exchangeId,
     address tokenIn,
@@ -151,13 +131,10 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   }
 
   /**
-   * @notice Calculates the amount of tokens to be minted as a result of expansion.
-   * @dev Calculates the amount of tokens that need to be minted as a result of the expansion
+   * @inheritdoc IGoodDollarExchangeProvider
+   * @dev Calculates the amount of G$ tokens that need to be minted as a result of the expansion
    *      while keeping the current price the same.
    *      calculation: amountToMint = (tokenSupply * reserveRatio - tokenSupply * newRatio) / newRatio
-   * @param exchangeId The id of the pool to calculate expansion for.
-   * @param expansionScaler Scaler for calculating the new reserve ratio.
-   * @return amountToMint amount of tokens to be minted as a result of the expansion.
    */
   function mintFromExpansion(
     bytes32 exchangeId,
@@ -184,13 +161,10 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   }
 
   /**
-   * @notice Calculates the amount of tokens to be minted as a result of collecting the reserve interest.
-   * @dev Calculates the amount of tokens that need to be minted as a result of the reserve interest
+   * @inheritdoc IGoodDollarExchangeProvider
+   * @dev Calculates the amount of G$ tokens that need to be minted as a result of the reserve interest
    *      flowing into the reserve while keeping the current price the same.
    *      calculation: amountToMint = reserveInterest * tokenSupply / reserveBalance
-   * @param exchangeId The id of the pool the reserve interest is added to.
-   * @param reserveInterest The amount of reserve tokens collected from interest.
-   * @return amountToMint amount of tokens to be minted as a result of the reserve interest.
    */
   function mintFromInterest(
     bytes32 exchangeId,
@@ -211,11 +185,9 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   }
 
   /**
-   * @notice Calculates the reserve ratio needed to mint the reward.
-   * @dev Calculates the new reserve ratio needed to mint the reward while keeping the current price the same.
+   * @inheritdoc IGoodDollarExchangeProvider
+   * @dev Calculates the new reserve ratio needed to mint the G$ reward while keeping the current price the same.
    *      calculation: newRatio = reserveBalance / (tokenSupply + reward) * currentPrice
-   * @param exchangeId The id of the pool the reward is minted from.
-   * @param reward The amount of tokens to be minted as a reward.
    */
   function updateRatioForReward(bytes32 exchangeId, uint256 reward) external onlyExpansionController whenNotPaused {
     PoolExchange memory exchange = getPoolExchange(exchangeId);
@@ -239,16 +211,16 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   }
 
   /**
-   * @notice Pauses the contract.
-   * @dev Functions is only callable by the GoodDollar DAO contract.
+   * @inheritdoc IGoodDollarExchangeProvider
+   * @dev Only callable by the GoodDollar DAO contract.
    */
   function pause() external virtual onlyAvatar {
     _pause();
   }
 
   /**
-   * @notice Unpauses the contract.
-   * @dev Functions is only callable by the GoodDollar DAO contract.
+   * @inheritdoc IGoodDollarExchangeProvider
+   * @dev Only callable by the GoodDollar DAO contract.
    */
   function unpause() external virtual onlyAvatar {
     _unpause();

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -8,7 +8,6 @@ import { IERC20 } from "openzeppelin-contracts-next/contracts/token/ERC20/IERC20
 import { IGoodDollar } from "contracts/goodDollar/interfaces/IGoodProtocol.sol";
 import { IDistributionHelper } from "contracts/goodDollar/interfaces/IGoodProtocol.sol";
 
-import { ReentrancyGuard } from "openzeppelin-contracts-next/contracts/security/ReentrancyGuard.sol";
 import { PausableUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol";
 import { OwnableUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import { unwrap, wrap, powu } from "prb/math/UD60x18.sol";
@@ -17,12 +16,7 @@ import { unwrap, wrap, powu } from "prb/math/UD60x18.sol";
  * @title GoodDollarExpansionController
  * @notice Provides functionality to expand the supply of GoodDollars.
  */
-contract GoodDollarExpansionController is
-  IGoodDollarExpansionController,
-  PausableUpgradeable,
-  OwnableUpgradeable,
-  ReentrancyGuard
-{
+contract GoodDollarExpansionController is IGoodDollarExpansionController, PausableUpgradeable, OwnableUpgradeable {
   /* ==================== State Variables ==================== */
 
   // MAX_WEIGHT is the max rate that can be assigned to an exchange
@@ -163,7 +157,7 @@ contract GoodDollarExpansionController is
    * @param exchangeId The id of the exchange to mint UBI for.
    * @param reserveInterest The amount of reserve tokens collected from interest.
    */
-  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external nonReentrant {
+  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external {
     require(reserveInterest > 0, "reserveInterest must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
@@ -183,7 +177,7 @@ contract GoodDollarExpansionController is
    * @param exchangeId The id of the exchange to mint UBI for.
    * @return amountMinted The amount of UBI tokens minted.
    */
-  function mintUBIFromReserveBalance(bytes32 exchangeId) external nonReentrant returns (uint256 amountMinted) {
+  function mintUBIFromReserveBalance(bytes32 exchangeId) external returns (uint256 amountMinted) {
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
 
@@ -204,7 +198,7 @@ contract GoodDollarExpansionController is
    * @param exchangeId The id of the exchange to mint UBI for.
    * @return amountMinted The amount of UBI tokens minted.
    */
-  function mintUBIFromExpansion(bytes32 exchangeId) external nonReentrant returns (uint256 amountMinted) {
+  function mintUBIFromExpansion(bytes32 exchangeId) external returns (uint256 amountMinted) {
     ExchangeExpansionConfig memory config = getExpansionConfig(exchangeId);
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
@@ -241,7 +235,7 @@ contract GoodDollarExpansionController is
    * @param to The address of the recipient.
    * @param amount The amount of tokens to mint.
    */
-  function mintRewardFromRR(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar nonReentrant {
+  function mintRewardFromRR(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
     require(to != address(0), "Invalid to address");
     require(amount > 0, "Amount must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -8,6 +8,7 @@ import { IERC20 } from "openzeppelin-contracts-next/contracts/token/ERC20/IERC20
 import { IGoodDollar } from "contracts/goodDollar/interfaces/IGoodProtocol.sol";
 import { IDistributionHelper } from "contracts/goodDollar/interfaces/IGoodProtocol.sol";
 
+import { ReentrancyGuard } from "openzeppelin-contracts-next/contracts/security/ReentrancyGuard.sol";
 import { PausableUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol";
 import { OwnableUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import { unwrap, wrap, powu } from "prb/math/UD60x18.sol";
@@ -16,7 +17,12 @@ import { unwrap, wrap, powu } from "prb/math/UD60x18.sol";
  * @title GoodDollarExpansionController
  * @notice Provides functionality to expand the supply of GoodDollars.
  */
-contract GoodDollarExpansionController is IGoodDollarExpansionController, PausableUpgradeable, OwnableUpgradeable {
+contract GoodDollarExpansionController is
+  IGoodDollarExpansionController,
+  PausableUpgradeable,
+  OwnableUpgradeable,
+  ReentrancyGuard
+{
   /* ==================== State Variables ==================== */
 
   // MAX_WEIGHT is the max rate that can be assigned to an exchange
@@ -157,7 +163,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
    * @param exchangeId The id of the exchange to mint UBI for.
    * @param reserveInterest The amount of reserve tokens collected from interest.
    */
-  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external {
+  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external nonReentrant {
     require(reserveInterest > 0, "reserveInterest must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
@@ -177,7 +183,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
    * @param exchangeId The id of the exchange to mint UBI for.
    * @return amountMinted The amount of UBI tokens minted.
    */
-  function mintUBIFromReserveBalance(bytes32 exchangeId) external returns (uint256 amountMinted) {
+  function mintUBIFromReserveBalance(bytes32 exchangeId) external nonReentrant returns (uint256 amountMinted) {
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
 
@@ -198,7 +204,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
    * @param exchangeId The id of the exchange to mint UBI for.
    * @return amountMinted The amount of UBI tokens minted.
    */
-  function mintUBIFromExpansion(bytes32 exchangeId) external returns (uint256 amountMinted) {
+  function mintUBIFromExpansion(bytes32 exchangeId) external nonReentrant returns (uint256 amountMinted) {
     ExchangeExpansionConfig memory config = getExpansionConfig(exchangeId);
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
@@ -235,7 +241,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
    * @param to The address of the recipient.
    * @param amount The amount of tokens to mint.
    */
-  function mintRewardFromRR(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
+  function mintRewardFromRR(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar nonReentrant {
     require(to != address(0), "Invalid to address");
     require(amount > 0, "Amount must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -200,9 +200,9 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     }
   }
 
-  function mintRewardFromRR(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
-    require(to != address(0), "Invalid to address");
   /// @inheritdoc IGoodDollarExpansionController
+  function mintRewardFromReserveRatio(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
+    require(to != address(0), "Recipient address must be set");
     require(amount > 0, "Amount must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -45,10 +45,8 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   /* ===================================================== */
 
   /**
-   * @dev Should be called with disable=true in deployments when
-   * it's accessed through a Proxy.
-   * Call this with disable=false during testing, when used
-   * without a proxy.
+   * @dev Should be called with disable=true in deployments when it's accessed through a Proxy.
+   * Call this with disable=false during testing, when used without a proxy.
    * @param disable Set to true to run `_disableInitializers()` inherited from
    * openzeppelin-contracts-upgradeable/Initializable.sol
    */
@@ -178,7 +176,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     if (shouldExpand || config.lastExpansion == 0) {
       uint256 numberOfExpansions;
 
-      //special case for first expansion
+      // Special case for first expansion
       if (config.lastExpansion == 0) {
         numberOfExpansions = 1;
       } else {

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -34,7 +34,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   IGoodDollarExchangeProvider public goodDollarExchangeProvider;
 
   // Maps exchangeId to exchangeExpansionConfig
-  mapping(bytes32 => ExchangeExpansionConfig) public exchangeExpansionConfigs;
+  mapping(bytes32 exchangeId => ExchangeExpansionConfig) public exchangeExpansionConfigs;
 
   // Address of the GoodDollar DAO contract.
   // solhint-disable-next-line var-name-mixedcase

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -137,7 +137,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
 
   /// @inheritdoc IGoodDollarExpansionController
   function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external {
-    require(reserveInterest > 0, "reserveInterest must be greater than 0");
+    require(reserveInterest > 0, "Reserve interest must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
 
@@ -220,7 +220,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   /* =========================================================== */
 
   function _setDistributionHelper(address _distributionHelper) internal {
-    require(_distributionHelper != address(0), "DistributionHelper address must be set");
+    require(_distributionHelper != address(0), "Distribution helper address must be set");
     distributionHelper = IDistributionHelper(_distributionHelper);
     emit DistributionHelperUpdated(_distributionHelper);
   }

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -17,7 +17,9 @@ import { unwrap, wrap, powu } from "prb/math/UD60x18.sol";
  * @notice Provides functionality to expand the supply of GoodDollars.
  */
 contract GoodDollarExpansionController is IGoodDollarExpansionController, PausableUpgradeable, OwnableUpgradeable {
+  /* ========================================================= */
   /* ==================== State Variables ==================== */
+  /* ========================================================= */
 
   // MAX_WEIGHT is the max rate that can be assigned to an exchange
   uint256 public constant MAX_WEIGHT = 1e18;
@@ -38,7 +40,9 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   // solhint-disable-next-line var-name-mixedcase
   address public AVATAR;
 
+  /* ===================================================== */
   /* ==================== Constructor ==================== */
+  /* ===================================================== */
 
   /**
    * @dev Should be called with disable=true in deployments when
@@ -54,13 +58,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     }
   }
 
-  /**
-   * @notice Initializes the contract with the given parameters.
-   * @param _goodDollarExchangeProvider The address of the GoodDollarExchangeProvider contract.
-   * @param _distributionHelper The address of the distribution helper contract.
-   * @param _reserve The address of the Reserve contract.
-   * @param _avatar The address of the GoodDollar DAO contract.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function initialize(
     address _goodDollarExchangeProvider,
     address _distributionHelper,
@@ -76,71 +74,56 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     setAvatar(_avatar);
   }
 
+  /* =================================================== */
   /* ==================== Modifiers ==================== */
+  /* =================================================== */
 
   modifier onlyAvatar() {
     require(msg.sender == AVATAR, "Only Avatar can call this function");
     _;
   }
 
+  /* ======================================================== */
   /* ==================== View Functions ==================== */
+  /* ======================================================== */
 
-  /**
-   * @notice Returns the expansion config for the given exchange.
-   * @param exchangeId The id of the exchange to get the expansion config for.
-   * @return config The expansion config.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function getExpansionConfig(bytes32 exchangeId) public view returns (ExchangeExpansionConfig memory) {
     require(exchangeExpansionConfigs[exchangeId].expansionRate > 0, "Expansion config not set");
     return exchangeExpansionConfigs[exchangeId];
   }
 
+  /* ============================================================ */
   /* ==================== Mutative Functions ==================== */
+  /* ============================================================ */
 
-  /**
-   * @notice Sets the GoodDollarExchangeProvider address.
-   * @param _goodDollarExchangeProvider The address of the GoodDollarExchangeProvider contract.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function setGoodDollarExchangeProvider(address _goodDollarExchangeProvider) public onlyOwner {
     require(_goodDollarExchangeProvider != address(0), "GoodDollarExchangeProvider address must be set");
     goodDollarExchangeProvider = IGoodDollarExchangeProvider(_goodDollarExchangeProvider);
     emit GoodDollarExchangeProviderUpdated(_goodDollarExchangeProvider);
   }
 
-  /**
-   * @notice Sets the distribution helper address.
-   * @param _distributionHelper The address of the distribution helper contract.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function setDistributionHelper(address _distributionHelper) public onlyAvatar {
     return _setDistributionHelper(_distributionHelper);
   }
 
-  /**
-   * @notice Sets the reserve address.
-   * @param _reserve The address of the reserve contract.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function setReserve(address _reserve) public onlyOwner {
     require(_reserve != address(0), "Reserve address must be set");
     reserve = _reserve;
     emit ReserveUpdated(_reserve);
   }
 
-  /**
-   * @notice Sets the AVATAR address.
-   * @param _avatar The address of the AVATAR contract.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function setAvatar(address _avatar) public onlyOwner {
     require(_avatar != address(0), "Avatar address must be set");
     AVATAR = _avatar;
     emit AvatarUpdated(_avatar);
   }
 
-  /**
-   * @notice Sets the expansion config for the given exchange.
-   * @param exchangeId The id of the exchange to set the expansion config for.
-   * @param expansionRate The rate of expansion.
-   * @param expansionFrequency The frequency of expansion.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function setExpansionConfig(bytes32 exchangeId, uint64 expansionRate, uint32 expansionFrequency) external onlyAvatar {
     require(expansionRate < MAX_WEIGHT, "Expansion rate must be less than 100%");
     require(expansionRate > 0, "Expansion rate must be greater than 0");
@@ -152,11 +135,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     emit ExpansionConfigSet(exchangeId, expansionRate, expansionFrequency);
   }
 
-  /**
-   * @notice Mints UBI for the given exchange from collecting reserve interest.
-   * @param exchangeId The id of the exchange to mint UBI for.
-   * @param reserveInterest The amount of reserve tokens collected from interest.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external {
     require(reserveInterest > 0, "reserveInterest must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
@@ -172,11 +151,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     emit InterestUBIMinted(exchangeId, amountToMint);
   }
 
-  /**
-   * @notice Mints UBI for the given exchange by comparing the reserve Balance of the contract to the virtual balance.
-   * @param exchangeId The id of the exchange to mint UBI for.
-   * @return amountMinted The amount of UBI tokens minted.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function mintUBIFromReserveBalance(bytes32 exchangeId) external returns (uint256 amountMinted) {
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
@@ -193,11 +168,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     }
   }
 
-  /**
-   * @notice Mints UBI for the given exchange by calculating the expansion rate.
-   * @param exchangeId The id of the exchange to mint UBI for.
-   * @return amountMinted The amount of UBI tokens minted.
-   */
+  /// @inheritdoc IGoodDollarExpansionController
   function mintUBIFromExpansion(bytes32 exchangeId) external returns (uint256 amountMinted) {
     ExchangeExpansionConfig memory config = getExpansionConfig(exchangeId);
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
@@ -229,14 +200,9 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     }
   }
 
-  /**
-   * @notice Mints a reward of tokens for the given exchange.
-   * @param exchangeId The id of the exchange to mint reward.
-   * @param to The address of the recipient.
-   * @param amount The amount of tokens to mint.
-   */
   function mintRewardFromRR(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
     require(to != address(0), "Invalid to address");
+  /// @inheritdoc IGoodDollarExpansionController
     require(amount > 0, "Amount must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
@@ -249,7 +215,9 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
     emit RewardMinted(exchangeId, to, amount);
   }
 
+  /* =========================================================== */
   /* ==================== Private Functions ==================== */
+  /* =========================================================== */
 
   function _setDistributionHelper(address _distributionHelper) internal {
     require(_distributionHelper != address(0), "DistributionHelper address must be set");

--- a/contracts/goodDollar/interfaces/IGoodProtocol.sol
+++ b/contracts/goodDollar/interfaces/IGoodProtocol.sol
@@ -9,7 +9,6 @@ interface IGoodDollar {
 
   function safeTransferFrom(address from, address to, uint256 value) external;
 
-  // Only used in Fork Tests to give the Broker minting rights during testing
   function addMinter(address _minter) external;
 
   function isMinter(address account) external view returns (bool);

--- a/contracts/goodDollar/interfaces/IGoodProtocol.sol
+++ b/contracts/goodDollar/interfaces/IGoodProtocol.sol
@@ -9,6 +9,7 @@ interface IGoodDollar {
 
   function safeTransferFrom(address from, address to, uint256 value) external;
 
+  // Only used in Fork Tests to give the Broker minting rights during testing
   function addMinter(address _minter) external;
 
   function isMinter(address account) external view returns (bool);

--- a/contracts/interfaces/IBancorExchangeProvider.sol
+++ b/contracts/interfaces/IBancorExchangeProvider.sol
@@ -12,7 +12,9 @@ interface IBancorExchangeProvider {
     uint32 exitContribution;
   }
 
-  /* ------- Events ------- */
+  /* ========================================== */
+  /* ================= Events ================= */
+  /* ========================================== */
 
   /**
    * @notice Emitted when the broker address is updated.
@@ -27,16 +29,16 @@ interface IBancorExchangeProvider {
   event ReserveUpdated(address indexed newReserve);
 
   /**
-   * @notice Emitted when a new PoolExchange has been created.
-   * @param exchangeId The id of the new PoolExchange
+   * @notice Emitted when a new pool has been created.
+   * @param exchangeId The id of the new pool
    * @param reserveAsset The address of the reserve asset
    * @param tokenAddress The address of the token
    */
   event ExchangeCreated(bytes32 indexed exchangeId, address indexed reserveAsset, address indexed tokenAddress);
 
   /**
-   * @notice Emitted when a PoolExchange has been destroyed.
-   * @param exchangeId The id of the PoolExchange
+   * @notice Emitted when a pool has been destroyed.
+   * @param exchangeId The id of the pool to destroy
    * @param reserveAsset The address of the reserve asset
    * @param tokenAddress The address of the token
    */
@@ -49,47 +51,68 @@ interface IBancorExchangeProvider {
    */
   event ExitContributionSet(bytes32 indexed exchangeId, uint256 exitContribution);
 
-  /* ------- Functions ------- */
+  /* =========================================== */
+  /* ================ Functions ================ */
+  /* =========================================== */
+
+  /**
+   * @notice Allows the contract to be upgradable via the proxy.
+   * @param _broker The address of the broker contract.
+   * @param _reserve The address of the reserve contract.
+   */
+  function initialize(address _broker, address _reserve) external;
 
   /**
    * @notice Retrieves the pool with the specified exchangeId.
-   * @param exchangeId The id of the pool to be retrieved.
-   * @return exchange The PoolExchange with that ID.
+   * @param exchangeId The ID of the pool to be retrieved.
+   * @return exchange The pool with that ID.
    */
   function getPoolExchange(bytes32 exchangeId) external view returns (PoolExchange memory exchange);
 
   /**
-   * @notice Get all exchange IDs.
-   * @return exchangeIds List of the exchangeIds.
+   * @notice Gets all pool IDs.
+   * @return exchangeIds List of the pool IDs.
    */
   function getExchangeIds() external view returns (bytes32[] memory exchangeIds);
 
   /**
-   * @notice Create a PoolExchange with the provided data.
-   * @param exchange The PoolExchange to be created.
-   * @return exchangeId The id of the exchange.
+   * @notice Gets the current price based of the Bancor formula
+   * @param exchangeId The ID of the pool to get the price for
+   * @return price The current continuous price of the pool
+   */
+  function currentPrice(bytes32 exchangeId) external view returns (uint256 price);
+
+  /**
+   * @notice Creates a new pool with the given parameters.
+   * @param exchange The pool to be created.
+   * @return exchangeId The ID of the new pool.
    */
   function createExchange(PoolExchange calldata exchange) external returns (bytes32 exchangeId);
 
   /**
-   * @notice Delete a PoolExchange.
-   * @param exchangeId The PoolExchange to be created.
-   * @param exchangeIdIndex The index of the exchangeId in the exchangeIds array.
-   * @return destroyed - true on successful delition.
+   * @notice Destroys a pool with the given parameters if it exists.
+   * @param exchangeId The ID of the pool to be destroyed.
+   * @param exchangeIdIndex The index of the pool in the exchangeIds array.
+   * @return destroyed A boolean indicating whether or not the exchange was successfully destroyed.
    */
   function destroyExchange(bytes32 exchangeId, uint256 exchangeIdIndex) external returns (bool destroyed);
 
   /**
-   * @notice Set the exit contribution for a given exchange
-   * @param exchangeId The id of the exchange
+   * @notice Sets the address of the broker contract.
+   * @param _broker The new address of the broker contract.
+   */
+  function setBroker(address _broker) external;
+
+  /**
+   * @notice Sets the address of the reserve contract.
+   * @param _reserve The new address of the reserve contract.
+   */
+  function setReserve(address _reserve) external;
+
+  /**
+   * @notice Sets the exit contribution for a given pool
+   * @param exchangeId The ID of the pool
    * @param exitContribution The exit contribution to be set
    */
   function setExitContribution(bytes32 exchangeId, uint32 exitContribution) external;
-
-  /**
-   * @notice gets the current price based of the bancor formula
-   * @param exchangeId The id of the exchange to get the price for
-   * @return price the current continious price
-   */
-  function currentPrice(bytes32 exchangeId) external returns (uint256 price);
 }

--- a/contracts/interfaces/IBancorExchangeProvider.sol
+++ b/contracts/interfaces/IBancorExchangeProvider.sol
@@ -51,9 +51,9 @@ interface IBancorExchangeProvider {
    */
   event ExitContributionSet(bytes32 indexed exchangeId, uint256 exitContribution);
 
-  /* =========================================== */
-  /* ================ Functions ================ */
-  /* =========================================== */
+  /* ======================================================== */
+  /* ==================== View Functions ==================== */
+  /* ======================================================== */
 
   /**
    * @notice Allows the contract to be upgradable via the proxy.
@@ -82,21 +82,9 @@ interface IBancorExchangeProvider {
    */
   function currentPrice(bytes32 exchangeId) external view returns (uint256 price);
 
-  /**
-   * @notice Creates a new pool with the given parameters.
-   * @param exchange The pool to be created.
-   * @return exchangeId The ID of the new pool.
-   */
-  function createExchange(PoolExchange calldata exchange) external returns (bytes32 exchangeId);
-
-  /**
-   * @notice Destroys a pool with the given parameters if it exists.
-   * @param exchangeId The ID of the pool to be destroyed.
-   * @param exchangeIdIndex The index of the pool in the exchangeIds array.
-   * @return destroyed A boolean indicating whether or not the exchange was successfully destroyed.
-   */
-  function destroyExchange(bytes32 exchangeId, uint256 exchangeIdIndex) external returns (bool destroyed);
-
+  /* ============================================================ */
+  /* ==================== Mutative Functions ==================== */
+  /* ============================================================ */
   /**
    * @notice Sets the address of the broker contract.
    * @param _broker The new address of the broker contract.
@@ -115,4 +103,19 @@ interface IBancorExchangeProvider {
    * @param exitContribution The exit contribution to be set
    */
   function setExitContribution(bytes32 exchangeId, uint32 exitContribution) external;
+
+  /**
+   * @notice Creates a new pool with the given parameters.
+   * @param exchange The pool to be created.
+   * @return exchangeId The ID of the new pool.
+   */
+  function createExchange(PoolExchange calldata exchange) external returns (bytes32 exchangeId);
+
+  /**
+   * @notice Destroys a pool with the given parameters if it exists.
+   * @param exchangeId The ID of the pool to be destroyed.
+   * @param exchangeIdIndex The index of the pool in the exchangeIds array.
+   * @return destroyed A boolean indicating whether or not the exchange was successfully destroyed.
+   */
+  function destroyExchange(bytes32 exchangeId, uint256 exchangeIdIndex) external returns (bool destroyed);
 }

--- a/contracts/interfaces/IBiPoolManager.sol
+++ b/contracts/interfaces/IBiPoolManager.sol
@@ -13,8 +13,7 @@ import { FixidityLib } from "celo/contracts/common/FixidityLib.sol";
 
 /**
  * @title BiPool Manager interface
- * @notice The two asset pool manager is responsible for
- * managing the state of all two-asset virtual pools.
+ * @notice An exchange provider implementation managing the state of all two-asset virtual pools.
  */
 interface IBiPoolManager {
   /**

--- a/contracts/interfaces/IBroker.sol
+++ b/contracts/interfaces/IBroker.sol
@@ -38,6 +38,69 @@ interface IBroker {
   event TradingLimitConfigured(bytes32 exchangeId, address token, ITradingLimits.Config config);
 
   /**
+   * @notice Allows the contract to be upgradable via the proxy.
+   * @param _exchangeProviders The addresses of the ExchangeProvider contracts.
+   * @param _reserves The address of the Reserve contract.
+   */
+  function initialize(address[] calldata _exchangeProviders, address[] calldata _reserves) external;
+
+  /**
+   * @notice Set the reserves for the exchange providers.
+   * @param _exchangeProviders The addresses of the ExchangeProvider contracts.
+   * @param _reserves The addresses of the Reserve contracts.
+   */
+  function setReserves(address[] calldata _exchangeProviders, address[] calldata _reserves) external;
+
+  /**
+   * @notice Add an exchange provider to the list of providers.
+   * @param exchangeProvider The address of the exchange provider to add.
+   * @param reserve The address of the reserve used by the exchange provider.
+   * @return index The index of the newly added specified exchange provider.
+   */
+  function addExchangeProvider(address exchangeProvider, address reserve) external returns (uint256 index);
+
+  /**
+   * @notice Remove an exchange provider from the list of providers.
+   * @param exchangeProvider The address of the exchange provider to remove.
+   * @param index The index of the exchange provider being removed.
+   */
+  function removeExchangeProvider(address exchangeProvider, uint256 index) external;
+
+  /**
+   * @notice Calculate amountIn of tokenIn needed for a given amountOut of tokenOut.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountOut The amount of tokenOut to be bought.
+   * @return amountIn The amount of tokenIn to be sold.
+   */
+  function getAmountIn(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountOut
+  ) external view returns (uint256 amountIn);
+
+  /**
+   * @notice Calculate amountOut of tokenOut received for a given amountIn of tokenIn.
+   * @param exchangeProvider the address of the exchange provider for the pair.
+   * @param exchangeId The id of the exchange to use.
+   * @param tokenIn The token to be sold.
+   * @param tokenOut The token to be bought.
+   * @param amountIn The amount of tokenIn to be sold.
+   * @return amountOut The amount of tokenOut to be bought.
+   */
+  function getAmountOut(
+    address exchangeProvider,
+    bytes32 exchangeId,
+    address tokenIn,
+    address tokenOut,
+    uint256 amountIn
+  ) external view returns (uint256 amountOut);
+
+  /**
    * @notice Execute a token swap with fixed amountIn.
    * @param exchangeProvider the address of the exchange provider for the pair.
    * @param exchangeId The id of the exchange to use.
@@ -76,38 +139,24 @@ interface IBroker {
   ) external returns (uint256 amountIn);
 
   /**
-   * @notice Calculate amountOut of tokenOut received for a given amountIn of tokenIn.
-   * @param exchangeProvider the address of the exchange provider for the pair.
-   * @param exchangeId The id of the exchange to use.
-   * @param tokenIn The token to be sold.
-   * @param tokenOut The token to be bought.
-   * @param amountIn The amount of tokenIn to be sold.
-   * @return amountOut The amount of tokenOut to be bought.
+   * @notice Permissionless way to burn stables from msg.sender directly.
+   * @param token The token getting burned.
+   * @param amount The amount of the token getting burned.
+   * @return True if transaction succeeds.
    */
-  function getAmountOut(
-    address exchangeProvider,
-    bytes32 exchangeId,
-    address tokenIn,
-    address tokenOut,
-    uint256 amountIn
-  ) external view returns (uint256 amountOut);
+  function burnStableTokens(address token, uint256 amount) external returns (bool);
 
   /**
-   * @notice Calculate amountIn of tokenIn needed for a given amountOut of tokenOut.
-   * @param exchangeProvider the address of the exchange provider for the pair.
-   * @param exchangeId The id of the exchange to use.
-   * @param tokenIn The token to be sold.
-   * @param tokenOut The token to be bought.
-   * @param amountOut The amount of tokenOut to be bought.
-   * @return amountIn The amount of tokenIn to be sold.
+   * @notice Configure trading limits for an (exchangeId, token) touple.
+   * @dev Will revert if the configuration is not valid according to the
+   * TradingLimits library.
+   * Resets existing state according to the TradingLimits library logic.
+   * Can only be called by owner.
+   * @param exchangeId the exchangeId to target.
+   * @param token the token to target.
+   * @param config the new trading limits config.
    */
-  function getAmountIn(
-    address exchangeProvider,
-    bytes32 exchangeId,
-    address tokenIn,
-    address tokenOut,
-    uint256 amountOut
-  ) external view returns (uint256 amountIn);
+  function configureTradingLimit(bytes32 exchangeId, address token, ITradingLimits.Config calldata config) external;
 
   /**
    * @notice Get the list of registered exchange providers.
@@ -116,44 +165,19 @@ interface IBroker {
    */
   function getExchangeProviders() external view returns (address[] memory);
 
-  function burnStableTokens(address token, uint256 amount) external returns (bool);
+  /**
+   * @notice Get the address of the exchange provider at a given index.
+   * @dev Auto-generated getter for the exchangeProviders array.
+   * @param index The index of the exchange provider.
+   * @return exchangeProvider The address of the exchange provider.
+   */
+  function exchangeProviders(uint256 index) external view returns (address exchangeProvider);
 
   /**
-   * @notice Allows the contract to be upgradable via the proxy.
-   * @param _exchangeProviders The addresses of the ExchangeProvider contracts.
-   * @param _reserves The address of the Reserve contract.
+   * @notice Check if a given address is an exchange provider.
+   * @dev Auto-generated getter for the isExchangeProvider mapping.
+   * @param exchangeProvider The address to check.
+   * @return isExchangeProvider True if the address is an exchange provider, false otherwise.
    */
-  function initialize(address[] calldata _exchangeProviders, address[] calldata _reserves) external;
-
-  //TODO: Bogdan added these to the interface but when upgrading to 0.8.18,
-  // This is causing a compilation error. because they are defined in Ownable.sol as well.
-  // only way of fixing this is to remove them from the interface. or have the explicit
-  // implementation in the contract and add a override(IBroker, Ownable) to the functions.
-
-  //function renounceOwnership() external;
-
-  //function owner() external view returns (address);
-
-  /// @notice IOwnable:
-  //function transferOwnership(address newOwner) external;
-
-  /// @notice Getters:
-  //function reserve() external view returns (address);
-
   function isExchangeProvider(address exchangeProvider) external view returns (bool);
-
-  /// @notice Setters:
-  function addExchangeProvider(address exchangeProvider, address reserve) external returns (uint256 index);
-
-  function removeExchangeProvider(address exchangeProvider, uint256 index) external;
-
-  function setReserves(address[] calldata _exchangeProviders, address[] calldata _reserves) external;
-
-  function configureTradingLimit(bytes32 exchangeId, address token, ITradingLimits.Config calldata config) external;
-
-  // function tradingLimitsConfig(bytes32 id) external view returns (ITradingLimits.Config memory);
-
-  // function tradingLimitsState(bytes32 id) external view returns (ITradingLimits.State memory);
-
-  function exchangeProviders(uint256 i) external view returns (address);
 }

--- a/contracts/interfaces/IExchangeProvider.sol
+++ b/contracts/interfaces/IExchangeProvider.sol
@@ -76,7 +76,7 @@ interface IExchangeProvider {
 
   /**
    * @notice Calculate amountIn of tokenIn needed for a given amountOut of tokenOut
-   * @param exchangeId The id of the exchange to use
+   * @param exchangeId The ID of the pool to use
    * @param tokenIn The token to be sold
    * @param tokenOut The token to be bought
    * @param amountOut The amount of tokenOut to be bought

--- a/contracts/interfaces/IGoodDollarExchangeProvider.sol
+++ b/contracts/interfaces/IGoodDollarExchangeProvider.sol
@@ -3,7 +3,9 @@ pragma solidity >=0.5.17 <0.8.19;
 pragma experimental ABIEncoderV2;
 
 interface IGoodDollarExchangeProvider {
-  /* ------- Events ------- */
+  /* ========================================== */
+  /* ================= Events ================= */
+  /* ========================================== */
 
   /**
    * @notice Emitted when the ExpansionController address is updated.
@@ -12,20 +14,22 @@ interface IGoodDollarExchangeProvider {
   event ExpansionControllerUpdated(address indexed expansionController);
 
   /**
-   * @notice Emitted when the AVATAR address is updated.
-   * @param AVATAR The address of the AVATAR contract.
+   * @notice Emitted when the GoodDollar DAO address is updated.
+   * @param AVATAR The address of the GoodDollar DAO contract.
    */
   // solhint-disable-next-line var-name-mixedcase
   event AvatarUpdated(address indexed AVATAR);
 
   /**
-   * @notice Emitted when reserve ratio for exchange is updated.
-   * @param exchangeId The id of the exchange.
+   * @notice Emitted when the reserve ratio for a pool is updated.
+   * @param exchangeId The id of the pool.
    * @param reserveRatio The new reserve ratio.
    */
   event ReserveRatioUpdated(bytes32 indexed exchangeId, uint32 reserveRatio);
 
-  /* ------- Functions ------- */
+  /* =========================================== */
+  /* ================ Functions ================ */
+  /* =========================================== */
 
   /**
    * @notice Initializes the contract with the given parameters.
@@ -37,35 +41,47 @@ interface IGoodDollarExchangeProvider {
   function initialize(address _broker, address _reserve, address _expansionController, address _avatar) external;
 
   /**
-   * @notice calculates the amount of tokens to be minted as a result of expansion.
-   * @param exchangeId The id of the pool to calculate expansion for.
+   * @notice Sets the address of the GoodDollar DAO contract.
+   * @param _avatar The address of the DAO contract.
+   */
+  function setAvatar(address _avatar) external;
+
+  /**
+   * @notice Sets the address of the Expansion Controller contract.
+   * @param _expansionController The address of the Expansion Controller contract.
+   */
+  function setExpansionController(address _expansionController) external;
+
+  /**
+   * @notice Calculates the amount of G$ tokens to be minted as a result of the expansion.
+   * @param exchangeId The ID of the pool to calculate the expansion for.
    * @param expansionScaler Scaler for calculating the new reserve ratio.
-   * @return amountToMint amount of tokens to be minted as a result of the expansion.
+   * @return amountToMint Amount of G$ tokens to be minted as a result of the expansion.
    */
   function mintFromExpansion(bytes32 exchangeId, uint256 expansionScaler) external returns (uint256 amountToMint);
 
   /**
-   * @notice calculates the amount of tokens to be minted as a result of the reserve interest.
-   * @param exchangeId The id of the pool the reserve interest is added to.
-   * @param reserveInterest The amount of reserve tokens collected from interest.
-   * @return amount of tokens to be minted as a result of the reserve interest.
+   * @notice Calculates the amount of G$ tokens to be minted as a result of the collected reserve interest.
+   * @param exchangeId The ID of the pool the collected reserve interest is added to.
+   * @param reserveInterest The amount of reserve asset tokens collected from interest.
+   * @return amountToMint The amount of G$ tokens to be minted as a result of the collected reserve interest.
    */
-  function mintFromInterest(bytes32 exchangeId, uint256 reserveInterest) external returns (uint256);
+  function mintFromInterest(bytes32 exchangeId, uint256 reserveInterest) external returns (uint256 amountToMint);
 
   /**
-   * @notice calculates the reserve ratio needed to mint the reward.
-   * @param exchangeId The id of the pool the reward is minted from.
-   * @param reward The amount of tokens to be minted as a reward.
+   * @notice Calculates the reserve ratio needed to mint the given G$ reward.
+   * @param exchangeId The ID of the pool the G$ reward is minted from.
+   * @param reward The amount of G$ tokens to be minted as a reward.
    */
   function updateRatioForReward(bytes32 exchangeId, uint256 reward) external;
 
   /**
-   * @notice pauses the Exchange disables minting.
+   * @notice Pauses the Exchange, disabling minting.
    */
   function pause() external;
 
   /**
-   * @notice unpauses the Exchange enables minting again.
+   * @notice Unpauses the Exchange, enabling minting again.
    */
   function unpause() external;
 }

--- a/contracts/interfaces/IGoodDollarExpansionController.sol
+++ b/contracts/interfaces/IGoodDollarExpansionController.sol
@@ -6,8 +6,8 @@ interface IGoodDollarExpansionController {
   /**
    * @notice Struct holding the configuration for the expansion of an exchange.
    * @param expansionRate The rate of expansion in percentage with 1e18 being 100%.
-   * @param expansionfrequency The frequency of expansion in seconds.
-   * @param lastExpansion The last timestamp an expansion was done.
+   * @param expansionFrequency The frequency of expansion in seconds.
+   * @param lastExpansion The timestamp of the last prior expansion.
    */
   struct ExchangeExpansionConfig {
     uint64 expansionRate;
@@ -36,38 +36,38 @@ interface IGoodDollarExpansionController {
   event ReserveUpdated(address indexed reserve);
 
   /**
-   * @notice Emitted when the AVATAR address is updated.
-   * @param avatar The address of the new AVATAR.
+   * @notice Emitted when the GoodDollar DAO address is updated.
+   * @param avatar The new address of the GoodDollar DAO.
    */
   event AvatarUpdated(address indexed avatar);
 
   /**
-   * @notice Emitted when the expansion config is set for an exchange.
-   * @param exchangeId The id of the exchange.
+   * @notice Emitted when the expansion config is set for an pool.
+   * @param exchangeId The ID of the pool.
    * @param expansionRate The rate of expansion.
-   * @param expansionfrequency The frequency of expansion.
+   * @param expansionFrequency The frequency of expansion.
    */
-  event ExpansionConfigSet(bytes32 indexed exchangeId, uint64 expansionRate, uint32 expansionfrequency);
+  event ExpansionConfigSet(bytes32 indexed exchangeId, uint64 expansionRate, uint32 expansionFrequency);
 
   /**
-   * @notice Emitted when a reward is minted.
-   * @param exchangeId The id of the exchange.
+   * @notice Emitted when a G$ reward is minted.
+   * @param exchangeId The ID of the pool.
    * @param to The address of the recipient.
-   * @param amount The amount of tokens minted.
+   * @param amount The amount of G$ tokens minted.
    */
   event RewardMinted(bytes32 indexed exchangeId, address indexed to, uint256 amount);
 
   /**
    * @notice Emitted when UBI is minted through collecting reserve interest.
-   * @param exchangeId The id of the exchange.
-   * @param amount Amount of tokens minted.
+   * @param exchangeId The ID of the pool.
+   * @param amount The amount of G$ tokens minted.
    */
   event InterestUBIMinted(bytes32 indexed exchangeId, uint256 amount);
 
   /**
    * @notice Emitted when UBI is minted through expansion.
-   * @param exchangeId The id of the exchange.
-   * @param amount Amount of tokens minted.
+   * @param exchangeId The ID of the pool.
+   * @param amount The amount of G$ tokens minted.
    */
   event ExpansionUBIMinted(bytes32 indexed exchangeId, uint256 amount);
 
@@ -86,6 +86,13 @@ interface IGoodDollarExpansionController {
     address _reserve,
     address _avatar
   ) external;
+
+  /**
+   * @notice Returns the expansion config for the given exchange.
+   * @param exchangeId The id of the exchange to get the expansion config for.
+   * @return config The expansion config.
+   */
+  function getExpansionConfig(bytes32 exchangeId) external returns (ExchangeExpansionConfig memory);
 
   /**
    * @notice Sets the GoodDollarExchangeProvider address.
@@ -112,39 +119,39 @@ interface IGoodDollarExpansionController {
   function setAvatar(address _avatar) external;
 
   /**
-   * @notice Sets the expansion config for the given exchange.
-   * @param exchangeId The id of the exchange to set the expansion config for.
+   * @notice Sets the expansion config for the given pool.
+   * @param exchangeId The ID of the pool to set the expansion config for.
    * @param expansionRate The rate of expansion.
    * @param expansionFrequency The frequency of expansion.
    */
   function setExpansionConfig(bytes32 exchangeId, uint64 expansionRate, uint32 expansionFrequency) external;
 
   /**
-   * @notice Mints UBI for the given exchange from collecting reserve interest.
-   * @param exchangeId The id of the exchange to mint UBI for.
+   * @notice Mints UBI as G$ tokens for a given pool from collected reserve interest.
+   * @param exchangeId The ID of the pool to mint UBI for.
    * @param reserveInterest The amount of reserve tokens collected from interest.
    */
   function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external;
 
   /**
-   * @notice Mints UBI for the given exchange by comparing the reserve Balance of the contract to the virtual balance.
-   * @param exchangeId The id of the exchange to mint UBI for.
-   * @return amountMinted The amount of UBI tokens minted.
+   * @notice Mints UBI as G$ tokens for a given pool by comparing the contract's reserve balance to the virtual balance.
+   * @param exchangeId The ID of the pool to mint UBI for.
+   * @return amountMinted The amount of G$ tokens minted.
    */
   function mintUBIFromReserveBalance(bytes32 exchangeId) external returns (uint256 amountMinted);
 
   /**
-   * @notice Mints UBI for the given exchange by calculating the expansion rate.
-   * @param exchangeId The id of the exchange to mint UBI for.
-   * @return amountMinted The amount of UBI tokens minted.
+   * @notice Mints UBI as G$ tokens for a given pool by calculating the expansion rate.
+   * @param exchangeId The ID of the pool to mint UBI for.
+   * @return amountMinted The amount of G$ tokens minted.
    */
   function mintUBIFromExpansion(bytes32 exchangeId) external returns (uint256 amountMinted);
 
   /**
-   * @notice Mints a reward of tokens for the given exchange.
-   * @param exchangeId The id of the exchange to mint reward.
+   * @notice Mints a reward of G$ tokens for a given pool.
+   * @param exchangeId The ID of the pool to mint a G$ reward for.
    * @param to The address of the recipient.
-   * @param amount The amount of tokens to mint.
+   * @param amount The amount of G$ tokens to mint.
    */
-  function mintRewardFromRR(bytes32 exchangeId, address to, uint256 amount) external;
+  function mintRewardFromReserveRatio(bytes32 exchangeId, address to, uint256 amount) external;
 }

--- a/contracts/swap/Broker.sol
+++ b/contracts/swap/Broker.sol
@@ -187,7 +187,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     bytes32 exchangeId,
     address token,
     ITradingLimits.Config memory config
-  ) public onlyOwner {
+  ) external onlyOwner {
     config.validate();
 
     bytes32 limitId = exchangeId ^ bytes32(uint256(uint160(token)));

--- a/contracts/swap/Broker.sol
+++ b/contracts/swap/Broker.sol
@@ -14,7 +14,6 @@ import { ITradingLimits } from "../interfaces/ITradingLimits.sol";
 
 import { TradingLimits } from "../libraries/TradingLimits.sol";
 import { Initializable } from "celo/contracts/common/Initializable.sol";
-// TODO: ensure we can use latest impl of openzeppelin
 import { ReentrancyGuard } from "openzeppelin-contracts-next/contracts/security/ReentrancyGuard.sol";
 
 interface IERC20Metadata {
@@ -35,7 +34,10 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
 
   /* ==================== State Variables ==================== */
 
+  /// @inheritdoc IBroker
   address[] public exchangeProviders;
+
+  /// @inheritdoc IBroker
   mapping(address => bool) public isExchangeProvider;
   mapping(bytes32 => ITradingLimits.State) public tradingLimitsState;
   mapping(bytes32 => ITradingLimits.Config) public tradingLimitsConfig;
@@ -55,11 +57,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
    */
   constructor(bool test) Initializable(test) {}
 
-  /**
-   * @notice Allows the contract to be upgradable via the proxy.
-   * @param _exchangeProviders The addresses of the ExchangeProvider contracts.
-   * @param _reserves The addresses of the Reserve contracts.
-   */
+  /// @inheritdoc IBroker
   function initialize(address[] calldata _exchangeProviders, address[] calldata _reserves) external initializer {
     _transferOwnership(msg.sender);
     for (uint256 i = 0; i < _exchangeProviders.length; i++) {
@@ -67,11 +65,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     }
   }
 
-  /**
-   * @notice Set the reserves for the exchange providers.
-   * @param _exchangeProviders The addresses of the ExchangeProvider contracts.
-   * @param _reserves The addresses of the Reserve contracts.
-   */
+  /// @inheritdoc IBroker
   function setReserves(
     address[] calldata _exchangeProviders,
     address[] calldata _reserves
@@ -86,12 +80,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
 
   /* ==================== Mutative Functions ==================== */
 
-  /**
-   * @notice Add an exchange provider to the list of providers.
-   * @param exchangeProvider The address of the exchange provider to add.
-   * @param reserve The address of the reserve used by the exchange provider.
-   * @return index The index of the newly added specified exchange provider.
-   */
+  /// @inheritdoc IBroker
   function addExchangeProvider(
     address exchangeProvider,
     address reserve
@@ -107,11 +96,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     index = exchangeProviders.length - 1;
   }
 
-  /**
-   * @notice Remove an exchange provider from the list of providers.
-   * @param exchangeProvider The address of the exchange provider to remove.
-   * @param index The index of the exchange provider being removed.
-   */
+  /// @inheritdoc IBroker
   function removeExchangeProvider(
     address exchangeProvider,
     uint256 index
@@ -124,15 +109,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     emit ExchangeProviderRemoved(exchangeProvider);
   }
 
-  /**
-   * @notice Calculate the amount of tokenIn to be sold for a given amountOut of tokenOut
-   * @param exchangeProvider the address of the exchange manager for the pair
-   * @param exchangeId The id of the exchange to use
-   * @param tokenIn The token to be sold
-   * @param tokenOut The token to be bought
-   * @param amountOut The amount of tokenOut to be bought
-   * @return amountIn The amount of tokenIn to be sold
-   */
+  /// @inheritdoc IBroker
   function getAmountIn(
     address exchangeProvider,
     bytes32 exchangeId,
@@ -144,15 +121,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     amountIn = IExchangeProvider(exchangeProvider).getAmountIn(exchangeId, tokenIn, tokenOut, amountOut);
   }
 
-  /**
-   * @notice Calculate the amount of tokenOut to be bought for a given amount of tokenIn to be sold
-   * @param exchangeProvider the address of the exchange manager for the pair
-   * @param exchangeId The id of the exchange to use
-   * @param tokenIn The token to be sold
-   * @param tokenOut The token to be bought
-   * @param amountIn The amount of tokenIn to be sold
-   * @return amountOut The amount of tokenOut to be bought
-   */
+  /// @inheritdoc IBroker
   function getAmountOut(
     address exchangeProvider,
     bytes32 exchangeId,
@@ -164,16 +133,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     amountOut = IExchangeProvider(exchangeProvider).getAmountOut(exchangeId, tokenIn, tokenOut, amountIn);
   }
 
-  /**
-   * @notice Execute a token swap with fixed amountIn.
-   * @param exchangeProvider the address of the exchange provider for the pair.
-   * @param exchangeId The id of the exchange to use.
-   * @param tokenIn The token to be sold.
-   * @param tokenOut The token to be bought.
-   * @param amountIn The amount of tokenIn to be sold.
-   * @param amountOutMin Minimum amountOut to be received - controls slippage.
-   * @return amountOut The amount of tokenOut to be bought.
-   */
+  /// @inheritdoc IBroker
   function swapIn(
     address exchangeProvider,
     bytes32 exchangeId,
@@ -194,16 +154,7 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     emit Swap(exchangeProvider, exchangeId, msg.sender, tokenIn, tokenOut, amountIn, amountOut);
   }
 
-  /**
-   * @notice Execute a token swap with fixed amountOut.
-   * @param exchangeProvider the address of the exchange provider for the pair.
-   * @param exchangeId The id of the exchange to use.
-   * @param tokenIn The token to be sold.
-   * @param tokenOut The token to be bought.
-   * @param amountOut The amount of tokenOut to be bought.
-   * @param amountInMax Maximum amount of tokenIn that can be traded.
-   * @return amountIn The amount of tokenIn to be sold.
-   */
+  /// @inheritdoc IBroker
   function swapOut(
     address exchangeProvider,
     bytes32 exchangeId,
@@ -224,30 +175,14 @@ contract Broker is IBroker, IBrokerAdmin, Initializable, Ownable, ReentrancyGuar
     emit Swap(exchangeProvider, exchangeId, msg.sender, tokenIn, tokenOut, amountIn, amountOut);
   }
 
-  /**
-   * @notice Permissionless way to burn stables from msg.sender directly.
-   * @param token The token getting burned.
-   * @param amount The amount of the token getting burned.
-   * @return True if transaction succeeds.
-   */
+  /// @inheritdoc IBroker
   function burnStableTokens(address token, uint256 amount) public returns (bool) {
     IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
     IERC20(token).safeBurn(amount);
     return true;
   }
 
-  /**
-   * @notice Configure trading limits for an (exchangeId, token) touple.
-   * @dev Will revert if the configuration is not valid according to the
-   * TradingLimits library.
-   * Resets existing state according to the TradingLimits library logic.
-   * Can only be called by owner.
-   * @param exchangeId the exchangeId to target.
-   * @param token the token to target.
-   * @param config the new trading limits config.
-   */
-  // TODO: Make this external with next update.
-  // slither-disable-next-line external-function
+  /// @inheritdoc IBroker
   function configureTradingLimit(
     bytes32 exchangeId,
     address token,

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -189,7 +189,7 @@ contract BancorExchangeProviderTest_initilizerSettersGetters is BancorExchangePr
 
   function test_getPoolExchange_whenExchangeDoesNotExist_shouldRevert() public {
     bytes32 exchangeId = "0xexchangeId";
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     bancorExchangeProvider.getPoolExchange(exchangeId);
   }
 
@@ -260,7 +260,7 @@ contract BancorExchangeProviderTest_createExchange is BancorExchangeProviderTest
       abi.encodeWithSelector(IReserve(reserveAddress).isCollateralAsset.selector, address(reserveToken)),
       abi.encode(false)
     );
-    vm.expectRevert("reserve asset must be a collateral registered with the reserve");
+    vm.expectRevert("Reserve asset must be a collateral registered with the reserve");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 
@@ -276,28 +276,28 @@ contract BancorExchangeProviderTest_createExchange is BancorExchangeProviderTest
       abi.encodeWithSelector(IReserve(reserveAddress).isStableAsset.selector, address(token)),
       abi.encode(false)
     );
-    vm.expectRevert("token must be a stable registered with the reserve");
+    vm.expectRevert("Token must be a stable registered with the reserve");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 
   function test_createExchange_whenReserveRatioIsSmaller2_shouldRevert() public {
     poolExchange1.reserveRatio = 0;
-    vm.expectRevert("Invalid reserve ratio");
+    vm.expectRevert("Reserve ratio is too low");
     bancorExchangeProvider.createExchange(poolExchange1);
     poolExchange1.reserveRatio = 1;
-    vm.expectRevert("Invalid reserve ratio");
+    vm.expectRevert("Reserve ratio is too low");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 
   function test_createExchange_whenReserveRatioAbove100Percent_shouldRevert() public {
     poolExchange1.reserveRatio = bancorExchangeProvider.MAX_WEIGHT() + 1;
-    vm.expectRevert("Invalid reserve ratio");
+    vm.expectRevert("Reserve ratio is too high");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 
   function test_createExchange_whenExitContributionAbove100Percent_shouldRevert() public {
     poolExchange1.exitContribution = bancorExchangeProvider.MAX_WEIGHT() + 1;
-    vm.expectRevert("Invalid exit contribution");
+    vm.expectRevert("Exit contribution is too high");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 
@@ -309,13 +309,13 @@ contract BancorExchangeProviderTest_createExchange is BancorExchangeProviderTest
 
   function test_createExchanges_whenReserveTokenHasMoreDecimalsThan18_shouldRevert() public {
     vm.mockCall(address(reserveToken), abi.encodeWithSelector(reserveToken.decimals.selector), abi.encode(19));
-    vm.expectRevert("reserve token decimals must be <= 18");
+    vm.expectRevert("Reserve asset decimals must be <= 18");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 
   function test_createExchange_whenTokenHasMoreDecimalsThan18_shouldRevert() public {
     vm.mockCall(address(token), abi.encodeWithSelector(token.decimals.selector), abi.encode(19));
-    vm.expectRevert("token decimals must be <= 18");
+    vm.expectRevert("Token decimals must be <= 18");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 
@@ -398,7 +398,7 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
 
   function test_getAmountIn_whenExchangeDoesNotExist_shouldRevert() public {
     bytes32 exchangeId = "0xexchangeId";
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     bancorExchangeProvider.getAmountIn(exchangeId, address(reserveToken), address(token), 1e18);
   }
 
@@ -449,7 +449,7 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
 
   function test_getAmountOut_whenExchangeDoesNotExist_shouldRevert() public {
     bytes32 exchangeId = "0xexchangeId";
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     bancorExchangeProvider.getAmountOut(exchangeId, address(reserveToken), address(token), 1e18);
   }
 
@@ -526,7 +526,7 @@ contract BancorExchangeProviderTest_swapIn is BancorExchangeProviderTest {
   function test_swapIn_whenExchangeDoesNotExist_shouldRevert() public {
     BancorExchangeProvider bancorExchangeProvider = initializeBancorExchangeProvider();
     vm.prank(brokerAddress);
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     bancorExchangeProvider.swapIn("0xexchangeId", address(reserveToken), address(token), 1e18);
   }
 
@@ -615,7 +615,7 @@ contract BancorExchangeProviderTest_swapOut is BancorExchangeProviderTest {
   function test_swapOut_whenExchangeDoesNotExist_shouldRevert() public {
     BancorExchangeProvider bancorExchangeProvider = initializeBancorExchangeProvider();
     vm.prank(brokerAddress);
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     bancorExchangeProvider.swapOut("0xexchangeId", address(reserveToken), address(token), 1e18);
   }
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -169,7 +169,7 @@ contract BancorExchangeProviderTest_initilizerSettersGetters is BancorExchangePr
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
 
     uint32 maxWeight = bancorExchangeProvider.MAX_WEIGHT();
-    vm.expectRevert("Invalid exit contribution");
+    vm.expectRevert("Exit contribution is too high");
     bancorExchangeProvider.setExitContribution(exchangeId, maxWeight + 1);
   }
 

--- a/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
+++ b/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
@@ -314,7 +314,7 @@ contract GoodDollarExchangeProviderTest_mintFromExpansion is GoodDollarExchangeP
 
   function test_mintFromExpansion_whenExchangeIdIsInvalid_shouldRevert() public {
     vm.prank(expansionControllerAddress);
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     exchangeProvider.mintFromExpansion(bytes32(0), expansionRate);
   }
 
@@ -374,7 +374,7 @@ contract GoodDollarExchangeProviderTest_mintFromInterest is GoodDollarExchangePr
 
   function test_mintFromInterest_whenExchangeIdIsInvalid_shouldRevert() public {
     vm.prank(expansionControllerAddress);
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     exchangeProvider.mintFromInterest(bytes32(0), reserveInterest);
   }
 
@@ -431,7 +431,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
 
   function test_updateRatioForReward_whenExchangeIdIsInvalid_shouldRevert() public {
     vm.prank(expansionControllerAddress);
-    vm.expectRevert("An exchange with the specified id does not exist");
+    vm.expectRevert("Exchange does not exist");
     exchangeProvider.updateRatioForReward(bytes32(0), reward);
   }
 

--- a/test/unit/goodDollar/GoodDollarExpansionController.t.sol
+++ b/test/unit/goodDollar/GoodDollarExpansionController.t.sol
@@ -137,7 +137,7 @@ contract GoodDollarExpansionControllerTest_initializerSettersGetters is GoodDoll
 
   function test_setDistributionHelper_whenAddressIsZero_shouldRevert() public {
     vm.startPrank(avatarAddress);
-    vm.expectRevert("DistributionHelper address must be set");
+    vm.expectRevert("Distribution helper address must be set");
     expansionController.setDistributionHelper(address(0));
     vm.stopPrank();
   }
@@ -271,7 +271,7 @@ contract GoodDollarExpansionControllerTest_mintUBIFromInterest is GoodDollarExpa
   }
 
   function test_mintUBIFromInterest_whenReserveInterestIs0_shouldRevert() public {
-    vm.expectRevert("reserveInterest must be greater than 0");
+    vm.expectRevert("Reserve interest must be greater than 0");
     expansionController.mintUBIFromInterest(exchangeId, 0);
   }
 

--- a/test/unit/goodDollar/GoodDollarExpansionController.t.sol
+++ b/test/unit/goodDollar/GoodDollarExpansionController.t.sol
@@ -23,7 +23,7 @@ contract GoodDollarExpansionControllerTest is Test {
 
   event AvatarUpdated(address indexed avatar);
 
-  event ExpansionConfigSet(bytes32 indexed exchangeId, uint64 expansionRate, uint32 expansionfrequency);
+  event ExpansionConfigSet(bytes32 indexed exchangeId, uint64 expansionRate, uint32 expansionFrequency);
 
   event RewardMinted(bytes32 indexed exchangeId, address indexed to, uint256 amount);
 
@@ -564,7 +564,7 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
   }
 }
 
-contract GoodDollarExpansionControllerTest_mintRewardFromRR is GoodDollarExpansionControllerTest {
+contract GoodDollarExpansionControllerTest_mintRewardFromReserveRatio is GoodDollarExpansionControllerTest {
   GoodDollarExpansionController expansionController;
 
   function setUp() public override {
@@ -595,25 +595,25 @@ contract GoodDollarExpansionControllerTest_mintRewardFromRR is GoodDollarExpansi
     );
   }
 
-  function test_mintRewardFromRR_whenCallerIsNotAvatar_shouldRevert() public {
+  function test_mintRewardFromReserveRatio_whenCallerIsNotAvatar_shouldRevert() public {
     vm.prank(makeAddr("NotAvatar"));
     vm.expectRevert("Only Avatar can call this function");
-    expansionController.mintRewardFromRR(exchangeId, makeAddr("To"), 1000e18);
+    expansionController.mintRewardFromReserveRatio(exchangeId, makeAddr("To"), 1000e18);
   }
 
-  function test_mintRewardFromRR_whenToIsZero_shouldRevert() public {
+  function test_mintRewardFromReserveRatio_whenToIsZero_shouldRevert() public {
     vm.prank(avatarAddress);
-    vm.expectRevert("Invalid to address");
-    expansionController.mintRewardFromRR(exchangeId, address(0), 1000e18);
+    vm.expectRevert("Recipient address must be set");
+    expansionController.mintRewardFromReserveRatio(exchangeId, address(0), 1000e18);
   }
 
-  function test_mintRewardFromRR_whenAmountIs0_shouldRevert() public {
+  function test_mintRewardFromReserveRatio_whenAmountIs0_shouldRevert() public {
     vm.prank(avatarAddress);
     vm.expectRevert("Amount must be greater than 0");
-    expansionController.mintRewardFromRR(exchangeId, makeAddr("To"), 0);
+    expansionController.mintRewardFromReserveRatio(exchangeId, makeAddr("To"), 0);
   }
 
-  function test_mintRewardFromRR_whenCallerIsAvatar_shouldMintAndEmit() public {
+  function test_mintRewardFromReserveRatio_whenCallerIsAvatar_shouldMintAndEmit() public {
     uint256 amountToMint = 1000e18;
     address to = makeAddr("To");
     uint256 toBalanceBefore = token.balanceOf(to);
@@ -622,7 +622,7 @@ contract GoodDollarExpansionControllerTest_mintRewardFromRR is GoodDollarExpansi
     emit RewardMinted(exchangeId, to, amountToMint);
 
     vm.prank(avatarAddress);
-    expansionController.mintRewardFromRR(exchangeId, to, amountToMint);
+    expansionController.mintRewardFromReserveRatio(exchangeId, to, amountToMint);
 
     assertEq(token.balanceOf(to), toBalanceBefore + amountToMint);
   }


### PR DESCRIPTION
### Description

Fixes https://github.com/mento-protocol/mento-general/issues/552

- [x] Made error messages across GoodDollar contracts more consistent
- [x] Made comments across GoodDollar comments more consistent
- [x] Introduced @inheritdoc to reduce comment duplication between interfaces and implementations in 0.8 contracts
- [x] Changed `Broker.configureTradingLimit()` from ~~public~~ to **external**