### PR TITLE
Fix/scaling issues for tokens with less than 18 decimals

### DIFF
--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -72,7 +72,11 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     _;
   }
 
-  modifier verifyExchangeTokens(address tokenIn, address tokenOut, PoolExchange memory exchange) {
+  modifier verifyExchangeTokens(
+    address tokenIn,
+    address tokenOut,
+    PoolExchange memory exchange
+  ) {
     require(
       (tokenIn == exchange.reserveAsset && tokenOut == exchange.tokenAddress) ||
         (tokenIn == exchange.tokenAddress && tokenOut == exchange.reserveAsset),
@@ -286,6 +290,9 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
 
     tokenPrecisionMultipliers[exchange.reserveAsset] = 10 ** (18 - uint256(reserveAssetDecimals));
     tokenPrecisionMultipliers[exchange.tokenAddress] = 10 ** (18 - uint256(tokenDecimals));
+
+    exchange.reserveBalance = exchange.reserveBalance * tokenPrecisionMultipliers[exchange.reserveAsset];
+    exchange.tokenSupply = exchange.tokenSupply * tokenPrecisionMultipliers[exchange.tokenAddress];
 
     exchanges[exchangeId] = exchange;
     exchangeIds.push(exchangeId);

--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -72,11 +72,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
     _;
   }
 
-  modifier verifyExchangeTokens(
-    address tokenIn,
-    address tokenOut,
-    PoolExchange memory exchange
-  ) {
+  modifier verifyExchangeTokens(address tokenIn, address tokenOut, PoolExchange memory exchange) {
     require(
       (tokenIn == exchange.reserveAsset && tokenOut == exchange.tokenAddress) ||
         (tokenIn == exchange.tokenAddress && tokenOut == exchange.reserveAsset),

--- a/contracts/goodDollar/GoodDollarExchangeProvider.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProvider.sol
@@ -180,14 +180,13 @@ contract GoodDollarExchangeProvider is IGoodDollarExchangeProvider, BancorExchan
   ) external onlyExpansionController whenNotPaused returns (uint256 amountToMint) {
     PoolExchange memory exchange = getPoolExchange(exchangeId);
 
-    uint256 reserveinterestScaled = reserveInterest * tokenPrecisionMultipliers[exchange.reserveAsset];
     uint256 amountToMintScaled = unwrap(
-      wrap(reserveinterestScaled).mul(wrap(exchange.tokenSupply)).div(wrap(exchange.reserveBalance))
+      wrap(reserveInterest).mul(wrap(exchange.tokenSupply)).div(wrap(exchange.reserveBalance))
     );
     amountToMint = amountToMintScaled / tokenPrecisionMultipliers[exchange.tokenAddress];
 
     exchanges[exchangeId].tokenSupply += amountToMintScaled;
-    exchanges[exchangeId].reserveBalance += reserveinterestScaled;
+    exchanges[exchangeId].reserveBalance += reserveInterest;
 
     return amountToMint;
   }

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -136,7 +136,7 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Ownabl
   }
 
   /// @inheritdoc IGoodDollarExpansionController
-  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external returns (uint256 amountToMint) {
+  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external returns (uint256 amountMinted) {
     require(reserveInterest > 0, "Reserve interest must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
@@ -144,13 +144,13 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Ownabl
     require(IERC20(exchange.reserveAsset).transferFrom(msg.sender, reserve, reserveInterest), "Transfer failed");
 
     uint256 reserveInterestScaled = reserveInterest * (10 ** (18 - IERC20Metadata(exchange.reserveAsset).decimals()));
-    amountToMint = goodDollarExchangeProvider.mintFromInterest(exchangeId, reserveInterestScaled);
+    amountMinted = goodDollarExchangeProvider.mintFromInterest(exchangeId, reserveInterestScaled);
 
-    IGoodDollar(exchange.tokenAddress).mint(address(distributionHelper), amountToMint);
+    IGoodDollar(exchange.tokenAddress).mint(address(distributionHelper), amountMinted);
 
     // Ignored, because contracts only interacts with trusted contracts and tokens
     // slither-disable-next-line reentrancy-events
-    emit InterestUBIMinted(exchangeId, amountToMint);
+    emit InterestUBIMinted(exchangeId, amountMinted);
   }
 
   /// @inheritdoc IGoodDollarExpansionController

--- a/contracts/goodDollar/GoodDollarExpansionController.sol
+++ b/contracts/goodDollar/GoodDollarExpansionController.sol
@@ -136,14 +136,16 @@ contract GoodDollarExpansionController is IGoodDollarExpansionController, Ownabl
   }
 
   /// @inheritdoc IGoodDollarExpansionController
-  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external {
+  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external returns (uint256 amountToMint) {
     require(reserveInterest > 0, "Reserve interest must be greater than 0");
     IBancorExchangeProvider.PoolExchange memory exchange = IBancorExchangeProvider(address(goodDollarExchangeProvider))
       .getPoolExchange(exchangeId);
 
-    uint256 amountToMint = goodDollarExchangeProvider.mintFromInterest(exchangeId, reserveInterest);
-
     require(IERC20(exchange.reserveAsset).transferFrom(msg.sender, reserve, reserveInterest), "Transfer failed");
+
+    uint256 reserveInterestScaled = reserveInterest * (10 ** (18 - IERC20Metadata(exchange.reserveAsset).decimals()));
+    amountToMint = goodDollarExchangeProvider.mintFromInterest(exchangeId, reserveInterestScaled);
+
     IGoodDollar(exchange.tokenAddress).mint(address(distributionHelper), amountToMint);
 
     // Ignored, because contracts only interacts with trusted contracts and tokens

--- a/contracts/interfaces/IGoodDollarExpansionController.sol
+++ b/contracts/interfaces/IGoodDollarExpansionController.sol
@@ -131,7 +131,7 @@ interface IGoodDollarExpansionController {
    * @param exchangeId The ID of the pool to mint UBI for.
    * @param reserveInterest The amount of reserve tokens collected from interest.
    */
-  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external;
+  function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external returns (uint256 amountMinted);
 
   /**
    * @notice Mints UBI as G$ tokens for a given pool by comparing the contract's reserve balance to the virtual balance.

--- a/contracts/interfaces/IGoodDollarExpansionController.sol
+++ b/contracts/interfaces/IGoodDollarExpansionController.sol
@@ -130,6 +130,7 @@ interface IGoodDollarExpansionController {
    * @notice Mints UBI as G$ tokens for a given pool from collected reserve interest.
    * @param exchangeId The ID of the pool to mint UBI for.
    * @param reserveInterest The amount of reserve tokens collected from interest.
+   * @return amountMinted The amount of G$ tokens minted.
    */
   function mintUBIFromInterest(bytes32 exchangeId, uint256 reserveInterest) external returns (uint256 amountMinted);
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -41,6 +41,7 @@ contract BancorExchangeProviderTest is Test {
   IBancorExchangeProvider.PoolExchange public poolExchange2;
   IBancorExchangeProvider.PoolExchange public poolExchange3;
   IBancorExchangeProvider.PoolExchange public poolExchange4;
+  IBancorExchangeProvider.PoolExchange public poolExchange5;
 
   function setUp() public virtual {
     reserveToken = new ERC20("cUSD", "cUSD");
@@ -84,6 +85,15 @@ contract BancorExchangeProviderTest is Test {
       tokenAddress: address(tokenWith6Decimals),
       tokenSupply: 300_000 * 1e6,
       reserveBalance: 60_000 * 1e18,
+      reserveRatio: 1e8 * 0.2,
+      exitContribution: 1e8 * 0.01
+    });
+
+    poolExchange5 = IBancorExchangeProvider.PoolExchange({
+      reserveAsset: address(reserveTokenWith6Decimals),
+      tokenAddress: address(tokenWith6Decimals),
+      tokenSupply: 300_000 * 1e6,
+      reserveBalance: 60_000 * 1e6,
       reserveRatio: 1e8 * 0.2,
       exitContribution: 1e8 * 0.01
     });
@@ -382,6 +392,23 @@ contract BancorExchangeProviderTest_createExchange is BancorExchangeProviderTest
 
     assertEq(bancorExchangeProvider.tokenPrecisionMultipliers(address(reserveToken)), 1);
     assertEq(bancorExchangeProvider.tokenPrecisionMultipliers(address(token)), 1);
+  }
+
+  function test_createExchange_whenTokensHasLessThan18Decimals_shouldCreateExchangeWithCorrectSupplyAndBalance()
+    public
+  {
+    bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange5);
+
+    IBancorExchangeProvider.PoolExchange memory poolExchange = bancorExchangeProvider.getPoolExchange(exchangeId);
+    assertEq(poolExchange.reserveAsset, poolExchange5.reserveAsset);
+    assertEq(poolExchange.tokenAddress, poolExchange5.tokenAddress);
+    assertEq(poolExchange.tokenSupply, poolExchange5.tokenSupply * 1e12);
+    assertEq(poolExchange.reserveBalance, poolExchange5.reserveBalance * 1e12);
+    assertEq(poolExchange.reserveRatio, poolExchange5.reserveRatio);
+    assertEq(poolExchange.exitContribution, poolExchange5.exitContribution);
+
+    assertEq(bancorExchangeProvider.tokenPrecisionMultipliers(address(reserveTokenWith6Decimals)), 1e12);
+    assertEq(bancorExchangeProvider.tokenPrecisionMultipliers(address(tokenWith6Decimals)), 1e12);
   }
 }
 

--- a/test/unit/goodDollar/BancorExchangeProvider.t.sol
+++ b/test/unit/goodDollar/BancorExchangeProvider.t.sol
@@ -74,7 +74,7 @@ contract BancorExchangeProviderTest is Test {
       reserveAsset: address(reserveTokenWith6Decimals),
       tokenAddress: address(token),
       tokenSupply: 300_000 * 1e18,
-      reserveBalance: 60_000 * 1e18,
+      reserveBalance: 60_000 * 1e6,
       reserveRatio: 1e8 * 0.2,
       exitContribution: 1e8 * 0.01
     });
@@ -82,7 +82,7 @@ contract BancorExchangeProviderTest is Test {
     poolExchange4 = IBancorExchangeProvider.PoolExchange({
       reserveAsset: address(reserveToken),
       tokenAddress: address(tokenWith6Decimals),
-      tokenSupply: 300_000 * 1e18,
+      tokenSupply: 300_000 * 1e6,
       reserveBalance: 60_000 * 1e18,
       reserveRatio: 1e8 * 0.2,
       exitContribution: 1e8 * 0.01
@@ -737,7 +737,7 @@ contract BancorExchangeProviderTest_getAmountIn is BancorExchangeProviderTest {
       reserveAsset: address(reserveToken6),
       tokenAddress: address(stableToken18),
       tokenSupply: 100_000 * 1e18, // 100,000
-      reserveBalance: 50_000 * 1e18, // 50,000
+      reserveBalance: 50_000 * 1e6, // 50,000
       reserveRatio: 1e8 * 0.5, // 50%
       exitContribution: 0
     });
@@ -1225,7 +1225,7 @@ contract BancorExchangeProviderTest_getAmountOut is BancorExchangeProviderTest {
       reserveAsset: address(reserveToken6),
       tokenAddress: address(stableToken18),
       tokenSupply: 100_000 * 1e18, // 100,000
-      reserveBalance: 50_000 * 1e18, // 50,000
+      reserveBalance: 50_000 * 1e6, // 50,000
       reserveRatio: 1e8 * 0.5, // 50%
       exitContribution: 0
     });
@@ -1563,8 +1563,7 @@ contract BancorExchangeProviderTest_swapIn is BancorExchangeProviderTest {
     uint256 amountIn = 1e6;
 
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange3);
-    uint256 reserveBalanceBefore = poolExchange3.reserveBalance;
-    uint256 tokenSupplyBefore = poolExchange3.tokenSupply;
+    (, , uint256 tokenSupplyBefore, uint256 reserveBalanceBefore, , ) = bancorExchangeProvider.exchanges(exchangeId);
 
     uint256 expectedAmountOut = bancorExchangeProvider.getAmountOut({
       exchangeId: exchangeId,
@@ -1616,8 +1615,7 @@ contract BancorExchangeProviderTest_swapIn is BancorExchangeProviderTest {
     uint256 amountIn = 1e18;
 
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange4);
-    uint256 reserveBalanceBefore = poolExchange4.reserveBalance;
-    uint256 tokenSupplyBefore = poolExchange4.tokenSupply;
+    (, , uint256 tokenSupplyBefore, uint256 reserveBalanceBefore, , ) = bancorExchangeProvider.exchanges(exchangeId);
 
     uint256 expectedAmountOut = bancorExchangeProvider.getAmountOut({
       exchangeId: exchangeId,
@@ -1751,8 +1749,7 @@ contract BancorExchangeProviderTest_swapOut is BancorExchangeProviderTest {
     uint256 amountOut = 1e18;
 
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange3);
-    uint256 reserveBalanceBefore = poolExchange3.reserveBalance;
-    uint256 tokenSupplyBefore = poolExchange3.tokenSupply;
+    (, , uint256 tokenSupplyBefore, uint256 reserveBalanceBefore, , ) = bancorExchangeProvider.exchanges(exchangeId);
 
     uint256 expectedAmountIn = bancorExchangeProvider.getAmountIn({
       exchangeId: exchangeId,
@@ -1804,8 +1801,7 @@ contract BancorExchangeProviderTest_swapOut is BancorExchangeProviderTest {
     uint256 amountOut = 1e18;
 
     bytes32 exchangeId = bancorExchangeProvider.createExchange(poolExchange4);
-    uint256 reserveBalanceBefore = poolExchange4.reserveBalance;
-    uint256 tokenSupplyBefore = poolExchange4.tokenSupply;
+    (, , uint256 tokenSupplyBefore, uint256 reserveBalanceBefore, , ) = bancorExchangeProvider.exchanges(exchangeId);
 
     uint256 expectedAmountIn = bancorExchangeProvider.getAmountIn({
       exchangeId: exchangeId,

--- a/test/unit/goodDollar/GoodDollarExpansionController.t.sol
+++ b/test/unit/goodDollar/GoodDollarExpansionController.t.sol
@@ -722,8 +722,8 @@ contract GoodDollarExpansionControllerIntegrationTest is GoodDollarExpansionCont
 
   function test_mintUBIFromReserveBalance_whenReserveTokenHas6Decimals_shouldMintAndEmit() public {
     uint256 reserveInterest = 1000e6;
-    // amountTo mint = reserveInterest * tokenSupply / reserveBalance
-    uint256 amountToMint = (reserveInterest * 1e12 * 7 * 1e9 * 1e18) / (200_000 * 1e18);
+    // amountToMint = reserveInterest * tokenSupply / reserveBalance
+    uint256 amountToMint = 35_000_000e18;
 
     deal(address(reserveToken6DecimalsMock), reserveAddress, 200_000 * 1e6 + reserveInterest);
     uint256 distributionHelperBalanceBefore = token.balanceOf(distributionHelper);
@@ -738,9 +738,8 @@ contract GoodDollarExpansionControllerIntegrationTest is GoodDollarExpansionCont
 
   function test_mintUBIFromInterest_whenReserveTokenHas6Decimals_shouldMintAndEmit() public {
     uint256 reserveInterest = 1000e6;
-    // amountTo mint = reserveInterest * tokenSupply / reserveBalance
-    uint256 amountToMint = (reserveInterest * 1e12 * 7 * 1e9 * 1e18) / (200_000 * 1e18);
-
+    // amountToMint = reserveInterest * tokenSupply / reserveBalance
+    uint256 amountToMint = 35_000_000e18;
     address interestCollector = makeAddr("InterestCollector");
 
     deal(address(reserveToken6DecimalsMock), interestCollector, reserveInterest);


### PR DESCRIPTION
### Description

Fixes the scaling issues we have in the GoodDollarExpansionController.sol by scaling up `reserveInterest` in `mintUBIFromReserveBalance` and `mintUBIFromInterest` and removing the scaling in `mintFromInterest`

### Other changes

- Updates `_createExchange` to scale tokens with less than 18 decimals instead of leaving that to the callers initiative
- Returns amountMinted from mintUBIFromInterest for consistency

### Tested

Fixed old unit tests, introduced new integration tests

### Related issues

- Fixes [the issue from the Lead Sherlock Watson](https://discord.com/channels/812037309376495636/1220753099283763292/1313200891557445632)
