### PR TITLE
feat: ensure exitContribution is less than 100%

### DIFF
--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -262,7 +262,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
 
   function _setExitContribution(bytes32 exchangeId, uint32 exitContribution) internal {
     require(exchanges[exchangeId].reserveAsset != address(0), "Exchange does not exist");
-    require(exitContribution <= MAX_WEIGHT, "Exit contribution is too high");
+    require(exitContribution < MAX_WEIGHT, "Exit contribution is too high");
 
     PoolExchange storage exchange = exchanges[exchangeId];
     exchange.exitContribution = exitContribution;

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -164,12 +164,12 @@ contract BancorExchangeProviderTest_initilizerSettersGetters is BancorExchangePr
     bancorExchangeProvider.setExitContribution(exchangeId, 1e5);
   }
 
-  function test_setExitContribution_whenExitContributionAbove100Percent_shouldRevert() public {
+  function test_setExitContribution_whenExitContributionIsNotLessThan100Percent_shouldRevert() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
 
     uint32 maxWeight = bancorExchangeProvider.MAX_WEIGHT();
     vm.expectRevert("Exit contribution is too high");
-    bancorExchangeProvider.setExitContribution(exchangeId, maxWeight + 1);
+    bancorExchangeProvider.setExitContribution(exchangeId, maxWeight);
   }
 
   function test_setExitContribution_whenSenderIsOwner_shouldUpdateAndEmit() public {


### PR DESCRIPTION
### Description

This PR ensures that the exit contribution is set to a value smaller 100%. 

### Other changes



### Tested

updated test to ensure setter fails on exitContribution of 100%

### Related issues

[https://github.com/mento-protocol/mento-general/issues/600](https://github.com/mento-protocol/mento-general/issues/600)


### Backwards compatibility



### Documentation

