### PR TITLE
fix: $GD resolved large reward issue

### DIFF
--- a/contracts/goodDollar/GoodDollarExchangeProvider.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProvider.sol
@@ -203,6 +203,8 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
     uint256 newRatioScaled = unwrap(numerator.div(denominator));
 
     uint32 newRatioUint = uint32(newRatioScaled / 1e10);
+    require(newRatioUint > 0, "New ratio must be greater than 0");
+
     exchanges[exchangeId].reserveRatio = newRatioUint;
     exchanges[exchangeId].tokenSupply += rewardScaled;
 

--- a/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
+++ b/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
@@ -683,6 +683,15 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     exchangeId = exchangeProvider.createExchange(poolExchange);
   }
 
+  function test_updateRatioForReward_whenNewRatioIsZero_shouldRevert() public {
+    // Use a very large reward that will make the denominator massive compared to numerator
+    uint256 veryLargeReward = type(uint256).max / 1e20; // Large but not large enough to overflow
+
+    vm.expectRevert("New ratio must be greater than 0");
+    vm.prank(expansionControllerAddress);
+    exchangeProvider.updateRatioForReward(exchangeId, veryLargeReward);
+  }
+
   function test_updateRatioForReward_whenCallerIsNotExpansionController_shouldRevert() public {
     vm.prank(makeAddr("NotExpansionController"));
     vm.expectRevert("Only ExpansionController can call this function");


### PR DESCRIPTION
### Description

This PR addresses the reward ratio reaching 0 if the reward is a large enough number

### Tested

`forge test ./test/unit/goodDollar/GoodDollarExchangeProvider.t.sol `

### Related issues

- Fixes [#595](https://github.com/mento-protocol/mento-general/issues/595)

