### PR TITLE
fix: Typo redundant casting

### DIFF
--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -167,7 +167,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
   function setReserve(address _reserve) public onlyOwner {
     require(_reserve != address(0), "Reserve address must be set");
     reserve = IReserve(_reserve);
-    emit ReserveUpdated(address(_reserve));
+    emit ReserveUpdated(_reserve);
   }
 
   /// @inheritdoc IBancorExchangeProvider

--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -165,7 +165,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
 
   /// @inheritdoc IBancorExchangeProvider
   function setReserve(address _reserve) public onlyOwner {
-    require(address(_reserve) != address(0), "Reserve address must be set");
+    require(_reserve != address(0), "Reserve address must be set");
     reserve = IReserve(_reserve);
     emit ReserveUpdated(address(_reserve));
   }


### PR DESCRIPTION
### Description

This PR fixes a redundant casting of an address 

### Related issues

- Fixes [#604](https://github.com/mento-protocol/mento-general/issues/604)
