### PR TITLE
Test/new exit contribution

### DIFF
--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -203,7 +203,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     uint256 scaledAmountIn = amountIn * tokenPrecisionMultipliers[tokenIn];
 
     if (tokenIn == exchange.tokenAddress) {
-      uint256 exitContribution = (scaledAmountIn * exchange.exitContribution) / MAX_WEIGHT;
+      exitContribution = (scaledAmountIn * exchange.exitContribution) / MAX_WEIGHT;
       scaledAmountIn -= exitContribution;
     }
 
@@ -220,7 +220,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
   function accountExitContribution(bytes32 exchangeId, uint256 exitContribution) internal {
     PoolExchange memory exchange = getPoolExchange(exchangeId);
     // newRatio = (Supply * oldRatio) / (Supply - exitContribution)
-    UD60x18 nominator = wrap(exchange.tokenSupply).mul(wrap(exchange.reserveRatio * 1e10));
+    UD60x18 nominator = wrap(exchange.tokenSupply).mul(wrap(exchange.reserveRatio));
     UD60x18 denominator = wrap(exchange.tokenSupply - exitContribution);
     UD60x18 newRatio = nominator.div(denominator);
 

--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -211,6 +211,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
   ) public virtual onlyBroker returns (uint256 amountOut) {
     PoolExchange memory exchange = getPoolExchange(exchangeId);
     uint256 scaledAmountIn = amountIn * tokenPrecisionMultipliers[tokenIn];
+    // slither-disable-next-line uninitialized-local
     uint256 exitContribution;
 
     if (tokenIn == exchange.tokenAddress) {
@@ -241,8 +242,9 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     PoolExchange memory exchange = getPoolExchange(exchangeId);
     uint256 scaledAmountOut = amountOut * tokenPrecisionMultipliers[tokenOut];
     uint256 scaledAmountIn = _getScaledAmountIn(exchange, tokenIn, tokenOut, scaledAmountOut);
-
+    // slither-disable-next-line uninitialized-local
     uint256 exitContribution;
+
     if (tokenIn == exchange.tokenAddress) {
       // apply exit contribution
       uint256 scaledAmountInWithExitContribution = (scaledAmountIn * MAX_WEIGHT) /

--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -255,7 +255,8 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
   function accountExitContribution(bytes32 exchangeId, uint256 exitContribution) internal {
     PoolExchange memory exchange = getPoolExchange(exchangeId);
     // newRatio = (Supply * oldRatio) / (Supply - exitContribution)
-    UD60x18 nominator = wrap(exchange.tokenSupply).mul(wrap(exchange.reserveRatio));
+    uint256 scaledReserveRatio = uint256(exchange.reserveRatio) * 1e10;
+    UD60x18 nominator = wrap(exchange.tokenSupply).mul(wrap(scaledReserveRatio));
     UD60x18 denominator = wrap(exchange.tokenSupply - exitContribution);
     UD60x18 newRatio = nominator.div(denominator);
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -1063,12 +1063,14 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
 
   function test_getAmountOut_whenTokenInIsTokenAndAmountLargerSupply_shouldRevert() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
+    uint256 amountIn = (poolExchange1.tokenSupply * 1e8 ) / (1e8 - poolExchange1.exitContribution);
+    
     vm.expectRevert("ERR_INVALID_AMOUNT");
     bancorExchangeProvider.getAmountOut({
       exchangeId: exchangeId,
       tokenIn: address(token),
       tokenOut: address(reserveToken),
-      amountIn: poolExchange1.tokenSupply + 1
+      amountIn: amountIn + 2
     });
   }
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -1626,7 +1626,7 @@ contract BancorExchangeProviderTest_swapOut is BancorExchangeProviderTest {
     bancorExchangeProvider.swapOut("0xexchangeId", address(reserveToken), address(token), 1e18);
   }
 
-  function test_swapOut_whenTokenInNotInexchange_shouldRevert() public {
+  function test_swapOut_whenTokenInNotInExchange_shouldRevert() public {
     BancorExchangeProvider bancorExchangeProvider = initializeBancorExchangeProvider();
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     vm.prank(brokerAddress);
@@ -1634,7 +1634,7 @@ contract BancorExchangeProviderTest_swapOut is BancorExchangeProviderTest {
     bancorExchangeProvider.swapOut(exchangeId, address(token2), address(token), 1e18);
   }
 
-  function test_swapOut_whenTokenOutNotInexchange_shouldRevert() public {
+  function test_swapOut_whenTokenOutNotInExchange_shouldRevert() public {
     BancorExchangeProvider bancorExchangeProvider = initializeBancorExchangeProvider();
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     vm.prank(brokerAddress);
@@ -1690,7 +1690,7 @@ contract BancorExchangeProviderTest_swapOut is BancorExchangeProviderTest {
     });
     vm.prank(brokerAddress);
     uint256 amountIn = bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), amountOut);
-    assertEq(amountIn, expectedAmountIn, "Amount in should be equal to expected amount in");
+    assertEq(amountIn, expectedAmountIn);
 
     (, , uint256 tokenSupplyAfter, uint256 reserveBalanceAfter, , ) = bancorExchangeProvider.exchanges(exchangeId);
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.18;
 // solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility, max-line-length
 // solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
 
-import { Test, console } from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 import { ERC20 } from "openzeppelin-contracts-next/contracts/token/ERC20/ERC20.sol";
 import { BancorExchangeProvider } from "contracts/goodDollar/BancorExchangeProvider.sol";
 import { IExchangeProvider } from "contracts/interfaces/IExchangeProvider.sol";
@@ -1176,7 +1176,6 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
       tokenOut: address(reserveToken),
       amountIn: amountIn
     });
-    console.log("amountOut", amountOut);
 
     // we allow up to 0.1% difference due to precision loss
     assertApproxEqRel(amountOut, expectedAmountOut, 1e18 * 0.001);

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -1658,7 +1658,7 @@ contract BancorExchangeProviderTest_swapOut is BancorExchangeProviderTest {
     BancorExchangeProvider bancorExchangeProvider = initializeBancorExchangeProvider();
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     vm.prank(brokerAddress);
-    vm.expectRevert("amountIn is greater than tokenSupply");
+    vm.expectRevert("amountIn required is greater than tokenSupply");
     bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), poolExchange1.reserveBalance);
   }
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -1109,6 +1109,7 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
       tokenOut: address(reserveToken),
       amountIn: amountIn
     });
+    
     assertEq(amountOut, expectedAmountOut);
   }
 


### PR DESCRIPTION
### Description

This PR tries to solve the discontinued curve problem that was causing the same sell amount when executed in two swaps resulting in a larger amountOut than when sold in one swap. 
The idea is to apply the exitContribution on the G$ amount being sold and burning that amount. In order to not move on the curve by this burn we increase the reserve ratio in order to keep the price before the exitContribution burn equal to the price after. 

### Other changes

Added requires that ensure the token Supply always stays at a minimum of 1 wei

### Tested

- new tests added ensuring the difference in splitting sells into multiple swaps stays super small compared to the gas costs   

### Related issues

 https://github.com/mento-protocol/mento-general/issues/596
https://github.com/mento-protocol/mento-core/issues/555


### Backwards compatibility



### Documentation


