### PR TITLE
feat: add tradingLimit decimal tracking

### DIFF
--- a/contracts/interfaces/ITradingLimits.sol
+++ b/contracts/interfaces/ITradingLimits.sol
@@ -9,6 +9,7 @@ interface ITradingLimits {
    * @param netflow0 The current netflow of the asset for limit0.
    * @param netflow1 The current netflow of the asset for limit1.
    * @param netflowGlobal The current netflow of the asset for limitGlobal.
+   * @param netflowDecimals The current decimal part of all netflows.
    */
   struct State {
     uint32 lastUpdated0;
@@ -16,6 +17,7 @@ interface ITradingLimits {
     int48 netflow0;
     int48 netflow1;
     int48 netflowGlobal;
+    int48 netflowDecimals;
   }
 
   /**

--- a/contracts/libraries/TradingLimits.sol
+++ b/contracts/libraries/TradingLimits.sol
@@ -123,6 +123,9 @@ library TradingLimits {
     if (config.flags & LG == 0) {
       self.netflowGlobal = 0;
     }
+    if (config.flags & (L0 | LG) == 0) {
+      self.netflowDecimals = 0;
+    }
     return self;
   }
 

--- a/test/fork/GoodDollar/GoodDollarBaseForkTest.sol
+++ b/test/fork/GoodDollar/GoodDollarBaseForkTest.sol
@@ -249,9 +249,14 @@ contract GoodDollarBaseForkTest is BaseForkTest {
   function getTradingLimitsState(address tokenAddress) public view returns (ITradingLimits.State memory state) {
     bytes32 limitId = getTradingLimitId(tokenAddress);
     ITradingLimits.State memory _state;
-    (_state.lastUpdated0, _state.lastUpdated1, _state.netflow0, _state.netflow1, _state.netflowGlobal) = Broker(
-      address(broker)
-    ).tradingLimitsState(limitId);
+    (
+      _state.lastUpdated0,
+      _state.lastUpdated1,
+      _state.netflow0,
+      _state.netflow1,
+      _state.netflowGlobal,
+      _state.netflowDecimals
+    ) = Broker(address(broker)).tradingLimitsState(limitId);
 
     return _state;
   }

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -51,7 +51,8 @@ library TradingLimitHelpers {
       limitState.lastUpdated1,
       limitState.netflow0,
       limitState.netflow1,
-      limitState.netflowGlobal
+      limitState.netflowGlobal,
+      limitState.netflowDecimals
     ) = Broker(address(ctx.broker())).tradingLimitsState(limitId);
     return limitState;
   }
@@ -81,7 +82,8 @@ library TradingLimitHelpers {
       limitState.lastUpdated1,
       limitState.netflow0,
       limitState.netflow1,
-      limitState.netflowGlobal
+      limitState.netflowGlobal,
+      limitState.netflowDecimals
     ) = Broker(address(ctx.broker())).tradingLimitsState(limitId);
     return limitState;
   }

--- a/test/unit/libraries/TradingLimits.t.sol
+++ b/test/unit/libraries/TradingLimits.t.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8;
 
 import { Test } from "mento-std/Test.sol";
 import { ITradingLimits } from "contracts/interfaces/ITradingLimits.sol";
-
 import { TradingLimitsHarness } from "test/utils/harnesses/TradingLimitsHarness.sol";
 
 // forge test --match-contract TradingLimits -vvv
@@ -99,13 +98,13 @@ contract TradingLimitsTest is Test {
 
   function test_validate_withL0_withoutTimestep_isNotValid() public {
     ITradingLimits.Config memory config = configL0(0, 1000);
-    vm.expectRevert(bytes("timestep0 can't be zero if active"));
+    vm.expectRevert("timestep0 can't be zero if active");
     harness.validate(config);
   }
 
   function test_validate_withL0_withoutLimit0_isNotValid() public {
     ITradingLimits.Config memory config = configL0(100, 0);
-    vm.expectRevert(bytes("limit0 can't be zero if active"));
+    vm.expectRevert("limit0 can't be zero if active");
     harness.validate(config);
   }
 
@@ -116,37 +115,37 @@ contract TradingLimitsTest is Test {
 
   function test_validate_withL1_withoutLimit1_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 0);
-    vm.expectRevert(bytes("limit1 can't be zero if active"));
+    vm.expectRevert("limit1 can't be zero if active");
     harness.validate(config);
   }
 
   function test_validate_withL0L1_withoutTimestape_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1(0, 1000, 1000, 10000);
-    vm.expectRevert(bytes("timestep0 can't be zero if active"));
+    vm.expectRevert("timestep0 can't be zero if active");
     harness.validate(config);
   }
 
   function test_validate_withL0L1_withLimit0LargerLimit1_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1(10000, 10000, 1000, 1000);
-    vm.expectRevert(bytes("limit1 must be greater than limit0"));
+    vm.expectRevert("limit1 must be greater than limit0");
     harness.validate(config);
   }
 
   function test_validate_withLG_withoutLimitGlobal_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 10000, 0);
-    vm.expectRevert(bytes("limitGlobal can't be zero if active"));
+    vm.expectRevert("limitGlobal can't be zero if active");
     harness.validate(config);
   }
 
   function test_validate_withL0LG_withLimit0LargerLimitGlobal_isNotValid() public {
     ITradingLimits.Config memory config = configL0LG(10000, 10000, 1000);
-    vm.expectRevert(bytes("limitGlobal must be greater than limit0"));
+    vm.expectRevert("limitGlobal must be greater than limit0");
     harness.validate(config);
   }
 
   function test_validate_withL1LG_withLimit1LargerLimitGlobal_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1LG(100, 1000, 10000, 10000, 1000);
-    vm.expectRevert(bytes("limitGlobal must be greater than limit1"));
+    vm.expectRevert("limitGlobal must be greater than limit1");
     harness.validate(config);
   }
 
@@ -157,7 +156,7 @@ contract TradingLimitsTest is Test {
 
   function test_configure_withL1LG_isNotValid() public {
     ITradingLimits.Config memory config = configL1LG(1000, 10000, 100000);
-    vm.expectRevert(bytes("L1 without L0 not allowed"));
+    vm.expectRevert("L1 without L0 not allowed");
     harness.validate(config);
   }
 
@@ -206,13 +205,13 @@ contract TradingLimitsTest is Test {
 
   function test_verify_withL0_andMetPositively() public {
     state.netflow0 = 1231;
-    vm.expectRevert(bytes("L0 Exceeded"));
+    vm.expectRevert("L0 Exceeded");
     harness.verify(state, configL0(500, 1230));
   }
 
   function test_verify_withL0_andMetNegatively() public {
     state.netflow0 = -1231;
-    vm.expectRevert(bytes("L0 Exceeded"));
+    vm.expectRevert("L0 Exceeded");
     harness.verify(state, configL0(500, 1230));
   }
 
@@ -223,13 +222,13 @@ contract TradingLimitsTest is Test {
 
   function test_verify_withL0L1_andL1MetPositively() public {
     state.netflow1 = 1231;
-    vm.expectRevert(bytes("L1 Exceeded"));
+    vm.expectRevert("L1 Exceeded");
     harness.verify(state, configL0L1(50, 100, 500, 1230));
   }
 
   function test_verify_withL0L1_andL1MetNegatively() public {
     state.netflow1 = -1231;
-    vm.expectRevert(bytes("L1 Exceeded"));
+    vm.expectRevert("L1 Exceeded");
     harness.verify(state, configL0L1(50, 100, 500, 1230));
   }
 
@@ -240,13 +239,70 @@ contract TradingLimitsTest is Test {
 
   function test_verify_withLG_andMetPositively() public {
     state.netflowGlobal = 1231;
-    vm.expectRevert(bytes("LG Exceeded"));
+    vm.expectRevert("LG Exceeded");
     harness.verify(state, configLG(1230));
   }
 
   function test_verify_withLG_andMetNegatively() public {
     state.netflowGlobal = -1231;
-    vm.expectRevert(bytes("LG Exceeded"));
+    vm.expectRevert("LG Exceeded");
+    harness.verify(state, configLG(1230));
+  }
+
+  function test_verify_withL0_takesDecimalsIntoAccount() public {
+    state.netflow0 = 1230;
+    state.netflowDecimals = 0;
+    // 1230 + 0.0 <= 1230 -> no revert
+    harness.verify(state, configL0(500, 1230));
+
+    state.netflow0 = -1230;
+    state.netflowDecimals = -1e14 * 0.1;
+    // -1230 - 0.1 < -1230 -> revert
+    vm.expectRevert("L0 Exceeded");
+    harness.verify(state, configL0(500, 1230));
+
+    state.netflow0 = 1230;
+    state.netflowDecimals = 1e14 * 0.1;
+    // 1230 + 0.1 <= 1230 -> revert
+    vm.expectRevert("L0 Exceeded");
+    harness.verify(state, configL0(500, 1230));
+  }
+
+  function test_verify_withL1_takesDecimalsIntoAccount() public {
+    state.netflow1 = 1230;
+    state.netflowDecimals = 0;
+    // 1230 + 0.0 <= 1230 -> no revert
+    harness.verify(state, configL1(500, 1230));
+
+    state.netflow1 = -1230;
+    state.netflowDecimals = -1e14 * 0.1;
+    // -1230 - 0.1 < -1230 -> revert
+    vm.expectRevert("L1 Exceeded");
+    harness.verify(state, configL1(500, 1230));
+
+    state.netflow1 = 1230;
+    state.netflowDecimals = 1e14 * 0.1;
+    // 1230 + 0.1 <= 1230 -> revert
+    vm.expectRevert("L1 Exceeded");
+    harness.verify(state, configL1(500, 1230));
+  }
+
+  function test_verify_withLG_takesDecimalsIntoAccount() public {
+    state.netflowGlobal = 1230;
+    state.netflowDecimals = 0;
+    // 1230 + 0.0 <= 1230 -> no revert
+    harness.verify(state, configLG(1230));
+
+    state.netflowGlobal = -1230;
+    state.netflowDecimals = -1e14 * 0.1;
+    // -1230 - 0.1 < -1230 -> revert
+    vm.expectRevert("LG Exceeded");
+    harness.verify(state, configLG(1230));
+
+    state.netflowGlobal = 1230;
+    state.netflowDecimals = 1e14 * 0.1;
+    // 1230 + 0.1 <= 1230 -> revert
+    vm.expectRevert("LG Exceeded");
     harness.verify(state, configLG(1230));
   }
 
@@ -293,24 +349,14 @@ contract TradingLimitsTest is Test {
     assertEq(state.netflowGlobal, 100);
   }
 
-  function test_update_withPositiveSubUnitAmounts_updatesAs1() public {
-    state = harness.update(state, configLG(500000), 1e6, 18);
-    assertEq(state.netflowGlobal, 1);
-  }
-
-  function test_update_withNegativeSubUnitAmounts_updatesAsMinus1() public {
-    state = harness.update(state, configLG(500000), -1e6, 18);
-    assertEq(state.netflowGlobal, -1);
-  }
-
   function test_update_withTooLargeAmount_reverts() public {
-    vm.expectRevert(bytes("dFlow too large"));
+    vm.expectRevert("dFlow too large");
     state = harness.update(state, configLG(500000), 3 * 10e32, 18);
   }
 
   function test_update_withTooSmallAmount_reverts() public {
     int256 tooSmall = (type(int48).min - int256(1)) * 1e18;
-    vm.expectRevert(bytes("dFlow too small"));
+    vm.expectRevert("dFlow too small");
     state = harness.update(state, configLG(500000), tooSmall, 18);
   }
 
@@ -321,7 +367,7 @@ contract TradingLimitsTest is Test {
     state = harness.update(state, config, (maxFlow - 1000) * 1e18, 18);
     state = harness.update(state, config, 1000 * 1e18, 18);
 
-    vm.expectRevert(bytes("int48 addition overflow"));
+    vm.expectRevert("int48 addition overflow");
     state = harness.update(state, config, 1 * 1e18, 18);
   }
 
@@ -332,7 +378,125 @@ contract TradingLimitsTest is Test {
     state = harness.update(state, config, (minFlow + 1000) * 1e18, 18);
     state = harness.update(state, config, -1000 * 1e18, 18);
 
-    vm.expectRevert(bytes("int48 addition overflow"));
+    vm.expectRevert("int48 addition overflow");
     state = harness.update(state, config, -1 * 1e18, 18);
+  }
+
+  function test_update_whenL0AndTimestep0_resetsNetFlowDecimals() public {
+    uint32 timestep0 = 5 minutes;
+    state.netflowDecimals = 1e14 * 0.1;
+
+    vm.warp(block.timestamp + timestep0 + 1);
+
+    state = harness.update(state, configL0(timestep0, 1000), 100 * 1e18, 18);
+    assertEq(state.netflowDecimals, 0);
+  }
+
+  function test_update_withPositiveDecimalsLessThan1e4_updatesAs0() public {
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), 1e4 * 0.9999, 18);
+    assertEq(state.netflow0, 0);
+    assertEq(state.netflow1, 0);
+    assertEq(state.netflowGlobal, 0);
+    assertEq(state.netflowDecimals, 0);
+
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), 12345, 18);
+    assertEq(state.netflow0, 0);
+    assertEq(state.netflow1, 0);
+    assertEq(state.netflowGlobal, 0);
+    assertEq(state.netflowDecimals, 1);
+  }
+
+  function test_update_withPositiveAmountsAndDecimals_updatesNetflowAndDecimals() public {
+    // state before netflowDecimals = 0.2
+    state.netflowDecimals = 0.2 * 1e14;
+    state.netflow0 = 1; // 1.2
+    state.netflow1 = -100; // -100 + 0.2 = -99.8
+    state.netflowGlobal = 1000; // 1000.2
+
+    ITradingLimits.State memory stateBefore = state;
+
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), 10.6 * 1e18, 18);
+
+    // state after netflowDecimals = netflowDecimalsBefore + 0.6
+    assertEq(state.netflowDecimals, stateBefore.netflowDecimals + 0.6 * 1e14);
+
+    // state after netflow = netflowBefore + 10
+    assertEq(state.netflow0, stateBefore.netflow0 + 10);
+    assertEq(state.netflow1, stateBefore.netflow1 + 10);
+    assertEq(state.netflowGlobal, stateBefore.netflowGlobal + 10);
+  }
+
+  function test_update_withPositiveCarryOver_updatesNetflowAndDecimals() public {
+    // state before netflowDecimals = 0.3
+    state.netflowDecimals = 0.3 * 1e14;
+    state.netflow0 = 1; // 1.3
+    state.netflow1 = -100; // -100 + 0.3 = -99.7
+    state.netflowGlobal = 1000; // 1000.3
+
+    ITradingLimits.State memory stateBefore = state;
+
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), 10.8 * 1e18, 18);
+
+    // state after netflowDecimals = netflowDecimalsBefore + 0.8 = 0.3 + 0.8 = 1.1 -> 0.1 & 1 carry
+    assertEq(state.netflowDecimals, 0.1 * 1e14);
+
+    // state after netflow = netflowBefore + 10 + carry = netflowBefore + 11
+    assertEq(state.netflow0, stateBefore.netflow0 + 11);
+    assertEq(state.netflow1, stateBefore.netflow1 + 11);
+    assertEq(state.netflowGlobal, stateBefore.netflowGlobal + 11);
+  }
+
+  function test_update_withNegativeDecimalsLessThan1e4_updatesAs0() public {
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), -1e4 * 0.9999, 18);
+    assertEq(state.netflow0, 0);
+    assertEq(state.netflow1, 0);
+    assertEq(state.netflowGlobal, 0);
+    assertEq(state.netflowDecimals, 0);
+
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), -12345, 18);
+    assertEq(state.netflow0, 0);
+    assertEq(state.netflow1, 0);
+    assertEq(state.netflowGlobal, 0);
+    assertEq(state.netflowDecimals, -1);
+  }
+
+  function test_update_withNegativeAmountsAndDecimals_updatesNetflowAndDecimals() public {
+    // state before netflowDecimals = -0.2
+    state.netflowDecimals = -0.2 * 1e14;
+    state.netflow0 = -1; // -1.2
+    state.netflow1 = 100; // 100 - 0.2 = 99.8
+    state.netflowGlobal = -1000; // -1000.2
+
+    ITradingLimits.State memory stateBefore = state;
+
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), -10.6 * 1e18, 18);
+
+    // state after netflowDecimals = netflowDecimalsBefore - 0.6
+    assertEq(state.netflowDecimals, stateBefore.netflowDecimals - 0.6 * 1e14);
+
+    // state after netflow = netflowBefore - 10
+    assertEq(state.netflow0, stateBefore.netflow0 - 10);
+    assertEq(state.netflow1, stateBefore.netflow1 - 10);
+    assertEq(state.netflowGlobal, stateBefore.netflowGlobal - 10);
+  }
+
+  function test_update_withNegativeCarryOver_updatesNetflowAndDecimals() public {
+    // state before netflowDecimals = -0.3
+    state.netflowDecimals = -0.3 * 1e14;
+    state.netflow0 = -1; // -1.3
+    state.netflow1 = 100; // 100 - 0.3 = 99.7
+    state.netflowGlobal = -1000; // -1000.3
+
+    ITradingLimits.State memory stateBefore = state;
+
+    state = harness.update(state, configL0L1LG(300, 1000, 86400, 100_000, 1_000_000), -10.8 * 1e18, 18);
+
+    // state after netflowDecimals = netflowDecimalsBefore - 0.8 = -0.3 - 0.8 = -1.1 -> -0.1 & -1 carry
+    assertEq(state.netflowDecimals, -0.1 * 1e14);
+
+    // state after netflow = netflowBefore - 10 + carry = netflowBefore - 11
+    assertEq(state.netflow0, stateBefore.netflow0 - 11);
+    assertEq(state.netflow1, stateBefore.netflow1 - 11);
+    assertEq(state.netflowGlobal, stateBefore.netflowGlobal - 11);
   }
 }

--- a/test/unit/libraries/TradingLimits.t.sol
+++ b/test/unit/libraries/TradingLimits.t.sol
@@ -191,6 +191,12 @@ contract TradingLimitsTest is Test {
     assertEq(state.netflowGlobal, 12312);
   }
 
+  function test_reset_withL0LGDisabled_resetsNetflowDecimals() public {
+    state.netflowDecimals = 1e14 * 0.1;
+    state = harness.reset(state, configEmpty());
+    assertEq(state.netflowDecimals, 0);
+  }
+
   /* ==================== State#verify ==================== */
 
   function test_verify_withNothingOn() public view {


### PR DESCRIPTION
### Description

This PR adds decimal tracking to our existing TradingLimits library.
Before, the trading limit state was stored in a Struct with five variables.
```solidity
struct State {
    uint32 lastUpdated0;
    uint32 lastUpdated1;
    int48 netflow0;
    int48 netflow1;
    int48 netflowGlobal;
  }
```
Together these 5 take up 208bits (32 + 32 + 48 + 48 + 48). One storage slot takes up 256 bits, meaning the current state does not fill up the entire slot and leaves space for another 48 bits.

The basic idea of this Pr is adding a single int48 that stores the current decimal part of all limit netflows. 
Since an int48 can store a max/min of 140737488355327/-140737488355328 our netflows will only have 14 decimal places. 

```solidity
struct State {
    uint32 lastUpdated0;
    uint32 lastUpdated1;
    int48 netflow0;
    int48 netflow1;
    int48 netflowGlobal;
    int48 netflowDecimals;
  }
```

For our netflows, the actual current netflow is `netflow*1e14 + netflowDecimals`. Therefore, the verify function was updated to check whether the limits are surpassed on the decimal places. 
e.g 
```
Config {
    limit0 = 1_000;
    limit1 = 10_000;
    limitGlobal = 100_000;
    flags = L0&L1&LG;
  }

State {
    netflow0 = 1_000;
    netflow1 = -10_000 ;
    netflowGlobal = 99_000;
    netflowDecimals = -0.2;
} 
```
In this scenario, the actual limits with decimals would look like this:
```
netflow0 - 0.2 = 999.8 -> limit0 not surpassed
netflow1 - 0.2 = -10_000.2 -> limit1 surpassed
netflowGlobal - 0.2 = 98_999.8 -> limitGlobal not surpassed
```

When L0 is configured, the decimals are reset when timestep0 seconds have passed. 

**Open Question:**
Currently, our trading limits do not account for amounts smaller than 1e4/-1e4. 
We could round them to 1e4/-1e4, similar to what we did previously for the unit part.
In both worlds, the gas costs for trading an amount less than 1e4 will be much higher than any benefit from
manipulating the net flow / bypassing the limits.  
 

### Other changes

- n/a

### Tested

- added tests for both the update and the verification changes 