### PR TITLE
Fix/use correct min for int48

### DIFF
--- a/contracts/libraries/TradingLimits.sol
+++ b/contracts/libraries/TradingLimits.sol
@@ -168,7 +168,7 @@ library TradingLimits {
    */
   function safeINT48Add(int48 a, int48 b) internal pure returns (int48) {
     int256 c = int256(a) + int256(b);
-    require(c >= -1 * MAX_INT48 && c <= MAX_INT48, "int48 addition overflow");
+    require(c >= MIN_INT48 && c <= MAX_INT48, "int48 addition overflow");
     return int48(c);
   }
 }

--- a/test/unit/libraries/TradingLimits.t.sol
+++ b/test/unit/libraries/TradingLimits.t.sol
@@ -309,10 +309,23 @@ contract TradingLimitsTest is Test {
 
   function test_update_withOverflowOnAdd_reverts() public {
     ITradingLimits.Config memory config = configLG(int48(uint48(2 ** 47)));
-    int256 maxFlow = int256(uint256(type(uint48).max / 2));
+    int256 maxFlow = int256(type(int48).max);
 
     state = harness.update(state, config, (maxFlow - 1000) * 1e18, 18);
+    state = harness.update(state, config, 1000 * 1e18, 18);
+
     vm.expectRevert(bytes("int48 addition overflow"));
-    state = harness.update(state, config, 1002 * 10e18, 18);
+    state = harness.update(state, config, 1 * 1e18, 18);
+  }
+
+  function test_update_withUnderflowOnAdd_reverts() public {
+    ITradingLimits.Config memory config = configLG(int48(uint48(2 ** 47)));
+    int256 minFlow = int256(type(int48).min);
+
+    state = harness.update(state, config, (minFlow + 1000) * 1e18, 18);
+    state = harness.update(state, config, -1000 * 1e18, 18);
+
+    vm.expectRevert(bytes("int48 addition overflow"));
+    state = harness.update(state, config, -1 * 1e18, 18);
   }
 }


### PR DESCRIPTION
### Description

Fixes Sherlock issue 46 by using `type(int48).min`

### Other changes

updates test for withOverflowOnAdd to test the correct limit

### Tested

unit tests

### Related issues

- Fixes [#598](https://github.com/mento-protocol/mento-general/issues/598)