### PR TITLE
Feat: slippage protection for reserve ratio

### DIFF
--- a/contracts/goodDollar/GoodDollarExchangeProvider.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProvider.sol
@@ -241,9 +241,4 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
    * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
    */
   uint256[50] private __gap;
-
-  // Helper function to calculate absolute value
-  function abs(int256 x) internal pure returns (uint256) {
-    return x < 0 ? uint256(-x) : uint256(x);
-  }
 }

--- a/contracts/goodDollar/GoodDollarExchangeProvider.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProvider.sol
@@ -210,7 +210,7 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
 
     require(newRatioUint > 0, "New ratio must be greater than 0");
 
-    uint256 allowedSlippage = (exchange.reserveRatio * maxSlippagePercentage) / 100;
+    uint256 allowedSlippage = (exchange.reserveRatio * maxSlippagePercentage) / MAX_WEIGHT;
     require(exchange.reserveRatio - newRatioUint <= allowedSlippage, "Slippage exceeded");
 
     exchanges[exchangeId].reserveRatio = newRatioUint;

--- a/contracts/goodDollar/GoodDollarExchangeProvider.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProvider.sol
@@ -190,21 +190,24 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   /**
    * @inheritdoc IGoodDollarExchangeProvider
    * @dev Calculates the new reserve ratio needed to mint the G$ reward while keeping the current price the same.
-   *      calculation: newRatio = reserveBalance / (tokenSupply + reward) * currentPrice
+   *      calculation: newRatio = (tokenSupply * reserveRatio) / (tokenSupply + reward)
    */
   function updateRatioForReward(bytes32 exchangeId, uint256 reward) external onlyExpansionController whenNotPaused {
     PoolExchange memory exchange = getPoolExchange(exchangeId);
 
-    uint256 currentPriceScaled = currentPrice(exchangeId) * tokenPrecisionMultipliers[exchange.reserveAsset];
-    uint256 rewardScaled = reward * tokenPrecisionMultipliers[exchange.tokenAddress];
+    uint256 scaledRatio = uint256(exchange.reserveRatio) * 1e10;
+    uint256 scaledReward = reward * tokenPrecisionMultipliers[exchange.tokenAddress];
 
-    UD60x18 numerator = wrap(exchange.reserveBalance);
-    UD60x18 denominator = wrap(exchange.tokenSupply + rewardScaled).mul(wrap(currentPriceScaled));
+    UD60x18 numerator = wrap(exchange.tokenSupply).mul(wrap(scaledRatio));
+    UD60x18 denominator = wrap(exchange.tokenSupply).add(wrap(scaledReward));
     uint256 newRatioScaled = unwrap(numerator.div(denominator));
 
     uint32 newRatioUint = uint32(newRatioScaled / 1e10);
+
+    require(newRatioUint > 0, "New ratio must be greater than 0");
+
     exchanges[exchangeId].reserveRatio = newRatioUint;
-    exchanges[exchangeId].tokenSupply += rewardScaled;
+    exchanges[exchangeId].tokenSupply += scaledReward;
 
     emit ReserveRatioUpdated(exchangeId, newRatioUint);
   }

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -24,6 +24,8 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   // MAX_WEIGHT is the max rate that can be assigned to an exchange
   uint256 public constant MAX_WEIGHT = 1e18;
 
+  uint32 public constant BANCOR_MAX_WEIGHT = 1e8;
+
   // Address of the distribution helper contract
   IDistributionHelper public distributionHelper;
 
@@ -191,7 +193,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   /// @inheritdoc IGoodDollarExpansionController
   function mintRewardFromReserveRatio(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
     // Defaults to no slippage protection
-    mintRewardFromReserveRatio(exchangeId, to, amount, 100);
+    mintRewardFromReserveRatio(exchangeId, to, amount, BANCOR_MAX_WEIGHT);
   }
 
   /// @inheritdoc IGoodDollarExpansionController
@@ -203,7 +205,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   ) public onlyAvatar {
     require(to != address(0), "Recipient address must be set");
     require(amount > 0, "Amount must be greater than 0");
-    require(maxSlippagePercentage <= 100, "Max slippage percentage cannot be greater than 100%");
+    require(maxSlippagePercentage <= BANCOR_MAX_WEIGHT, "Max slippage percentage cannot be greater than 100%");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
 

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -21,9 +21,10 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
   /* ==================== State Variables ==================== */
   /* ========================================================= */
 
-  // MAX_WEIGHT is the max rate that can be assigned to an exchange
-  uint256 public constant MAX_WEIGHT = 1e18;
+  // EXPANSION_MAX_WEIGHT is the max rate that can be assigned to an exchange
+  uint256 public constant EXPANSION_MAX_WEIGHT = 1e18;
 
+  // BANCOR_MAX_WEIGHT is used for BPS calculations in GoodDollarExchangeProvider
   uint32 public constant BANCOR_MAX_WEIGHT = 1e8;
 
   // Address of the distribution helper contract
@@ -125,7 +126,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
 
   /// @inheritdoc IGoodDollarExpansionController
   function setExpansionConfig(bytes32 exchangeId, uint64 expansionRate, uint32 expansionFrequency) external onlyAvatar {
-    require(expansionRate < MAX_WEIGHT, "Expansion rate must be less than 100%");
+    require(expansionRate < EXPANSION_MAX_WEIGHT, "Expansion rate must be less than 100%");
     require(expansionRate > 0, "Expansion rate must be greater than 0");
     require(expansionFrequency > 0, "Expansion frequency must be greater than 0");
 
@@ -246,7 +247,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
       numberOfExpansions = (block.timestamp - config.lastExpansion) / config.expansionFrequency;
     }
 
-    uint256 stepReserveRatioScalar = MAX_WEIGHT - config.expansionRate;
+    uint256 stepReserveRatioScalar = EXPANSION_MAX_WEIGHT - config.expansionRate;
     return unwrap(powu(wrap(stepReserveRatioScalar), numberOfExpansions));
   }
 

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -190,7 +190,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
 
   /// @inheritdoc IGoodDollarExpansionController
   function mintRewardFromReserveRatio(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
-    // Default to 100% slippage
+    // Defaults to no slippage protection
     mintRewardFromReserveRatio(exchangeId, to, amount, 100);
   }
 

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -190,12 +190,24 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Pausab
 
   /// @inheritdoc IGoodDollarExpansionController
   function mintRewardFromReserveRatio(bytes32 exchangeId, address to, uint256 amount) external onlyAvatar {
+    // Default to 100% slippage
+    mintRewardFromReserveRatio(exchangeId, to, amount, 100);
+  }
+
+  /// @inheritdoc IGoodDollarExpansionController
+  function mintRewardFromReserveRatio(
+    bytes32 exchangeId,
+    address to,
+    uint256 amount,
+    uint256 maxSlippagePercentage
+  ) public onlyAvatar {
     require(to != address(0), "Recipient address must be set");
     require(amount > 0, "Amount must be greater than 0");
+    require(maxSlippagePercentage <= 100, "Max slippage percentage cannot be greater than 100%");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
 
-    goodDollarExchangeProvider.updateRatioForReward(exchangeId, amount);
+    goodDollarExchangeProvider.updateRatioForReward(exchangeId, amount, maxSlippagePercentage);
     IGoodDollar(exchange.tokenAddress).mint(to, amount);
 
     // Ignored, because contracts only interacts with trusted contracts and tokens

--- a/contracts/interfaces/IGoodDollarExchangeProvider.sol
+++ b/contracts/interfaces/IGoodDollarExchangeProvider.sol
@@ -72,8 +72,9 @@ interface IGoodDollarExchangeProvider {
    * @notice Calculates the reserve ratio needed to mint the given G$ reward.
    * @param exchangeId The ID of the pool the G$ reward is minted from.
    * @param reward The amount of G$ tokens to be minted as a reward.
+   * @param maxSlippagePercentage Maximum allowed percentage difference between new and old reserve ratio (0-100).
    */
-  function updateRatioForReward(bytes32 exchangeId, uint256 reward) external;
+  function updateRatioForReward(bytes32 exchangeId, uint256 reward, uint256 maxSlippagePercentage) external;
 
   /**
    * @notice Pauses the Exchange, disabling minting.

--- a/contracts/interfaces/IGoodDollarExchangeProvider.sol
+++ b/contracts/interfaces/IGoodDollarExchangeProvider.sol
@@ -72,7 +72,7 @@ interface IGoodDollarExchangeProvider {
    * @notice Calculates the reserve ratio needed to mint the given G$ reward.
    * @param exchangeId The ID of the pool the G$ reward is minted from.
    * @param reward The amount of G$ tokens to be minted as a reward.
-   * @param maxSlippagePercentage Maximum allowed percentage difference between new and old reserve ratio (0-100).
+   * @param maxSlippagePercentage Maximum allowed percentage difference between new and old reserve ratio (0-1e8).
    */
   function updateRatioForReward(bytes32 exchangeId, uint256 reward, uint256 maxSlippagePercentage) external;
 

--- a/contracts/interfaces/IGoodDollarExpansionController.sol
+++ b/contracts/interfaces/IGoodDollarExpansionController.sol
@@ -148,7 +148,7 @@ interface IGoodDollarExpansionController {
   function mintUBIFromExpansion(bytes32 exchangeId) external returns (uint256 amountMinted);
 
   /**
-   * @notice Mints a reward of G$ tokens for a given pool. Defaults to 100% slippage.
+   * @notice Mints a reward of G$ tokens for a given pool. Defaults to no slippage protection.
    * @param exchangeId The ID of the pool to mint a G$ reward for.
    * @param to The address of the recipient.
    * @param amount The amount of G$ tokens to mint.

--- a/contracts/interfaces/IGoodDollarExpansionController.sol
+++ b/contracts/interfaces/IGoodDollarExpansionController.sol
@@ -148,10 +148,24 @@ interface IGoodDollarExpansionController {
   function mintUBIFromExpansion(bytes32 exchangeId) external returns (uint256 amountMinted);
 
   /**
-   * @notice Mints a reward of G$ tokens for a given pool.
+   * @notice Mints a reward of G$ tokens for a given pool. Defaults to 100% slippage.
    * @param exchangeId The ID of the pool to mint a G$ reward for.
    * @param to The address of the recipient.
    * @param amount The amount of G$ tokens to mint.
    */
   function mintRewardFromReserveRatio(bytes32 exchangeId, address to, uint256 amount) external;
+
+  /**
+   * @notice Mints a reward of G$ tokens for a given pool.
+   * @param exchangeId The ID of the pool to mint a G$ reward for.
+   * @param to The address of the recipient.
+   * @param amount The amount of G$ tokens to mint.
+   * @param maxSlippagePercentage Maximum allowed percentage difference between new and old reserve ratio (0-100).
+   */
+  function mintRewardFromReserveRatio(
+    bytes32 exchangeId,
+    address to,
+    uint256 amount,
+    uint256 maxSlippagePercentage
+  ) external;
 }

--- a/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
+++ b/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
@@ -686,7 +686,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
 
     vm.expectRevert("New ratio must be greater than 0");
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, veryLargeReward);
+    exchangeProvider.updateRatioForReward(exchangeId, veryLargeReward, 1e8);
   }
 
   function test_updateRatioForReward_whenCallerIsNotExpansionController_shouldRevert() public {

--- a/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
+++ b/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
@@ -686,13 +686,13 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
   function test_updateRatioForReward_whenCallerIsNotExpansionController_shouldRevert() public {
     vm.prank(makeAddr("NotExpansionController"));
     vm.expectRevert("Only ExpansionController can call this function");
-    exchangeProvider.updateRatioForReward(exchangeId, reward, 100);
+    exchangeProvider.updateRatioForReward(exchangeId, reward, 1e8);
   }
 
   function test_updateRatioForReward_whenExchangeIdIsInvalid_shouldRevert() public {
     vm.prank(expansionControllerAddress);
     vm.expectRevert("Exchange does not exist");
-    exchangeProvider.updateRatioForReward(bytes32(0), reward, 100);
+    exchangeProvider.updateRatioForReward(bytes32(0), reward, 1e8);
   }
 
   function test_updateRatioForReward_whenRewardLarger0_shouldReturnCorrectRatioAndEmit() public {
@@ -704,7 +704,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     vm.expectEmit(true, true, true, true);
     emit ReserveRatioUpdated(exchangeId, expectedReserveRatio);
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, reward, 100);
+    exchangeProvider.updateRatioForReward(exchangeId, reward, 1e8);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -730,7 +730,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     vm.expectEmit(true, true, true, true);
     emit ReserveRatioUpdated(exchangeId, expectedReserveRatio);
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, _reward, 100);
+    exchangeProvider.updateRatioForReward(exchangeId, _reward, 1e8);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -755,7 +755,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     vm.expectEmit(true, true, true, true);
     emit ReserveRatioUpdated(exchangeId, expectedReserveRatio);
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, _reward, 100);
+    exchangeProvider.updateRatioForReward(exchangeId, _reward, 1e8);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -779,12 +779,12 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
 
     vm.prank(expansionControllerAddress);
     vm.expectRevert("Slippage exceeded");
-    exchangeProvider.updateRatioForReward(exchangeId, _reward, 12);
+    exchangeProvider.updateRatioForReward(exchangeId, _reward, 12 * 1e6);
 
     vm.expectEmit(true, true, true, true);
     emit ReserveRatioUpdated(exchangeId, expectedReserveRatio);
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, _reward, 13);
+    exchangeProvider.updateRatioForReward(exchangeId, _reward, 13 * 1e6);
   }
 
   function test_updateRatioForReward_withMultipleConsecutiveRewards() public {
@@ -796,7 +796,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
 
     vm.startPrank(expansionControllerAddress);
     for (uint256 i = 0; i < 5; i++) {
-      exchangeProvider.updateRatioForReward(exchangeId, reward, 100);
+      exchangeProvider.updateRatioForReward(exchangeId, reward, 1e8);
       totalReward += reward;
     }
     vm.stopPrank();
@@ -824,7 +824,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     uint256 priceBefore = exchangeProvider.currentPrice(exchangeId);
 
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, fuzzedReward, 100);
+    exchangeProvider.updateRatioForReward(exchangeId, fuzzedReward, 1e8);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -910,6 +910,6 @@ contract GoodDollarExchangeProviderTest_pausable is GoodDollarExchangeProviderTe
 
     exchangeProvider.mintFromExpansion(exchangeId, 1e18);
     exchangeProvider.mintFromInterest(exchangeId, 1e18);
-    exchangeProvider.updateRatioForReward(exchangeId, 1e18, 100);
+    exchangeProvider.updateRatioForReward(exchangeId, 1e18, 1e8);
   }
 }

--- a/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
+++ b/test/unit/goodDollar/GoodDollarExchangeProvider.t.sol
@@ -686,13 +686,13 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
   function test_updateRatioForReward_whenCallerIsNotExpansionController_shouldRevert() public {
     vm.prank(makeAddr("NotExpansionController"));
     vm.expectRevert("Only ExpansionController can call this function");
-    exchangeProvider.updateRatioForReward(exchangeId, reward);
+    exchangeProvider.updateRatioForReward(exchangeId, reward, 100);
   }
 
   function test_updateRatioForReward_whenExchangeIdIsInvalid_shouldRevert() public {
     vm.prank(expansionControllerAddress);
     vm.expectRevert("Exchange does not exist");
-    exchangeProvider.updateRatioForReward(bytes32(0), reward);
+    exchangeProvider.updateRatioForReward(bytes32(0), reward, 100);
   }
 
   function test_updateRatioForReward_whenRewardLarger0_shouldReturnCorrectRatioAndEmit() public {
@@ -704,7 +704,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     vm.expectEmit(true, true, true, true);
     emit ReserveRatioUpdated(exchangeId, expectedReserveRatio);
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, reward);
+    exchangeProvider.updateRatioForReward(exchangeId, reward, 100);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -729,7 +729,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     vm.expectEmit(true, true, true, true);
     emit ReserveRatioUpdated(exchangeId, expectedReserveRatio);
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, _reward);
+    exchangeProvider.updateRatioForReward(exchangeId, _reward, 100);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -754,7 +754,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     vm.expectEmit(true, true, true, true);
     emit ReserveRatioUpdated(exchangeId, expectedReserveRatio);
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, _reward);
+    exchangeProvider.updateRatioForReward(exchangeId, _reward, 100);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -777,7 +777,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
 
     vm.startPrank(expansionControllerAddress);
     for (uint256 i = 0; i < 5; i++) {
-      exchangeProvider.updateRatioForReward(exchangeId, reward);
+      exchangeProvider.updateRatioForReward(exchangeId, reward, 100);
       totalReward += reward;
     }
     vm.stopPrank();
@@ -805,7 +805,7 @@ contract GoodDollarExchangeProviderTest_updateRatioForReward is GoodDollarExchan
     uint256 priceBefore = exchangeProvider.currentPrice(exchangeId);
 
     vm.prank(expansionControllerAddress);
-    exchangeProvider.updateRatioForReward(exchangeId, fuzzedReward);
+    exchangeProvider.updateRatioForReward(exchangeId, fuzzedReward, 100);
 
     IBancorExchangeProvider.PoolExchange memory poolExchangeAfter = exchangeProvider.getPoolExchange(exchangeId);
     uint256 priceAfter = exchangeProvider.currentPrice(exchangeId);
@@ -870,7 +870,7 @@ contract GoodDollarExchangeProviderTest_pausable is GoodDollarExchangeProviderTe
     exchangeProvider.mintFromInterest(exchangeId, 1e18);
 
     vm.expectRevert("Pausable: paused");
-    exchangeProvider.updateRatioForReward(exchangeId, 1e18);
+    exchangeProvider.updateRatioForReward(exchangeId, 1e18, 100);
   }
 
   function test_unpause_whenCallerIsAvatar_shouldUnpauseAndEnableExchange() public {
@@ -891,6 +891,6 @@ contract GoodDollarExchangeProviderTest_pausable is GoodDollarExchangeProviderTe
 
     exchangeProvider.mintFromExpansion(exchangeId, 1e18);
     exchangeProvider.mintFromInterest(exchangeId, 1e18);
-    exchangeProvider.updateRatioForReward(exchangeId, 1e18);
+    exchangeProvider.updateRatioForReward(exchangeId, 1e18, 100);
   }
 }

--- a/test/unit/goodDollar/GoodDollarExpansionController.t.sol
+++ b/test/unit/goodDollar/GoodDollarExpansionController.t.sol
@@ -614,7 +614,7 @@ contract GoodDollarExpansionControllerTest_mintRewardFromReserveRatio is GoodDol
   function test_mintRewardFromReserveRatio_whenSlippageIsGreaterThan100_shouldRevert() public {
     vm.prank(avatarAddress);
     vm.expectRevert("Max slippage percentage cannot be greater than 100%");
-    expansionController.mintRewardFromReserveRatio(exchangeId, makeAddr("To"), 1000e18, 101);
+    expansionController.mintRewardFromReserveRatio(exchangeId, makeAddr("To"), 1000e18, 1e8 + 1);
   }
 
   function test_mintRewardFromReserveRatio_whenCallerIsAvatar_shouldMintAndEmit() public {

--- a/test/utils/harnesses/GoodDollarExpansionControllerHarness.sol
+++ b/test/utils/harnesses/GoodDollarExpansionControllerHarness.sol
@@ -7,7 +7,7 @@ import { GoodDollarExpansionController } from "contracts/goodDollar/GoodDollarEx
 contract GoodDollarExpansionControllerHarness is GoodDollarExpansionController {
   constructor(bool disabled) GoodDollarExpansionController(disabled) {}
 
-  function exposed_getReserveRatioScalar(ExchangeExpansionConfig calldata config) external returns (uint256) {
+  function exposed_getReserveRatioScalar(ExchangeExpansionConfig calldata config) external view returns (uint256) {
     return _getReserveRatioScalar(config);
   }
 }


### PR DESCRIPTION
### Description

Adds slippage protection to `updateRatioForReward()`

### Other changes

Simplifies the new ratio calculation formula

### Tested

Unit tests

### Related issues

- Fixes [#594](https://github.com/mento-protocol/mento-general/issues/594)

