### PR TITLE
Feat: locking l2 upgrade

### DIFF
--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -93,7 +93,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    */
   LibBrokenLine.BrokenLine public totalSupplyLine;
 
-  // *************** 
+  // ***************
   // New variables for L2 transition upgrade (4 slots)
   // ***************
   /**
@@ -105,7 +105,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    */
   address public mentoLabsMultisig;
   /**
-   * @dev L2 starting point week number used to move the first week after the L2 transition to the last week before the L2 transition
+   * @dev L2 starting point week number
    */
   int256 public l2StartingPointWeek;
   /**
@@ -300,7 +300,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    */
   function roundTimestamp(uint32 ts) public view returns (uint32) {
     require(!paused, "locking is paused");
-    
+
     if (ts < getEpochShift()) {
       return 0;
     }
@@ -316,7 +316,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
 
   /**
    * @notice method returns the amount of blocks to shift locking epoch to on L1 CELO.
-   * we move it to 00-00 UTC Wednesday (approx) by shifting 89964 blocks 
+   * we move it to 00-00 UTC Wednesday (approx) by shifting 89964 blocks
    */
   function getEpochShift() internal view virtual returns (uint32) {
     return 89964;
@@ -399,45 +399,42 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
     updateTotalSupplyLine(time);
   }
   /**
-    * @notice Sets the Mento Labs multisig address
-    * @param mentoLabsMultisig_ address of the Mento Labs multisig
-    *
-    */
+   * @notice Sets the Mento Labs multisig address
+   * @param mentoLabsMultisig_ address of the Mento Labs multisig
+   *
+   */
   function setMentoLabsMultisig(address mentoLabsMultisig_) external onlyOwner {
     mentoLabsMultisig = mentoLabsMultisig_;
   }
   /**
-    * @notice Sets the L2 transition block number and pauses locking and governance
-    * @param blockNo block number of the L2 transition
-    *
-    */
-  function setL2TransitionBlock(uint256 blockNo) external onlyMentoLabs{
-
+   * @notice Sets the L2 transition block number and pauses locking and governance
+   * @param blockNo block number of the L2 transition
+   *
+   */
+  function setL2TransitionBlock(uint256 blockNo) external onlyMentoLabs {
     l2Block = blockNo;
     paused = true;
   }
 
   /**
-    * @notice Sets the L2 shift amount
-    * @param l2Shift_ shift amount that will be used after L2 transition
+   * @notice Sets the L2 shift amount
+   * @param l2Shift_ shift amount that will be used after L2 transition
    */
-  function setL2Shift(uint32 l2Shift_) external onlyMentoLabs{
-
+  function setL2Shift(uint32 l2Shift_) external onlyMentoLabs {
     l2Shift = l2Shift_;
   }
 
   /**
-    * @notice Sets the L2 starting point week number
-    * @param l2StartingPointWeek_ starting point week number that will be used after L2 transition
+   * @notice Sets the L2 starting point week number
+   * @param l2StartingPointWeek_ starting point week number that will be used after L2 transition
    */
   function setL2StartingPointWeek(int256 l2StartingPointWeek_) external onlyMentoLabs {
-
     l2StartingPointWeek = l2StartingPointWeek_;
   }
 
   /**
-    * @notice Sets the paused flag
-    * @param paused_ flag to pause locking and governance
+   * @notice Sets the paused flag
+   * @param paused_ flag to pause locking and governance
    */
   function setPaused(bool paused_) external onlyMentoLabs {
     paused = paused_;

--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -401,16 +401,16 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
   /**
     * @notice Sets the Mento Labs multisig address
     * @param mentoLabsMultisig_ address of the Mento Labs multisig
+    *
     */
-   */
   function setMentoLabsMultisig(address mentoLabsMultisig_) external onlyOwner {
     mentoLabsMultisig = mentoLabsMultisig_;
   }
   /**
     * @notice Sets the L2 transition block number and pauses locking and governance
     * @param blockNo block number of the L2 transition
+    *
     */
-   */
   function setL2TransitionBlock(uint256 blockNo) external onlyMentoLabs{
 
     l2Block = blockNo;
@@ -419,7 +419,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
 
   /**
     * @notice Sets the L2 shift amount
-    * @param _l2Shift shift amount that will be used after L2 transition
+    * @param l2Shift_ shift amount that will be used after L2 transition
    */
   function setL2Shift(uint32 l2Shift_) external onlyMentoLabs{
 

--- a/contracts/governance/locking/LockingBase.sol
+++ b/contracts/governance/locking/LockingBase.sol
@@ -7,8 +7,6 @@ import "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.s
 import "openzeppelin-contracts-upgradeable/contracts/governance/utils/IVotesUpgradeable.sol";
 import "./libs/LibBrokenLine.sol";
 
-import "forge-std/console.sol";
-
 /**
  * @title LockingBase
  * @dev This abstract contract provides the foundational functionality
@@ -94,16 +92,12 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
   LibBrokenLine.BrokenLine public totalSupplyLine;
 
   // ***************
-  // New variables for L2 transition upgrade (4 slots)
+  // New variables for L2 transition upgrade (3 slots)
   // ***************
   /**
    * @dev L2 transtion block number
    */
   uint256 public l2Block;
-  /**
-   * @dev Address of the Mento Labs multisig
-   */
-  address public mentoLabsMultisig;
   /**
    * @dev L2 starting point week number
    */
@@ -112,6 +106,10 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
    * @dev Shift amount used after L2 transition to move the start of the epoch to 00-00 UTC Wednesday (approx)
    */
   uint32 public l2Shift;
+  /**
+   * @dev Address of the Mento Labs multisig
+   */
+  address public mentoLabsMultisig;
   /**
    * @dev Flag to pause locking and governance
    */
@@ -315,7 +313,7 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
   }
 
   /**
-   * @notice method returns the amount of blocks to shift locking epoch to on L1 CELO.
+   * @notice method returns the amount of blocks to shift locking epoch on L1 CELO.
    * we move it to 00-00 UTC Wednesday (approx) by shifting 89964 blocks
    */
   function getEpochShift() internal view virtual returns (uint32) {
@@ -408,11 +406,11 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
   }
   /**
    * @notice Sets the L2 transition block number and pauses locking and governance
-   * @param blockNo block number of the L2 transition
+   * @param l2Block_ block number of the L2 transition
    *
    */
-  function setL2TransitionBlock(uint256 blockNo) external onlyMentoLabs {
-    l2Block = blockNo;
+  function setL2TransitionBlock(uint256 l2Block_) external onlyMentoLabs {
+    l2Block = l2Block_;
     paused = true;
   }
 
@@ -440,5 +438,5 @@ abstract contract LockingBase is OwnableUpgradeable, IVotesUpgradeable {
     paused = paused_;
   }
 
-  uint256[46] private __gap;
+  uint256[47] private __gap;
 }

--- a/test/fork/ForkTests.t.sol
+++ b/test/fork/ForkTests.t.sol
@@ -44,6 +44,7 @@ import { BancorExchangeProviderForkTest } from "./BancorExchangeProviderForkTest
 import { GoodDollarTradingLimitsForkTest } from "./GoodDollar/TradingLimitsForkTest.sol";
 import { GoodDollarSwapForkTest } from "./GoodDollar/SwapForkTest.sol";
 import { GoodDollarExpansionForkTest } from "./GoodDollar/ExpansionForkTest.sol";
+import { LockingUpgradeForkTest } from "./upgrades/LockingUpgradeForkTest.sol";
 
 contract Alfajores_ChainForkTest is ChainForkTest(ALFAJORES_ID, 1, uints(15)) {}
 
@@ -116,3 +117,5 @@ contract Celo_GoodDollarTradingLimitsForkTest is GoodDollarTradingLimitsForkTest
 contract Celo_GoodDollarSwapForkTest is GoodDollarSwapForkTest(CELO_ID) {}
 
 contract Celo_GoodDollarExpansionForkTest is GoodDollarExpansionForkTest(CELO_ID) {}
+
+contract Celo_LockingUpgradeForkTest is LockingUpgradeForkTest(CELO_ID) {}

--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -6,10 +6,9 @@ import { Locking } from "contracts/governance/locking/Locking.sol";
 import { GovernanceFactory } from "contracts/governance/GovernanceFactory.sol";
 import { ProxyAdmin } from "openzeppelin-contracts-next/contracts/proxy/transparent/ProxyAdmin.sol";
 import { ITransparentUpgradeableProxy } from "openzeppelin-contracts-next/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "forge-std/console.sol";
 
 // used to avoid stack too deep error
-struct Balances {
+struct LockingSnapshot {
   uint256 totalSupply;
   uint256 pastTotalSupply;
   uint256 balance1;
@@ -23,6 +22,7 @@ struct Balances {
   uint256 withdrawable1;
   uint256 withdrawable2;
 }
+
 contract LockingUpgradeForkTest is BaseForkTest {
   // airdrop claimers from the mainnet
   address public constant AIRDROP_CLAIMER_1 = 0x3152eE4a18ee3209524F9071A6BcAdA098f19838;
@@ -50,129 +50,141 @@ contract LockingUpgradeForkTest is BaseForkTest {
     newLockingImplementation = address(new Locking());
     vm.prank(timelockController);
     proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(locking)), newLockingImplementation);
-  }
-
-  function test_upgrade() public {
-    Balances memory beforeBalances;
-    Balances memory afterBalances;
 
     vm.prank(timelockController);
     locking.setMentoLabsMultisig(mentoLabsMultisig);
 
-    // THU Nov-07-2024 12:00:23 AM +UTC
+    // THU Nov-07-2024 00:00:23 +UTC
     vm.roll(28653031);
     vm.warp(1730937623);
+  }
+
+  function test_blockNoDependentCalculations_afterL2Transition_shouldWorkAsBefore() public {
+    LockingSnapshot memory beforeSnapshot;
+    LockingSnapshot memory afterSnapshot;
 
     // move 3 weeks forward on L1
-    moveDays(3 * 7, true, false);
+    _moveDays({ day: 3 * 7, forward: true, isL2: false });
 
     uint256 weekNoBefore = locking.getWeek();
 
-    beforeBalances.totalSupply = locking.totalSupply();
-    beforeBalances.pastTotalSupply = locking.getPastTotalSupply(block.number - 3 * L1_WEEK);
-    beforeBalances.balance1 = locking.balanceOf(AIRDROP_CLAIMER_1);
-    beforeBalances.balance2 = locking.balanceOf(AIRDROP_CLAIMER_2);
-    beforeBalances.votingPower1 = locking.getVotes(AIRDROP_CLAIMER_1);
-    beforeBalances.votingPower2 = locking.getVotes(AIRDROP_CLAIMER_2);
-    beforeBalances.pastVotingPower1 = locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L1_WEEK);
-    beforeBalances.pastVotingPower2 = locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L1_WEEK);
-    beforeBalances.lockedBalance1 = locking.locked(AIRDROP_CLAIMER_1);
-    beforeBalances.lockedBalance2 = locking.locked(AIRDROP_CLAIMER_2);
-    beforeBalances.withdrawable1 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1);
-    beforeBalances.withdrawable2 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2);
+    // Take snapshot 3 weeks after Nov 07
+    beforeSnapshot = _takeSnapshot(AIRDROP_CLAIMER_1, AIRDROP_CLAIMER_2);
 
     // move 5 weeks forward on L1
-    moveDays(5 * 7, true, false);
+    _moveDays({ day: 5 * 7, forward: true, isL2: false });
 
-    afterBalances.totalSupply = locking.totalSupply();
-    afterBalances.pastTotalSupply = locking.getPastTotalSupply(block.number - 3 * L1_WEEK);
-    afterBalances.balance1 = locking.balanceOf(AIRDROP_CLAIMER_1);
-    afterBalances.balance2 = locking.balanceOf(AIRDROP_CLAIMER_2);
-    afterBalances.votingPower1 = locking.getVotes(AIRDROP_CLAIMER_1);
-    afterBalances.votingPower2 = locking.getVotes(AIRDROP_CLAIMER_2);
-    afterBalances.pastVotingPower1 = locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L1_WEEK);
-    afterBalances.pastVotingPower2 = locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L1_WEEK);
-    afterBalances.lockedBalance1 = locking.locked(AIRDROP_CLAIMER_1);
-    afterBalances.lockedBalance2 = locking.locked(AIRDROP_CLAIMER_2);
-    afterBalances.withdrawable1 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1);
-    afterBalances.withdrawable2 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2);
+    // Take snapshot 8 weeks after Nov 07
+    afterSnapshot = _takeSnapshot(AIRDROP_CLAIMER_1, AIRDROP_CLAIMER_2);
 
-    // move 35 days backward on L1
-    moveDays(35, false, false);
+    // move 5 weeks backward on L1
+    _moveDays({ day: 5 * 7, forward: false, isL2: false });
 
-    uint256 blocksTillNextWeek = ((L1_WEEK * (locking.getWeek() + locking.startingPointWeek() + 1)) + 89964) -
-      block.number;
+    uint256 blocksTillNextWeekL1 = _calculateBlocksTillNextWeek({ isL2: false });
 
-    // simulate L2 upgrade
-    vm.prank(mentoLabsMultisig);
-    locking.setL2TransitionBlock(block.number);
+    _simulateL2Upgrade();
 
-    vm.prank(mentoLabsMultisig);
-    locking.setL2StartingPointWeek(20);
-
-    vm.prank(mentoLabsMultisig);
-    locking.setL2Shift(507776);
-
-    vm.prank(mentoLabsMultisig);
-    locking.setPaused(false);
-
-    uint256 blocksTillNextWeek2 = ((L2_WEEK * (locking.getWeek() + uint256(locking.l2StartingPointWeek()) + 1)) +
-      507776) - block.number;
+    uint256 blocksTillNextWeekL2 = _calculateBlocksTillNextWeek({ isL2: true });
 
     // if the shift number is correct, the number of blocks till the next week should be 5 times the previous number
-    assertEq(blocksTillNextWeek2, 5 * blocksTillNextWeek);
+    assertEq(blocksTillNextWeekL2, 5 * blocksTillNextWeekL1);
 
     assertEq(locking.getWeek(), weekNoBefore);
-    assertEq(locking.totalSupply(), beforeBalances.totalSupply);
+    assertEq(locking.totalSupply(), beforeSnapshot.totalSupply);
     // the past values should be calculated using the L1 week value
-    assertEq(locking.getPastTotalSupply(block.number - 3 * L1_WEEK), beforeBalances.pastTotalSupply);
-    assertEq(locking.balanceOf(AIRDROP_CLAIMER_1), beforeBalances.balance1);
-    assertEq(locking.balanceOf(AIRDROP_CLAIMER_2), beforeBalances.balance2);
-    assertEq(locking.getVotes(AIRDROP_CLAIMER_1), beforeBalances.votingPower1);
-    assertEq(locking.getVotes(AIRDROP_CLAIMER_2), beforeBalances.votingPower2);
-    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L1_WEEK), beforeBalances.pastVotingPower1);
-    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L1_WEEK), beforeBalances.pastVotingPower2);
-    assertEq(locking.locked(AIRDROP_CLAIMER_1), beforeBalances.lockedBalance1);
-    assertEq(locking.locked(AIRDROP_CLAIMER_2), beforeBalances.lockedBalance2);
-    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1), beforeBalances.withdrawable1);
-    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2), beforeBalances.withdrawable2);
+    assertEq(locking.getPastTotalSupply(block.number - 3 * L1_WEEK), beforeSnapshot.pastTotalSupply);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_1), beforeSnapshot.balance1);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_2), beforeSnapshot.balance2);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_1), beforeSnapshot.votingPower1);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_2), beforeSnapshot.votingPower2);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L1_WEEK), beforeSnapshot.pastVotingPower1);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L1_WEEK), beforeSnapshot.pastVotingPower2);
+    assertEq(locking.locked(AIRDROP_CLAIMER_1), beforeSnapshot.lockedBalance1);
+    assertEq(locking.locked(AIRDROP_CLAIMER_2), beforeSnapshot.lockedBalance2);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1), beforeSnapshot.withdrawable1);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2), beforeSnapshot.withdrawable2);
 
-    // // move 5 weeks forward on L2
-    moveDays(5 * 7, true, true);
+    // move 5 weeks forward on L2
+    _moveDays({ day: 5 * 7, forward: true, isL2: true });
 
     assertEq(locking.getWeek(), weekNoBefore + 5);
 
-    blocksTillNextWeek2 =
-      ((L2_WEEK * (locking.getWeek() + uint256(locking.l2StartingPointWeek()) + 1)) + 507776) -
-      block.number;
+    blocksTillNextWeekL2 = _calculateBlocksTillNextWeek({ isL2: true });
 
-    assertEq(blocksTillNextWeek2, 5 * blocksTillNextWeek);
-    assertEq(locking.totalSupply(), afterBalances.totalSupply);
-    assertEq(locking.getPastTotalSupply(block.number - 3 * L2_WEEK), afterBalances.pastTotalSupply);
-    assertEq(locking.balanceOf(AIRDROP_CLAIMER_1), afterBalances.balance1);
-    assertEq(locking.balanceOf(AIRDROP_CLAIMER_2), afterBalances.balance2);
-    assertEq(locking.getVotes(AIRDROP_CLAIMER_1), afterBalances.votingPower1);
-    assertEq(locking.getVotes(AIRDROP_CLAIMER_2), afterBalances.votingPower2);
-    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L2_WEEK), afterBalances.pastVotingPower1);
-    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L2_WEEK), afterBalances.pastVotingPower2);
-    assertEq(locking.locked(AIRDROP_CLAIMER_1), afterBalances.lockedBalance1);
-    assertEq(locking.locked(AIRDROP_CLAIMER_2), afterBalances.lockedBalance2);
-    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1), afterBalances.withdrawable1);
-    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2), afterBalances.withdrawable2);
+    assertEq(blocksTillNextWeekL2, 5 * blocksTillNextWeekL1);
+    assertEq(locking.totalSupply(), afterSnapshot.totalSupply);
+    assertEq(locking.getPastTotalSupply(block.number - 3 * L2_WEEK), afterSnapshot.pastTotalSupply);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_1), afterSnapshot.balance1);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_2), afterSnapshot.balance2);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_1), afterSnapshot.votingPower1);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_2), afterSnapshot.votingPower2);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L2_WEEK), afterSnapshot.pastVotingPower1);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L2_WEEK), afterSnapshot.pastVotingPower2);
+    assertEq(locking.locked(AIRDROP_CLAIMER_1), afterSnapshot.lockedBalance1);
+    assertEq(locking.locked(AIRDROP_CLAIMER_2), afterSnapshot.lockedBalance2);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1), afterSnapshot.withdrawable1);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2), afterSnapshot.withdrawable2);
+
+    // move 5 days forward on L2
+    _moveDays({ day: 5, forward: true, isL2: true });
+    // we should be at the same week (TUE around 00:00)
+    assertEq(locking.getWeek(), weekNoBefore + 5);
+    // move 1 day forward on L2 + 90 mins as buffer
+    _moveDays({ day: 1, forward: true, isL2: true });
+    vm.roll(block.number + 90 minutes);
+    // we should be at the next week (WED around 01:00)
+    assertEq(locking.getWeek(), weekNoBefore + 6);
+  }
+
+  // takes a snapshot of the locking contract at current block
+  function _takeSnapshot(address claimer1, address claimer2) internal view returns (LockingSnapshot memory snapshot) {
+    snapshot.totalSupply = locking.totalSupply();
+    snapshot.pastTotalSupply = locking.getPastTotalSupply(block.number - 3 * L1_WEEK);
+    snapshot.balance1 = locking.balanceOf(claimer1);
+    snapshot.balance2 = locking.balanceOf(claimer2);
+    snapshot.votingPower1 = locking.getVotes(claimer1);
+    snapshot.votingPower2 = locking.getVotes(claimer2);
+    snapshot.pastVotingPower1 = locking.getPastVotes(claimer1, block.number - 3 * L1_WEEK);
+    snapshot.pastVotingPower2 = locking.getPastVotes(claimer2, block.number - 3 * L1_WEEK);
+    snapshot.lockedBalance1 = locking.locked(claimer1);
+    snapshot.lockedBalance2 = locking.locked(claimer2);
+    snapshot.withdrawable1 = locking.getAvailableForWithdraw(claimer1);
+    snapshot.withdrawable2 = locking.getAvailableForWithdraw(claimer2);
+  }
+
+  // returns the number of blocks till the next week
+  // by calculating the first block of the next week and substracting the current block
+  function _calculateBlocksTillNextWeek(bool isL2) internal view returns (uint256) {
+    if (isL2) {
+      return ((L2_WEEK * (locking.getWeek() + uint256(locking.l2StartingPointWeek()) + 1)) + 507776) - block.number;
+    } else {
+      return ((L1_WEEK * (locking.getWeek() + locking.startingPointWeek() + 1)) + 89964) - block.number;
+    }
+  }
+
+  // simulates the L2 upgrade by setting the necessary parameters
+  function _simulateL2Upgrade() internal {
+    vm.prank(mentoLabsMultisig);
+    locking.setL2TransitionBlock(block.number);
+    vm.prank(mentoLabsMultisig);
+    locking.setL2StartingPointWeek(20);
+    vm.prank(mentoLabsMultisig);
+    locking.setL2Shift(507776);
+    vm.prank(mentoLabsMultisig);
+    locking.setPaused(false);
   }
 
   // move days forward or backward on L1 or L2
-  function moveDays(uint256 day, bool forward, bool isL2) public {
+  function _moveDays(uint256 day, bool forward, bool isL2) internal {
     uint256 ts = vm.getBlockTimestamp();
     uint256 height = vm.getBlockNumber();
 
     uint256 newTs = forward ? ts + day * 1 days : ts - day * 1 days;
+
     uint256 blockChange = isL2 ? (day * 1 days) : ((day * 1 days) / 5);
     uint256 newHeight = forward ? height + blockChange : height - blockChange;
+
     vm.warp(newTs);
     vm.roll(newHeight);
-
-    ts = vm.getBlockTimestamp();
-    height = vm.getBlockNumber();
   }
 }

--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -131,7 +131,7 @@ contract LockingUpgradeForkTest is BaseForkTest {
     // move 1 day forward on L2 + 90 mins as buffer
     _moveDays({ day: 1, forward: true, isL2: true });
     vm.roll(block.number + 90 minutes);
-    // we should be at the next week (WED around 01:00)
+    // we should be at the next week (WED around 01:30)
     assertEq(locking.getWeek(), afterSnapshot.weekNo + 1);
   }
 

--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8;
+
+import { BaseForkTest } from "../BaseForkTest.sol";
+import { Locking } from "contracts/governance/locking/Locking.sol";
+import { GovernanceFactory } from "contracts/governance/GovernanceFactory.sol";
+import { ProxyAdmin } from "openzeppelin-contracts-next/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ITransparentUpgradeableProxy } from "openzeppelin-contracts-next/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "forge-std/console.sol";
+
+// used to avoid stack too deep error
+struct Balances {
+  uint256 totalSupply;
+  uint256 pastTotalSupply;
+  uint256 balance1;
+  uint256 balance2;
+  uint256 votingPower1;
+  uint256 votingPower2;
+  uint256 pastVotingPower1;
+  uint256 pastVotingPower2;
+  uint256 lockedBalance1;
+  uint256 lockedBalance2;
+  uint256 withdrawable1;
+  uint256 withdrawable2;
+}
+contract LockingUpgradeForkTest is BaseForkTest {
+  // airdrop claimers from the mainnet
+  address public constant AIRDROP_CLAIMER_1 = 0x3152eE4a18ee3209524F9071A6BcAdA098f19838;
+  address public constant AIRDROP_CLAIMER_2 = 0x44EB9Bf2D6B161499f1b706c331aa2Ba1d5069c7;
+
+  uint256 public constant L1_WEEK = 7 days / 5;
+  uint256 public constant L2_WEEK = 7 days;
+
+  GovernanceFactory public governanceFactory = GovernanceFactory(0xee6CE2dbe788dFC38b8F583Da86cB9caf2C8cF5A);
+  ProxyAdmin public proxyAdmin;
+  Locking public locking;
+  address public timelockController;
+  address public newLockingImplementation;
+
+  address public mentoLabsMultisig = makeAddr("mentoLabsMultisig");
+
+  constructor(uint256 _chainId) BaseForkTest(_chainId) {}
+
+  function setUp() public virtual override {
+    super.setUp();
+    proxyAdmin = governanceFactory.proxyAdmin();
+    locking = governanceFactory.locking();
+    timelockController = address(governanceFactory.governanceTimelock());
+
+    newLockingImplementation = address(new Locking());
+    vm.prank(timelockController);
+    proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(locking)), newLockingImplementation);
+  }
+
+  function test_upgrade() public {
+    Balances memory beforeBalances;
+    Balances memory afterBalances;
+
+    vm.prank(timelockController);
+    locking.setMentoLabsMultisig(mentoLabsMultisig);
+
+    // THU Nov-07-2024 12:00:23 AM +UTC
+    vm.roll(28653031);
+    vm.warp(1730937623);
+
+    // move 3 weeks forward on L1
+    moveDays(3 * 7, true, false);
+
+    uint256 weekNoBefore = locking.getWeek();
+
+    beforeBalances.totalSupply = locking.totalSupply();
+    beforeBalances.pastTotalSupply = locking.getPastTotalSupply(block.number - 3 * L1_WEEK);
+    beforeBalances.balance1 = locking.balanceOf(AIRDROP_CLAIMER_1);
+    beforeBalances.balance2 = locking.balanceOf(AIRDROP_CLAIMER_2);
+    beforeBalances.votingPower1 = locking.getVotes(AIRDROP_CLAIMER_1);
+    beforeBalances.votingPower2 = locking.getVotes(AIRDROP_CLAIMER_2);
+    beforeBalances.pastVotingPower1 = locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L1_WEEK);
+    beforeBalances.pastVotingPower2 = locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L1_WEEK);
+    beforeBalances.lockedBalance1 = locking.locked(AIRDROP_CLAIMER_1);
+    beforeBalances.lockedBalance2 = locking.locked(AIRDROP_CLAIMER_2);
+    beforeBalances.withdrawable1 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1);
+    beforeBalances.withdrawable2 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2);
+
+    // move 5 weeks forward on L1
+    moveDays(5 * 7, true, false);
+
+    afterBalances.totalSupply = locking.totalSupply();
+    afterBalances.pastTotalSupply = locking.getPastTotalSupply(block.number - 3 * L1_WEEK);
+    afterBalances.balance1 = locking.balanceOf(AIRDROP_CLAIMER_1);
+    afterBalances.balance2 = locking.balanceOf(AIRDROP_CLAIMER_2);
+    afterBalances.votingPower1 = locking.getVotes(AIRDROP_CLAIMER_1);
+    afterBalances.votingPower2 = locking.getVotes(AIRDROP_CLAIMER_2);
+    afterBalances.pastVotingPower1 = locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L1_WEEK);
+    afterBalances.pastVotingPower2 = locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L1_WEEK);
+    afterBalances.lockedBalance1 = locking.locked(AIRDROP_CLAIMER_1);
+    afterBalances.lockedBalance2 = locking.locked(AIRDROP_CLAIMER_2);
+    afterBalances.withdrawable1 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1);
+    afterBalances.withdrawable2 = locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2);
+
+    // move 35 days backward on L1
+    moveDays(35, false, false);
+
+    uint256 blocksTillNextWeek = ((L1_WEEK * (locking.getWeek() + locking.startingPointWeek() + 1)) + 89964) -
+      block.number;
+
+    // simulate L2 upgrade
+    vm.prank(mentoLabsMultisig);
+    locking.setL2TransitionBlock(block.number);
+
+    vm.prank(mentoLabsMultisig);
+    locking.setL2StartingPointWeek(20);
+
+    vm.prank(mentoLabsMultisig);
+    locking.setL2Shift(507776);
+
+    vm.prank(mentoLabsMultisig);
+    locking.setPaused(false);
+
+    uint256 blocksTillNextWeek2 = ((L2_WEEK * (locking.getWeek() + uint256(locking.l2StartingPointWeek()) + 1)) +
+      507776) - block.number;
+
+    // if the shift number is correct, the number of blocks till the next week should be 5 times the previous number
+    assertEq(blocksTillNextWeek2, 5 * blocksTillNextWeek);
+
+    assertEq(locking.getWeek(), weekNoBefore);
+    assertEq(locking.totalSupply(), beforeBalances.totalSupply);
+    // the past values should be calculated using the L1 week value
+    assertEq(locking.getPastTotalSupply(block.number - 3 * L1_WEEK), beforeBalances.pastTotalSupply);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_1), beforeBalances.balance1);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_2), beforeBalances.balance2);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_1), beforeBalances.votingPower1);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_2), beforeBalances.votingPower2);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L1_WEEK), beforeBalances.pastVotingPower1);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L1_WEEK), beforeBalances.pastVotingPower2);
+    assertEq(locking.locked(AIRDROP_CLAIMER_1), beforeBalances.lockedBalance1);
+    assertEq(locking.locked(AIRDROP_CLAIMER_2), beforeBalances.lockedBalance2);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1), beforeBalances.withdrawable1);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2), beforeBalances.withdrawable2);
+
+    // // move 5 weeks forward on L2
+    moveDays(5 * 7, true, true);
+
+    assertEq(locking.getWeek(), weekNoBefore + 5);
+
+    blocksTillNextWeek2 =
+      ((L2_WEEK * (locking.getWeek() + uint256(locking.l2StartingPointWeek()) + 1)) + 507776) -
+      block.number;
+
+    assertEq(blocksTillNextWeek2, 5 * blocksTillNextWeek);
+    assertEq(locking.totalSupply(), afterBalances.totalSupply);
+    assertEq(locking.getPastTotalSupply(block.number - 3 * L2_WEEK), afterBalances.pastTotalSupply);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_1), afterBalances.balance1);
+    assertEq(locking.balanceOf(AIRDROP_CLAIMER_2), afterBalances.balance2);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_1), afterBalances.votingPower1);
+    assertEq(locking.getVotes(AIRDROP_CLAIMER_2), afterBalances.votingPower2);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_1, block.number - 3 * L2_WEEK), afterBalances.pastVotingPower1);
+    assertEq(locking.getPastVotes(AIRDROP_CLAIMER_2, block.number - 3 * L2_WEEK), afterBalances.pastVotingPower2);
+    assertEq(locking.locked(AIRDROP_CLAIMER_1), afterBalances.lockedBalance1);
+    assertEq(locking.locked(AIRDROP_CLAIMER_2), afterBalances.lockedBalance2);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_1), afterBalances.withdrawable1);
+    assertEq(locking.getAvailableForWithdraw(AIRDROP_CLAIMER_2), afterBalances.withdrawable2);
+  }
+
+  // move days forward or backward on L1 or L2
+  function moveDays(uint256 day, bool forward, bool isL2) public {
+    uint256 ts = vm.getBlockTimestamp();
+    uint256 height = vm.getBlockNumber();
+
+    uint256 newTs = forward ? ts + day * 1 days : ts - day * 1 days;
+    uint256 blockChange = isL2 ? (day * 1 days) : ((day * 1 days) / 5);
+    uint256 newHeight = forward ? height + blockChange : height - blockChange;
+    vm.warp(newTs);
+    vm.roll(newHeight);
+
+    ts = vm.getBlockTimestamp();
+    height = vm.getBlockNumber();
+  }
+}

--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -1,3 +1,4 @@
+/* solhint-disable max-line-length */
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8;
 

--- a/test/unit/governance/Locking/LockingTest.sol
+++ b/test/unit/governance/Locking/LockingTest.sol
@@ -31,4 +31,8 @@ contract LockingTest is GovernanceTest {
   function _incrementBlock(uint32 _amount) internal {
     locking.incrementBlock(_amount);
   }
+
+  function _reduceBlock(uint32 _amount) internal {
+    locking.reduceBlock(_amount);
+  }
 }

--- a/test/unit/governance/Locking/locking.upgrade.t.sol
+++ b/test/unit/governance/Locking/locking.upgrade.t.sol
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.18;
+// solhint-disable func-name-mixedcase, contract-name-camelcase
+
+import { LockingTest } from "./LockingTest.sol";
+
+import "forge-std/console.sol";
+
+contract Upgrade_LockingTest is LockingTest {
+
+  address public mentoLabs = makeAddr("MentoLabsMultisig");
+
+  uint32 public l1Day;
+  uint32 public l2Day;
+  uint32 public l1Week;
+  uint32 public l2Week;
+
+   function setUp() public override{
+    super.setUp();
+    l1Week = locking.WEEK();
+    l2Week = locking.L2_WEEK();
+    l1Day = l1Week / 7;
+    l2Day = l2Week / 7;
+  }
+
+  function test_initialSetup_shouldHaveCorrectValues() public view {
+    assertEq(locking.L2_WEEK(), 7 days);
+    assertEq(locking.mentoLabsMultisig(), address(0));
+    assertEq(locking.l2Block(), 0);
+    assertEq(locking.l2StartingPointWeek(), 0);
+    assertEq(locking.l2Shift(), 0);
+    assert(!locking.paused());
+  }
+
+  function test_setMentoLabsMultisig_whenCalledByNonOwner_shouldRevert() public {
+    vm.prank(alice);
+    vm.expectRevert("Ownable: caller is not the owner");
+    locking.setMentoLabsMultisig(mentoLabs);
+  }
+
+  function test_setMentoLabsMultisig_whenCalledByOwner_shouldSetMultisigAddress() public {
+    assertEq(locking.mentoLabsMultisig(), address(0));
+    
+    vm.prank(owner);
+    locking.setMentoLabsMultisig(mentoLabs);
+
+    assertEq(locking.mentoLabsMultisig(), mentoLabs);
+  }
+
+  modifier setMultisig() {
+    vm.prank(owner);
+    locking.setMentoLabsMultisig(mentoLabs);
+    _;
+  }
+
+  function test_setL2TransitionBlock_whenCalledByNonMentoMultisig_shouldRevert() public setMultisig {
+    vm.prank(alice);
+    vm.expectRevert("caller is not MentoLabs multisig");
+    locking.setL2TransitionBlock(block.number);
+  }
+
+  function test_setL2TransitionBlock_whenCalledByMentoMultisig_shouldSetL2BlockAndPause() public setMultisig {
+    assertEq(locking.l2Block(), 0);
+    assert(!locking.paused());
+    
+    uint32 blockNumber = uint32(block.number + 100);
+    
+    vm.prank(mentoLabs);
+    locking.setL2TransitionBlock(blockNumber);
+
+    assertEq(locking.l2Block(), blockNumber);
+    assert(locking.paused());
+  }
+
+  function test_setL2Shift_whenCalledByNonMentoMultisig_shouldRevert() public setMultisig {
+    vm.prank(alice);
+    vm.expectRevert("caller is not MentoLabs multisig");
+    locking.setL2Shift(100);
+  }
+
+  function test_setL2Shift_whenCalledByMentoMultisig_shouldSetL2BlockAndPause() public setMultisig {
+    assertEq(locking.l2Shift(), 0);
+    
+    vm.prank(mentoLabs);
+    locking.setL2Shift(100);
+
+    assertEq(locking.l2Shift(), 100);
+  }
+
+  function test_setL2StartingPointWeek_whenCalledByNonMentoMultisig_shouldRevert() public setMultisig {
+    vm.prank(alice);
+    vm.expectRevert("caller is not MentoLabs multisig");
+    locking.setL2StartingPointWeek(100);
+  }
+
+  function test_setL2StartingPointWeek_whenCalledByMentoMultisig_shouldSetL2BlockAndPause() public setMultisig {
+    assertEq(locking.l2StartingPointWeek(), 0);
+    
+    
+    vm.prank(mentoLabs);
+    locking.setL2StartingPointWeek(100);
+
+    assertEq(locking.l2StartingPointWeek(), 100);
+  }
+  function test_setPaused_whenCalledByNonMentoMultisig_shouldRevert() public setMultisig {
+    vm.prank(alice);
+    vm.expectRevert("caller is not MentoLabs multisig");
+    locking.setPaused(true);
+  }
+
+  function test_setPaused_whenCalledByMentoMultisig_shouldPauseContracts() public setMultisig {
+    assert(!locking.paused());
+
+    mentoToken.mint(alice, 1000000e18);
+    
+    vm.prank(mentoLabs);
+    locking.setPaused(true);
+
+
+    assert(locking.paused());
+
+    vm.expectRevert("locking is paused");
+    vm.prank(alice);
+    locking.lock(alice, bob, 1000e18, 5, 5);
+
+    vm.expectRevert("locking is paused");
+    vm.prank(alice);
+    locking.withdraw();
+
+
+    vm.prank(mentoLabs);
+    locking.setPaused(false);
+
+    assert(!locking.paused());
+  }
+
+  modifier l2LockingSetup(uint32 advanceWeeks_, uint32 startingPointWeek_, uint32 l1Shift_) {
+    vm.prank(owner);
+    locking.setMentoLabsMultisig(mentoLabs);
+
+    _incrementBlock(l1Week * advanceWeeks_);
+
+    locking.setStatingPointWeek(startingPointWeek_);
+    locking.setEpochShift(l1Shift_);
+
+    vm.prank(mentoLabs);
+    locking.setL2TransitionBlock(block.number);
+
+    vm.prank(mentoLabs);
+    locking.setPaused(false);
+
+    _;
+  }
+
+  function test_getWeek_whenShiftAndStartingPointIs0_shouldReturnCorrectWeekNo() public l2LockingSetup(8, 0, 0) {
+
+    // 2 + 8 weeks = 10 weeks on l1 = 2 weeks on l2
+    assertEq(locking.getWeek(), 2);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Week);
+
+    _incrementBlock(l2Day * 3);
+
+    assertEq(locking.getWeek(), 2);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Day * 4);
+
+    _incrementBlock(l2Day * 5);
+
+    assertEq(locking.getWeek(), 3);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Day * 6);
+
+    _incrementBlock(l2Day * 8);
+
+    assertEq(locking.getWeek(), 4);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Day * 5);
+  }
+
+  function test_getWeek_whenL2StartingPointIsPositive_shouldReturnCorrectWeekNo() public l2LockingSetup(198, 190, 0) {
+    // l1 week no = 198 + 2 - (190) = 10
+    uint32 l1WeekNo = 10;
+    // l2 week no = (198 + 2) / 5 = 40
+    assertEq(locking.getWeek(), 40);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Week);
+
+    // l2WeekNo - l1WeekNo = 40 - 10 = 30
+    vm.prank(mentoLabs);
+    locking.setL2StartingPointWeek(30);
+
+    // after the L2 starting point week is set, the week should be equal to the l1 week no
+    assertEq(locking.getWeek(), l1WeekNo);
+  }
+
+  function test_getWeek_whenL2StartingPointIsNegative_shouldReturnCorrectWeekNo() public l2LockingSetup(18,0,0) {
+    // l1 week no = 18 + 2 - 0 = 20
+    uint32 l1WeekNo = 20;
+    // l2 week no = (18 + 2) / 5 = 4
+    assertEq(locking.getWeek(), 4);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Week);
+
+    // l2WeekNo - l1WeekNo = 4 - 20 = -16
+    vm.prank(mentoLabs);
+    locking.setL2StartingPointWeek(-16);
+
+    // after the L2 starting point week is set, the week should be equal to the l1 week no
+    assertEq(locking.getWeek(), l1WeekNo);
+  }
+
+  function test_getWeek_whenShiftIsPositive_shouldReturnCorrectWeekNo() public l2LockingSetup(18, 5, l1Day * 3) {
+    // l1 week no = 18 + 2 - 5 - 1 = 19
+    uint32 l1WeekNo = 14;
+
+    // l2 week no = (18 + 2) / 5 = 4
+    assertEq(locking.getWeek(), 4);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Week);
+
+    // l2WeekNo - l1WeekNo = 4 - 14 - 1 = -11
+    vm.prank(mentoLabs);
+    locking.setL2StartingPointWeek(-11);
+
+    vm.prank(mentoLabs);
+    locking.setL2Shift(l2Day * 3);
+
+    // after the L2 starting point week and l2Shift are set, the timing should be equal to the l1 timing
+    assertEq(locking.getWeek(), l1WeekNo);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Day * 3);
+
+    _incrementBlock(l2Day);
+
+    assertEq(locking.getWeek(), l1WeekNo);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Day * 2);
+
+    _incrementBlock(l2Day);
+
+    assertEq(locking.getWeek(), l1WeekNo);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Day);
+
+
+    _incrementBlock(l2Day);
+
+    assertEq(locking.getWeek(), l1WeekNo + 1);
+    assertEq(locking.l2BlockTillNextPeriod(), l2Week);
+  }
+
+  function test_totalSupply_whenCalledAfterL2Transition_shouldReturnCorrectValues() public setMultisig {
+    mentoToken.mint(alice, 1000000e18);
+
+    // week no: 20
+    _incrementBlock(l1Week * 18);
+
+    vm.prank(alice);
+    locking.lock(alice, alice, 1000e18, 104, 0);
+
+    // week no: 40
+    _incrementBlock(l1Week * 20);
+
+
+    uint256 totalSupplyL1W40 = locking.totalSupply();
+    uint256 pastTotalSupplyL1W30= locking.getPastTotalSupply(locking.blockNumberMocked() - l1Week * 10);
+
+    // week no: 60
+    _incrementBlock(l1Week * 20);
+
+    uint256 totalSupplyL1W60 = locking.totalSupply();
+    uint256 pastTotalSupplyL1W50= locking.getPastTotalSupply(locking.blockNumberMocked() - l1Week * 10);
+
+    // roll back to week 40
+    _reduceBlock(l1Week * 20);
+    
+
+    vm.prank(mentoLabs);
+    locking.setL2TransitionBlock(l1Week * 40);
+
+
+    vm.prank(mentoLabs);
+    locking.setPaused(false);
+
+    // 8 - 40 = -32
+    vm.prank(mentoLabs);
+    locking.setL2StartingPointWeek(-32);
+
+    assertEq(locking.totalSupply(), totalSupplyL1W40);
+    assertEq(locking.getPastTotalSupply(locking.blockNumberMocked() - l1Week * 10), pastTotalSupplyL1W30);
+
+    // week no: 60
+    _incrementBlock(l2Week * 20);
+    assertEq(locking.totalSupply(), totalSupplyL1W60);
+    assertEq(locking.getPastTotalSupply(locking.blockNumberMocked() - l2Week * 10), pastTotalSupplyL1W50);
+  }
+
+  function test_balanceOfAndGetVotes_whenCalledAfterL2Transition_shouldReturnCorrectValues() public setMultisig {
+    mentoToken.mint(alice, 1000000e18);
+
+    //  week no: 20
+    _incrementBlock(l1Week * 18);
+
+    vm.prank(alice);
+    locking.lock(alice, alice, 1000e18, 104, 0);
+
+    // week no: 40
+    _incrementBlock(l1Week * 20);
+
+
+    uint256 balanceOfL1W40 = locking.balanceOf(alice);
+    uint256 votesL1W40 = locking.getVotes(alice);
+    uint256 pastVotesL1W30 = locking.getPastVotes(alice, locking.blockNumberMocked() - l1Week * 10);
+
+    // week no: 60
+    _incrementBlock(l1Week * 20);
+
+    uint256 balanceOfL1W60 = locking.balanceOf(alice);
+    uint256 votesL1W60 = locking.getVotes(alice);
+    uint256 pastVotesL1W50 = locking.getPastVotes(alice, locking.blockNumberMocked() - l1Week * 10);
+
+    // roll back to week 40
+    _reduceBlock(l1Week * 20);
+    
+
+    vm.prank(mentoLabs);
+    locking.setL2TransitionBlock(l1Week * 40);
+
+
+    vm.prank(mentoLabs);
+    locking.setPaused(false);
+
+    // 8 - 40 = -32
+    vm.prank(mentoLabs);
+    locking.setL2StartingPointWeek(-32);
+
+    assertEq(locking.balanceOf(alice), balanceOfL1W40);
+    assertEq(locking.getVotes(alice), votesL1W40);
+    assertEq(locking.getPastVotes(alice, locking.blockNumberMocked() - l1Week * 10), pastVotesL1W30);
+
+    // week no: 60
+    _incrementBlock(l2Week * 20);
+    assertEq(locking.balanceOf(alice), balanceOfL1W60);
+    assertEq(locking.getVotes(alice), votesL1W60);
+    assertEq(locking.getPastVotes(alice, locking.blockNumberMocked() - l2Week * 10), pastVotesL1W50);
+  }
+
+  function test_lockedAndWithdrawable_whenCalledAfterL2Transition_shouldReturnCorrectValues() public setMultisig {
+    mentoToken.mint(alice, 1000000e18);
+
+    //  week no: 20
+    _incrementBlock(l1Week * 18);
+
+    vm.prank(alice);
+    locking.lock(alice, alice, 1000e18, 104, 0);
+
+    // week no: 40
+    _incrementBlock(l1Week * 20);
+
+
+    uint256 lockedL1W40 = locking.locked(alice);
+    uint256 withdrawableL1W40 = locking.getAvailableForWithdraw(alice);
+
+    // week no: 60
+    _incrementBlock(l1Week * 20);
+
+    uint256 lockedL1W60 = locking.locked(alice);
+    uint256 withdrawableL1W60 = locking.getAvailableForWithdraw(alice); 
+
+    // roll back to week 40
+    _reduceBlock(l1Week * 20);
+    
+
+    vm.prank(mentoLabs);
+    locking.setL2TransitionBlock(l1Week * 40);
+
+    vm.prank(mentoLabs);
+    locking.setPaused(false);
+
+    // 8 - 40 = -32
+    vm.prank(mentoLabs);
+    locking.setL2StartingPointWeek(-32);
+
+    assertEq(locking.locked(alice), lockedL1W40);
+    assertEq(locking.getAvailableForWithdraw(alice), withdrawableL1W40);
+
+    // week no: 60
+    _incrementBlock(l2Week * 20);
+    assertEq(locking.locked(alice), lockedL1W60);
+    assertEq(locking.getAvailableForWithdraw(alice), withdrawableL1W60);
+  }
+ 
+}

--- a/test/unit/governance/Locking/locking.upgrade.t.sol
+++ b/test/unit/governance/Locking/locking.upgrade.t.sol
@@ -17,8 +17,8 @@ contract Upgrade_LockingTest is LockingTest {
 
    function setUp() public override{
     super.setUp();
-    l1Week = locking.WEEK();
-    l2Week = locking.L2_WEEK();
+    l1Week = 7 days / 5;
+    l2Week = 7 days;
     l1Day = l1Week / 7;
     l2Day = l2Week / 7;
   }

--- a/test/unit/governance/Locking/locking.upgrade.t.sol
+++ b/test/unit/governance/Locking/locking.upgrade.t.sol
@@ -7,7 +7,6 @@ import { LockingTest } from "./LockingTest.sol";
 import "forge-std/console.sol";
 
 contract Upgrade_LockingTest is LockingTest {
-
   address public mentoLabs = makeAddr("MentoLabsMultisig");
 
   uint32 public l1Day;
@@ -15,7 +14,7 @@ contract Upgrade_LockingTest is LockingTest {
   uint32 public l1Week;
   uint32 public l2Week;
 
-   function setUp() public override{
+  function setUp() public override {
     super.setUp();
     l1Week = 7 days / 5;
     l2Week = 7 days;
@@ -40,7 +39,7 @@ contract Upgrade_LockingTest is LockingTest {
 
   function test_setMentoLabsMultisig_whenCalledByOwner_shouldSetMultisigAddress() public {
     assertEq(locking.mentoLabsMultisig(), address(0));
-    
+
     vm.prank(owner);
     locking.setMentoLabsMultisig(mentoLabs);
 
@@ -62,9 +61,9 @@ contract Upgrade_LockingTest is LockingTest {
   function test_setL2TransitionBlock_whenCalledByMentoMultisig_shouldSetL2BlockAndPause() public setMultisig {
     assertEq(locking.l2Block(), 0);
     assert(!locking.paused());
-    
+
     uint32 blockNumber = uint32(block.number + 100);
-    
+
     vm.prank(mentoLabs);
     locking.setL2TransitionBlock(blockNumber);
 
@@ -80,7 +79,7 @@ contract Upgrade_LockingTest is LockingTest {
 
   function test_setL2Shift_whenCalledByMentoMultisig_shouldSetL2BlockAndPause() public setMultisig {
     assertEq(locking.l2Shift(), 0);
-    
+
     vm.prank(mentoLabs);
     locking.setL2Shift(100);
 
@@ -95,8 +94,7 @@ contract Upgrade_LockingTest is LockingTest {
 
   function test_setL2StartingPointWeek_whenCalledByMentoMultisig_shouldSetL2BlockAndPause() public setMultisig {
     assertEq(locking.l2StartingPointWeek(), 0);
-    
-    
+
     vm.prank(mentoLabs);
     locking.setL2StartingPointWeek(100);
 
@@ -112,10 +110,9 @@ contract Upgrade_LockingTest is LockingTest {
     assert(!locking.paused());
 
     mentoToken.mint(alice, 1000000e18);
-    
+
     vm.prank(mentoLabs);
     locking.setPaused(true);
-
 
     assert(locking.paused());
 
@@ -126,7 +123,6 @@ contract Upgrade_LockingTest is LockingTest {
     vm.expectRevert("locking is paused");
     vm.prank(alice);
     locking.withdraw();
-
 
     vm.prank(mentoLabs);
     locking.setPaused(false);
@@ -153,7 +149,6 @@ contract Upgrade_LockingTest is LockingTest {
   }
 
   function test_getWeek_whenShiftAndStartingPointIs0_shouldReturnCorrectWeekNo() public l2LockingSetup(8, 0, 0) {
-
     // 2 + 8 weeks = 10 weeks on l1 = 2 weeks on l2
     assertEq(locking.getWeek(), 2);
     assertEq(locking.l2BlockTillNextPeriod(), l2Week);
@@ -189,7 +184,7 @@ contract Upgrade_LockingTest is LockingTest {
     assertEq(locking.getWeek(), l1WeekNo);
   }
 
-  function test_getWeek_whenL2StartingPointIsNegative_shouldReturnCorrectWeekNo() public l2LockingSetup(18,0,0) {
+  function test_getWeek_whenL2StartingPointIsNegative_shouldReturnCorrectWeekNo() public l2LockingSetup(18, 0, 0) {
     // l1 week no = 18 + 2 - 0 = 20
     uint32 l1WeekNo = 20;
     // l2 week no = (18 + 2) / 5 = 4
@@ -233,7 +228,6 @@ contract Upgrade_LockingTest is LockingTest {
     assertEq(locking.getWeek(), l1WeekNo);
     assertEq(locking.l2BlockTillNextPeriod(), l2Day);
 
-
     _incrementBlock(l2Day);
 
     assertEq(locking.getWeek(), l1WeekNo + 1);
@@ -252,23 +246,20 @@ contract Upgrade_LockingTest is LockingTest {
     // week no: 40
     _incrementBlock(l1Week * 20);
 
-
     uint256 totalSupplyL1W40 = locking.totalSupply();
-    uint256 pastTotalSupplyL1W30= locking.getPastTotalSupply(locking.blockNumberMocked() - l1Week * 10);
+    uint256 pastTotalSupplyL1W30 = locking.getPastTotalSupply(locking.blockNumberMocked() - l1Week * 10);
 
     // week no: 60
     _incrementBlock(l1Week * 20);
 
     uint256 totalSupplyL1W60 = locking.totalSupply();
-    uint256 pastTotalSupplyL1W50= locking.getPastTotalSupply(locking.blockNumberMocked() - l1Week * 10);
+    uint256 pastTotalSupplyL1W50 = locking.getPastTotalSupply(locking.blockNumberMocked() - l1Week * 10);
 
     // roll back to week 40
     _reduceBlock(l1Week * 20);
-    
 
     vm.prank(mentoLabs);
     locking.setL2TransitionBlock(l1Week * 40);
-
 
     vm.prank(mentoLabs);
     locking.setPaused(false);
@@ -298,7 +289,6 @@ contract Upgrade_LockingTest is LockingTest {
     // week no: 40
     _incrementBlock(l1Week * 20);
 
-
     uint256 balanceOfL1W40 = locking.balanceOf(alice);
     uint256 votesL1W40 = locking.getVotes(alice);
     uint256 pastVotesL1W30 = locking.getPastVotes(alice, locking.blockNumberMocked() - l1Week * 10);
@@ -312,11 +302,9 @@ contract Upgrade_LockingTest is LockingTest {
 
     // roll back to week 40
     _reduceBlock(l1Week * 20);
-    
 
     vm.prank(mentoLabs);
     locking.setL2TransitionBlock(l1Week * 40);
-
 
     vm.prank(mentoLabs);
     locking.setPaused(false);
@@ -348,7 +336,6 @@ contract Upgrade_LockingTest is LockingTest {
     // week no: 40
     _incrementBlock(l1Week * 20);
 
-
     uint256 lockedL1W40 = locking.locked(alice);
     uint256 withdrawableL1W40 = locking.getAvailableForWithdraw(alice);
 
@@ -356,11 +343,10 @@ contract Upgrade_LockingTest is LockingTest {
     _incrementBlock(l1Week * 20);
 
     uint256 lockedL1W60 = locking.locked(alice);
-    uint256 withdrawableL1W60 = locking.getAvailableForWithdraw(alice); 
+    uint256 withdrawableL1W60 = locking.getAvailableForWithdraw(alice);
 
     // roll back to week 40
     _reduceBlock(l1Week * 20);
-    
 
     vm.prank(mentoLabs);
     locking.setL2TransitionBlock(l1Week * 40);
@@ -380,5 +366,4 @@ contract Upgrade_LockingTest is LockingTest {
     assertEq(locking.locked(alice), lockedL1W60);
     assertEq(locking.getAvailableForWithdraw(alice), withdrawableL1W60);
   }
- 
 }

--- a/test/utils/harnesses/LockingHarness.sol
+++ b/test/utils/harnesses/LockingHarness.sol
@@ -11,6 +11,10 @@ contract LockingHarness is Locking {
     blockNumberMocked = blockNumberMocked + _amount;
   }
 
+  function reduceBlock(uint32 _amount) external {
+    blockNumberMocked = blockNumberMocked - _amount;
+  }
+
   function getBlockNumber() internal view override returns (uint32) {
     return blockNumberMocked;
   }
@@ -45,6 +49,16 @@ contract LockingHarness is Locking {
 
   function blockTillNextPeriod() external view returns (uint256) {
     uint256 currentWeek = this.getWeek();
-    return (WEEK * (currentWeek + 1)) + getEpochShift() - getBlockNumber();
+    return (WEEK * (currentWeek + startingPointWeek + 1)) + getEpochShift() - getBlockNumber();
   }
+
+  function l2BlockTillNextPeriod() external view returns (uint256) {
+    uint256 currentWeek = this.getWeek();
+    return (L2_WEEK * uint256(int(currentWeek) + l2StartingPointWeek + 1)) + l2Shift - getBlockNumber();
+  }
+
+
+  function setStatingPointWeek(uint32 _week) external {
+    startingPointWeek = _week;
+  } 
 }

--- a/test/utils/harnesses/LockingHarness.sol
+++ b/test/utils/harnesses/LockingHarness.sol
@@ -57,8 +57,7 @@ contract LockingHarness is Locking {
     return (L2_WEEK * uint256(int(currentWeek) + l2StartingPointWeek + 1)) + l2Shift - getBlockNumber();
   }
 
-
   function setStatingPointWeek(uint32 _week) external {
     startingPointWeek = _week;
-  } 
+  }
 }


### PR DESCRIPTION
### Description

Updates Locking Contracts to handle upcoming block.time change

Mainly changes the roundTimestamp() to have a forked implementation that uses different values to calculate week no for the blocks before and after l2 transition. Week numbers that return from roundTimestamp before and after should be continues and consistent.

### Other changes

No

### Tested

Unit and fork tests

### Related issues

- Fixes #538 
