### PR TITLE
feat: add GD proxies

### DIFF
--- a/contracts/goodDollar/GoodDollarExchangeProviderProxy.sol
+++ b/contracts/goodDollar/GoodDollarExchangeProviderProxy.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.18;
+
+import {
+  TransparentUpgradeableProxy
+} from "openzeppelin-contracts-next/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract GoodDollarExchangeProviderProxy is TransparentUpgradeableProxy {
+  constructor(
+    address _logic,
+    address admin_,
+    bytes memory _data
+  ) payable TransparentUpgradeableProxy(_logic, admin_, _data) {}
+}

--- a/contracts/goodDollar/GoodDollarExpansionControllerProxy.sol
+++ b/contracts/goodDollar/GoodDollarExpansionControllerProxy.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.18;
+
+import {
+  TransparentUpgradeableProxy
+} from "openzeppelin-contracts-next/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract GoodDollarExpansionControllerProxy is TransparentUpgradeableProxy {
+  constructor(
+    address _logic,
+    address admin_,
+    bytes memory _data
+  ) payable TransparentUpgradeableProxy(_logic, admin_, _data) {}
+}

--- a/contracts/goodDollar/GoodDollarReserveProxy.sol
+++ b/contracts/goodDollar/GoodDollarReserveProxy.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+
+import "celo/contracts/common/Proxy.sol";
+
+/* solhint-disable-next-line no-empty-blocks */
+contract GoodDollarReserveProxy is Proxy {}


### PR DESCRIPTION
### Description

- This PR adds the named proxy contracts for the upcoming G$ deployment. 
- We are using the OZ TransparentUpgradeableProxy contract for the exchangeProvider as well as the expansionController
- For the GoodDollarReserve proxy we went with the same celo proxy implementation used by the existing mento reserve proxy. The Reason for not using the newer more common OZ proxy implementations is to not make future reserve upgrades too complicated and have different proxy logics point to the same implementation contract. 

If anybody is strongly in favor of using the newer OZ proxy implementation or has some additional thoughts on this lmk.

### Other changes



### Tested



### Related issues

- Fixes #566 

### Backwards compatibility



### Documentation

