### PR TITLE
Fix: Exchange created with zero reserve

### DIFF
--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -361,6 +361,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     require(exchange.reserveRatio > 1, "Reserve ratio is too low");
     require(exchange.reserveRatio <= MAX_WEIGHT, "Reserve ratio is too high");
     require(exchange.exitContribution <= MAX_WEIGHT, "Exit contribution is too high");
+    require(exchange.reserveBalance > 0, "Reserve balance must be greater than 0");
   }
 
   /**

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -164,6 +164,12 @@ contract BancorExchangeProviderTest_initilizerSettersGetters is BancorExchangePr
     bancorExchangeProvider.setExitContribution(exchangeId, 1e5);
   }
 
+  function test_setExitContribution_whenReserveBalanceIsZero_shouldRevert() public {
+    poolExchange1.reserveBalance = 0;
+    vm.expectRevert("Reserve balance must be greater than 0");
+    bancorExchangeProvider.createExchange(poolExchange1);
+  }
+
   function test_setExitContribution_whenExitContributionIsNotLessThan100Percent_shouldRevert() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -452,19 +452,6 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
     });
   }
 
-  function test_getAmountIn_whenTokenInIsTokenAndReserveBalanceIsZero_shouldRevert() public {
-    poolExchange1.reserveBalance = 0;
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
-
-    vm.expectRevert("ERR_INVALID_RESERVE_BALANCE");
-    bancorExchangeProvider.getAmountIn({
-      exchangeId: exchangeId,
-      tokenIn: address(token),
-      tokenOut: address(reserveToken),
-      amountOut: 1e18
-    });
-  }
-
   function test_getAmountIn_whenTokenInIsTokenAndAmountOutLargerThanReserveBalance_shouldRevert() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     vm.expectRevert("ERR_INVALID_AMOUNT");
@@ -525,19 +512,6 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
 
     vm.expectRevert("ERR_INVALID_SUPPLY");
-    bancorExchangeProvider.getAmountIn({
-      exchangeId: exchangeId,
-      tokenIn: address(reserveToken),
-      tokenOut: address(token),
-      amountOut: 1e18
-    });
-  }
-
-  function test_getAmountIn_whenTokenInIsReserveAssetAndReserveBalanceIsZero_shouldRevert() public {
-    poolExchange1.reserveBalance = 0;
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
-
-    vm.expectRevert("ERR_INVALID_RESERVE_BALANCE");
     bancorExchangeProvider.getAmountIn({
       exchangeId: exchangeId,
       tokenIn: address(reserveToken),
@@ -998,18 +972,6 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
     });
   }
 
-  function test_getAmountOut_whenTokenInIsReserveAssetAndReserveBalanceIsZero_shouldRevert() public {
-    poolExchange1.reserveBalance = 0;
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
-    vm.expectRevert("ERR_INVALID_RESERVE_BALANCE");
-    bancorExchangeProvider.getAmountOut({
-      exchangeId: exchangeId,
-      tokenIn: address(reserveToken),
-      tokenOut: address(token),
-      amountIn: 1e18
-    });
-  }
-
   function test_getAmountOut_whenTokenInIsReserveAssetAndAmountInIsZero_shouldReturnZero() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     uint256 amountOut = bancorExchangeProvider.getAmountOut({
@@ -1041,18 +1003,6 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
     poolExchange1.tokenSupply = 0;
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     vm.expectRevert("ERR_INVALID_SUPPLY");
-    bancorExchangeProvider.getAmountOut({
-      exchangeId: exchangeId,
-      tokenIn: address(token),
-      tokenOut: address(reserveToken),
-      amountIn: 1e18
-    });
-  }
-
-  function test_getAmountOut_whenTokenInIsTokenAndReserveBalanceIsZero_shouldRevert() public {
-    poolExchange1.reserveBalance = 0;
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
-    vm.expectRevert("ERR_INVALID_RESERVE_BALANCE");
     bancorExchangeProvider.getAmountOut({
       exchangeId: exchangeId,
       tokenIn: address(token),

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -164,12 +164,6 @@ contract BancorExchangeProviderTest_initilizerSettersGetters is BancorExchangePr
     bancorExchangeProvider.setExitContribution(exchangeId, 1e5);
   }
 
-  function test_setExitContribution_whenReserveBalanceIsZero_shouldRevert() public {
-    poolExchange1.reserveBalance = 0;
-    vm.expectRevert("Reserve balance must be greater than 0");
-    bancorExchangeProvider.createExchange(poolExchange1);
-  }
-
   function test_setExitContribution_whenExitContributionIsNotLessThan100Percent_shouldRevert() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
 
@@ -256,6 +250,12 @@ contract BancorExchangeProviderTest_createExchange is BancorExchangeProviderTest
   function test_createExchange_whenReserveAssetIsZero_shouldRevert() public {
     poolExchange1.reserveAsset = address(0);
     vm.expectRevert("Invalid reserve asset");
+    bancorExchangeProvider.createExchange(poolExchange1);
+  }
+
+  function test_createExchange_whenReserveBalanceIsZero_shouldRevert() public {
+    poolExchange1.reserveBalance = 0;
+    vm.expectRevert("Reserve balance must be greater than 0");
     bancorExchangeProvider.createExchange(poolExchange1);
   }
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -452,29 +452,6 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
     });
   }
 
-  function test_getAmountIn_whenTokenInIsTokenAndReserveBalanceIsZero_shouldRevert() public {
-    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
-      reserveAsset: address(reserveToken),
-      tokenAddress: address(token),
-      tokenSupply: 300_000 * 1e18,
-      reserveBalance: 60_000 * 1e18,
-      reserveRatio: 1e8 * 0.2,
-      exitContribution: 0
-    });
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
-
-    vm.prank(brokerAddress);
-    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
-
-    vm.expectRevert("ERR_INVALID_SUPPLY");
-    bancorExchangeProvider.getAmountIn({
-      exchangeId: exchangeId,
-      tokenIn: address(token),
-      tokenOut: address(reserveToken),
-      amountOut: 1e18
-    });
-  }
-
   function test_getAmountIn_whenTokenInIsTokenAndAmountOutLargerThanReserveBalance_shouldRevert() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     vm.expectRevert("ERR_INVALID_AMOUNT");
@@ -533,29 +510,6 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
   function test_getAmountIn_whenTokenInIsReserveAssetAndSupplyIsZero_shouldRevert() public {
     poolExchange1.tokenSupply = 0;
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
-
-    vm.expectRevert("ERR_INVALID_SUPPLY");
-    bancorExchangeProvider.getAmountIn({
-      exchangeId: exchangeId,
-      tokenIn: address(reserveToken),
-      tokenOut: address(token),
-      amountOut: 1e18
-    });
-  }
-
-  function test_getAmountIn_whenTokenInIsReserveAssetAndReserveBalanceIsZero_shouldRevert() public {
-    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
-      reserveAsset: address(reserveToken),
-      tokenAddress: address(token),
-      tokenSupply: 300_000 * 1e18,
-      reserveBalance: 60_000 * 1e18,
-      reserveRatio: 1e8 * 0.2,
-      exitContribution: 0
-    });
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
-
-    vm.prank(brokerAddress);
-    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
 
     vm.expectRevert("ERR_INVALID_SUPPLY");
     bancorExchangeProvider.getAmountIn({
@@ -1018,29 +972,6 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
     });
   }
 
-  function test_getAmountOut_whenTokenInIsReserveAssetAndReserveBalanceIsZero_shouldRevert() public {
-    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
-      reserveAsset: address(reserveToken),
-      tokenAddress: address(token),
-      tokenSupply: 300_000 * 1e18,
-      reserveBalance: 60_000 * 1e18,
-      reserveRatio: 1e8 * 0.2,
-      exitContribution: 0
-    });
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
-
-    vm.prank(brokerAddress);
-    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
-
-    vm.expectRevert("ERR_INVALID_SUPPLY");
-    bancorExchangeProvider.getAmountOut({
-      exchangeId: exchangeId,
-      tokenIn: address(reserveToken),
-      tokenOut: address(token),
-      amountIn: 1e18
-    });
-  }
-
   function test_getAmountOut_whenTokenInIsReserveAssetAndAmountInIsZero_shouldReturnZero() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     uint256 amountOut = bancorExchangeProvider.getAmountOut({
@@ -1071,29 +1002,6 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
   function test_getAmountOut_whenTokenInIsTokenAndSupplyIsZero_shouldRevert() public {
     poolExchange1.tokenSupply = 0;
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
-    vm.expectRevert("ERR_INVALID_SUPPLY");
-    bancorExchangeProvider.getAmountOut({
-      exchangeId: exchangeId,
-      tokenIn: address(token),
-      tokenOut: address(reserveToken),
-      amountIn: 1e18
-    });
-  }
-
-  function test_getAmountOut_whenTokenInIsTokenAndReserveBalanceIsZero_shouldRevert() public {
-    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
-      reserveAsset: address(reserveToken),
-      tokenAddress: address(token),
-      tokenSupply: 300_000 * 1e18,
-      reserveBalance: 60_000 * 1e18,
-      reserveRatio: 1e8 * 0.2,
-      exitContribution: 0
-    });
-    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
-
-    vm.prank(brokerAddress);
-    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
-
     vm.expectRevert("ERR_INVALID_SUPPLY");
     bancorExchangeProvider.getAmountOut({
       exchangeId: exchangeId,

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -452,6 +452,29 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
     });
   }
 
+  function test_getAmountIn_whenTokenInIsTokenAndReserveBalanceIsZero_shouldRevert() public {
+    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
+      reserveAsset: address(reserveToken),
+      tokenAddress: address(token),
+      tokenSupply: 300_000 * 1e18,
+      reserveBalance: 60_000 * 1e18,
+      reserveRatio: 1e8 * 0.2,
+      exitContribution: 0
+    });
+    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
+
+    vm.prank(brokerAddress);
+    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
+
+    vm.expectRevert("ERR_INVALID_SUPPLY");
+    bancorExchangeProvider.getAmountIn({
+      exchangeId: exchangeId,
+      tokenIn: address(token),
+      tokenOut: address(reserveToken),
+      amountOut: 1e18
+    });
+  }
+
   function test_getAmountIn_whenTokenInIsTokenAndAmountOutLargerThanReserveBalance_shouldRevert() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     vm.expectRevert("ERR_INVALID_AMOUNT");
@@ -510,6 +533,29 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
   function test_getAmountIn_whenTokenInIsReserveAssetAndSupplyIsZero_shouldRevert() public {
     poolExchange1.tokenSupply = 0;
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
+
+    vm.expectRevert("ERR_INVALID_SUPPLY");
+    bancorExchangeProvider.getAmountIn({
+      exchangeId: exchangeId,
+      tokenIn: address(reserveToken),
+      tokenOut: address(token),
+      amountOut: 1e18
+    });
+  }
+
+  function test_getAmountIn_whenTokenInIsReserveAssetAndReserveBalanceIsZero_shouldRevert() public {
+    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
+      reserveAsset: address(reserveToken),
+      tokenAddress: address(token),
+      tokenSupply: 300_000 * 1e18,
+      reserveBalance: 60_000 * 1e18,
+      reserveRatio: 1e8 * 0.2,
+      exitContribution: 0
+    });
+    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
+
+    vm.prank(brokerAddress);
+    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
 
     vm.expectRevert("ERR_INVALID_SUPPLY");
     bancorExchangeProvider.getAmountIn({
@@ -972,6 +1018,29 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
     });
   }
 
+  function test_getAmountOut_whenTokenInIsReserveAssetAndReserveBalanceIsZero_shouldRevert() public {
+    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
+      reserveAsset: address(reserveToken),
+      tokenAddress: address(token),
+      tokenSupply: 300_000 * 1e18,
+      reserveBalance: 60_000 * 1e18,
+      reserveRatio: 1e8 * 0.2,
+      exitContribution: 0
+    });
+    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
+
+    vm.prank(brokerAddress);
+    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
+
+    vm.expectRevert("ERR_INVALID_SUPPLY");
+    bancorExchangeProvider.getAmountOut({
+      exchangeId: exchangeId,
+      tokenIn: address(reserveToken),
+      tokenOut: address(token),
+      amountIn: 1e18
+    });
+  }
+
   function test_getAmountOut_whenTokenInIsReserveAssetAndAmountInIsZero_shouldReturnZero() public {
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
     uint256 amountOut = bancorExchangeProvider.getAmountOut({
@@ -1002,6 +1071,29 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
   function test_getAmountOut_whenTokenInIsTokenAndSupplyIsZero_shouldRevert() public {
     poolExchange1.tokenSupply = 0;
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange1);
+    vm.expectRevert("ERR_INVALID_SUPPLY");
+    bancorExchangeProvider.getAmountOut({
+      exchangeId: exchangeId,
+      tokenIn: address(token),
+      tokenOut: address(reserveToken),
+      amountIn: 1e18
+    });
+  }
+
+  function test_getAmountOut_whenTokenInIsTokenAndReserveBalanceIsZero_shouldRevert() public {
+    IBancorExchangeProvider.PoolExchange memory poolExchangeTemp = IBancorExchangeProvider.PoolExchange({
+      reserveAsset: address(reserveToken),
+      tokenAddress: address(token),
+      tokenSupply: 300_000 * 1e18,
+      reserveBalance: 60_000 * 1e18,
+      reserveRatio: 1e8 * 0.2,
+      exitContribution: 0
+    });
+    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchangeTemp);
+
+    vm.prank(brokerAddress);
+    bancorExchangeProvider.swapOut(exchangeId, address(token), address(reserveToken), 60_000 * 1e18);
+
     vm.expectRevert("ERR_INVALID_SUPPLY");
     bancorExchangeProvider.getAmountOut({
       exchangeId: exchangeId,


### PR DESCRIPTION
### Description

This PR adds a check to prevent exchanges with zero reserve being created.

This rendered 4 tests redundant due to an exchange of this nature not being possible at creation

### Related issues

- Fixes [#602](https://github.com/mento-protocol/mento-general/issues/602)