### PR TITLE
fix: setting of last expansion timestamp

### DIFF
--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -231,6 +231,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
       exchangeExpansionConfigs[exchangeId].lastExpansion = uint32(block.timestamp);
     } else {
       numberOfExpansions = (block.timestamp - config.lastExpansion) / config.expansionFrequency;
+      // slither-disable-next-line divide-before-multiply
       exchangeExpansionConfigs[exchangeId].lastExpansion = uint32(
         config.lastExpansion + numberOfExpansions * config.expansionFrequency
       );

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -172,11 +172,10 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
       .getPoolExchange(exchangeId);
     ExchangeExpansionConfig memory config = getExpansionConfig(exchangeId);
 
-    bool shouldExpand = block.timestamp > config.lastExpansion + config.expansionFrequency;
+    bool shouldExpand = block.timestamp >= config.lastExpansion + config.expansionFrequency;
     if (shouldExpand || config.lastExpansion == 0) {
-      uint256 reserveRatioScalar = _getReserveRatioScalar(config);
+      uint256 reserveRatioScalar = _getReserveRatioScalar(exchangeId);
 
-      exchangeExpansionConfigs[exchangeId].lastExpansion = uint32(block.timestamp);
       amountMinted = goodDollarExchangeProvider.mintFromExpansion(exchangeId, reserveRatioScalar);
 
       IGoodDollar(exchange.tokenAddress).mint(address(distributionHelper), amountMinted);
@@ -219,17 +218,22 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
 
   /**
    * @notice Calculates the reserve ratio scalar for the given expansion config.
-   * @param config The expansion config.
+   * @param exchangeId The ID of the exchange.
    * @return reserveRatioScalar The reserve ratio scalar.
    */
-  function _getReserveRatioScalar(ExchangeExpansionConfig memory config) internal view returns (uint256) {
+  function _getReserveRatioScalar(bytes32 exchangeId) internal returns (uint256) {
+    ExchangeExpansionConfig memory config = getExpansionConfig(exchangeId);
     uint256 numberOfExpansions;
 
     // If there was no previous expansion, we expand once.
     if (config.lastExpansion == 0) {
       numberOfExpansions = 1;
+      exchangeExpansionConfigs[exchangeId].lastExpansion = uint32(block.timestamp);
     } else {
       numberOfExpansions = (block.timestamp - config.lastExpansion) / config.expansionFrequency;
+      exchangeExpansionConfigs[exchangeId].lastExpansion = uint32(
+        config.lastExpansion + numberOfExpansions * config.expansionFrequency
+      );
     }
 
     uint256 stepReserveRatioScalar = MAX_WEIGHT - config.expansionRate;

--- a/test/unit/goodDollar/GoodDollarExpansionController.t.sol
+++ b/test/unit/goodDollar/GoodDollarExpansionController.t.sol
@@ -370,7 +370,7 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
     expansionController.mintUBIFromExpansion("NotSetExchangeId");
   }
 
-  function test_mintUBIFromExpansion_whenShouldNotExpand_shouldNotExpand() public {
+  function test_mintUBIFromExpansion_whenLessThanExpansionFrequencyPassed_shouldNotExpand() public {
     // doing one initial expansion to not be first expansion
     // since on first expansion the expansion is always applied once.
     expansionController.mintUBIFromExpansion(exchangeId);
@@ -378,8 +378,7 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
     IGoodDollarExpansionController.ExchangeExpansionConfig memory config = expansionController.getExpansionConfig(
       exchangeId
     );
-    uint256 lastExpansion = config.lastExpansion;
-    skip(lastExpansion + config.expansionFrequency - 1);
+    skip(config.expansionFrequency - 1);
 
     assertEq(expansionController.mintUBIFromExpansion(exchangeId), 0);
   }
@@ -465,13 +464,10 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
     // 1 day has passed since last expansion and expansion rate is 1% so the rate passed to the exchangeProvider
     // should be 0.99^1 = 0.99
     uint256 reserveRatioScalar = 1e18 * 0.99;
-    skip(expansionFrequency + 1);
+    skip(expansionFrequency);
 
     uint256 amountToMint = 1000e18;
     uint256 distributionHelperBalanceBefore = token.balanceOf(distributionHelper);
-
-    vm.expectEmit(true, true, true, true);
-    emit ExpansionUBIMinted(exchangeId, amountToMint);
 
     vm.expectCall(
       exchangeProvider,
@@ -485,6 +481,9 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
       distributionHelper,
       abi.encodeWithSelector(IDistributionHelper(distributionHelper).onDistribution.selector, amountToMint)
     );
+
+    vm.expectEmit(true, true, true, true);
+    emit ExpansionUBIMinted(exchangeId, amountToMint);
 
     uint256 amountMinted = expansionController.mintUBIFromExpansion(exchangeId);
     IGoodDollarExpansionController.ExchangeExpansionConfig memory config = expansionController.getExpansionConfig(
@@ -496,7 +495,7 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
     assertEq(config.lastExpansion, block.timestamp);
   }
 
-  function test_mintUBIFromExpansion_whenMultipleDaysPassed_shouldCalculateCorrectRateAndExpand() public {
+  function test_mintUBIFromExpansion_whenThreeAndAHalfDaysPassed_shouldMintCorrectAmountAndSetLastExpansion() public {
     // doing one initial expansion to not be first expansion
     // since on first expansion the expansion is always applied once.
     expansionController.mintUBIFromExpansion(exchangeId);
@@ -505,7 +504,12 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
     // should be 0.99^3 = 0.970299
     uint256 reserveRatioScalar = 1e18 * 0.970299;
 
-    skip(3 * expansionFrequency + 1);
+    IGoodDollarExpansionController.ExchangeExpansionConfig memory stateBefore = expansionController.getExpansionConfig(
+      exchangeId
+    );
+
+    // 3.5 days have passed since last expansion
+    skip((7 * expansionFrequency) / 2);
 
     uint256 amountToMint = 1000e18;
     uint256 distributionHelperBalanceBefore = token.balanceOf(distributionHelper);
@@ -533,7 +537,7 @@ contract GoodDollarExpansionControllerTest_mintUBIFromExpansion is GoodDollarExp
 
     assertEq(amountMinted, amountToMint);
     assertEq(token.balanceOf(distributionHelper), distributionHelperBalanceBefore + amountToMint);
-    assertEq(config.lastExpansion, block.timestamp);
+    assertEq(config.lastExpansion, stateBefore.lastExpansion + expansionFrequency * 3);
   }
 }
 
@@ -543,18 +547,14 @@ contract GoodDollarExpansionControllerTest_getExpansionScalar is GoodDollarExpan
   function setUp() public override {
     super.setUp();
     expansionController = new GoodDollarExpansionControllerHarness(false);
+    expansionController.initialize(exchangeProvider, distributionHelper, reserveAddress, avatarAddress);
   }
 
-  function test_getExpansionScaler_whenExpansionRateIs0_shouldReturn1e18() public {
-    IGoodDollarExpansionController.ExchangeExpansionConfig memory config = IGoodDollarExpansionController
-      .ExchangeExpansionConfig(0, 1, 0);
-    assertEq(expansionController.exposed_getReserveRatioScalar(config), 1e18);
-  }
-
-  function test_getExpansionScaler_whenExpansionRateIs1_shouldReturn1() public {
-    IGoodDollarExpansionController.ExchangeExpansionConfig memory config = IGoodDollarExpansionController
-      .ExchangeExpansionConfig(1e18 - 1, 1, 0);
-    assertEq(expansionController.exposed_getReserveRatioScalar(config), 1);
+  function test_getExpansionScaler_whenStepReserveRatioScalerIs1_shouldReturn1() public {
+    vm.prank(avatarAddress);
+    expansionController.setExpansionConfig(exchangeId, 1e18 - 1, 1);
+    // stepReserveRatioScalar is 1e18 - expansionRate = 1e18 - (1e18 - 1) = 1
+    assertEq(expansionController.exposed_getReserveRatioScalar(exchangeId), 1);
   }
 
   function testFuzz_getExpansionScaler(
@@ -570,9 +570,11 @@ contract GoodDollarExpansionControllerTest_getExpansionScalar is GoodDollarExpan
 
     skip(lastExpansion + timeDelta);
 
-    IGoodDollarExpansionController.ExchangeExpansionConfig memory config = IGoodDollarExpansionController
-      .ExchangeExpansionConfig(expansionRate, expansionFrequency, lastExpansion);
-    uint256 scaler = expansionController.exposed_getReserveRatioScalar(config);
+    vm.prank(avatarAddress);
+    expansionController.setExpansionConfig(exchangeId, expansionRate, expansionFrequency);
+    expansionController.setLastExpansion(exchangeId, lastExpansion);
+    uint256 scaler = expansionController.exposed_getReserveRatioScalar(exchangeId);
+
     assert(scaler >= 0 && scaler <= 1e18);
   }
 }

--- a/test/utils/harnesses/GoodDollarExpansionControllerHarness.sol
+++ b/test/utils/harnesses/GoodDollarExpansionControllerHarness.sol
@@ -7,7 +7,11 @@ import { GoodDollarExpansionController } from "contracts/goodDollar/GoodDollarEx
 contract GoodDollarExpansionControllerHarness is GoodDollarExpansionController {
   constructor(bool disabled) GoodDollarExpansionController(disabled) {}
 
-  function exposed_getReserveRatioScalar(ExchangeExpansionConfig calldata config) external returns (uint256) {
-    return _getReserveRatioScalar(config);
+  function exposed_getReserveRatioScalar(bytes32 exchangeId) external returns (uint256) {
+    return _getReserveRatioScalar(exchangeId);
+  }
+
+  function setLastExpansion(bytes32 exchangeId, uint32 lastExpansion) external {
+    exchangeExpansionConfigs[exchangeId].lastExpansion = lastExpansion;
   }
 }


### PR DESCRIPTION
### Description

fixes issue in how lastUpdated was set:
before if  3.5 days passed and a daily expansion was configured, 3 expansions were calculated and the last expansion timestamp was updated to now essentially losing half a day. Over time this could have resulted in the yearly expansion rate not being achieved. 

### Other changes



### Tested

-  added tests for this behavior 

### Related issues

https://github.com/mento-protocol/mento-general/issues/592

### Backwards compatibility



### Documentation


