### PR TITLE
feat: ensure amountOut's are rounded down and amountIn's are roundedUp

### DIFF
--- a/contracts/goodDollar/BancorExchangeProvider.sol
+++ b/contracts/goodDollar/BancorExchangeProvider.sol
@@ -151,7 +151,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
       require(scaledAmountIn < exchange.tokenSupply, "amountIn is greater than tokenSupply");
     }
 
-    amountIn = scaledAmountIn / tokenPrecisionMultipliers[tokenIn];
+    amountIn = divAndRoundUp(scaledAmountIn, tokenPrecisionMultipliers[tokenIn]);
     return amountIn;
   }
 
@@ -261,7 +261,7 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
       _accountExitContribution(exchangeId, exitContribution);
     }
 
-    amountIn = scaledAmountInWithExitContribution / tokenPrecisionMultipliers[tokenIn];
+    amountIn = divAndRoundUp(scaledAmountInWithExitContribution, tokenPrecisionMultipliers[tokenIn]);
     return amountIn;
   }
 
@@ -354,6 +354,16 @@ contract BancorExchangeProvider is IExchangeProvider, IBancorExchangeProvider, B
 
     exchanges[exchangeId].reserveRatio = uint32(newRatio);
     exchanges[exchangeId].tokenSupply -= exitContribution;
+  }
+
+  /**
+   * @notice Division and rounding up if there is a remainder
+   * @param a The dividend
+   * @param b The divisor
+   * @return The result of the division rounded up
+   */
+  function divAndRoundUp(uint256 a, uint256 b) internal pure returns (uint256) {
+    return (a / b) + (a % b > 0 ? 1 : 0);
   }
 
   /**


### PR DESCRIPTION
### Description

This PR ensures that amountOut's returned are always rounded down when tokenPrecisionMultipliers are applied and amountIn's are always rounded up. The rounding down of amountOut's was already done through the division by tokenPrecisionMultipliers the same was done to the the amountIn. This meant that when a token has less than 18 decimals the amountIn was wrongly scaled down -> returning a better price than what the calculation returned.
This has been changed by adding a new `divAndRoundUp` function. The function adds a +1 when the amountIn is scaled down to a different decimal precision and decimals are lossed.

### Other changes

- added tests that verify we also do the rounding down correctly for amountOut. 

### Tested

- new tests added for both getAmountIn and swapOut

### Related issues

https://discord.com/channels/812037309376495636/1220753099283763292/1313168114019729468

### Backwards compatibility



### Documentation


