### PR TITLE
Fix: Relocking min amount bypass

### DIFF
--- a/contracts/governance/locking/LockingRelock.sol
+++ b/contracts/governance/locking/LockingRelock.sol
@@ -68,6 +68,7 @@ abstract contract LockingRelock is LockingBase {
     uint32 toTime
   ) internal view {
     require(newAmount > 0, "zero amount");
+    require(newAmount >= 1e18, "amount is less than minimum");
     require(newCliff <= MAX_CLIFF_PERIOD, "cliff too big");
     require(newSlopePeriod <= MAX_SLOPE_PERIOD, "slope period too big");
     require(newSlopePeriod > 0, "slope period equal 0");
@@ -117,7 +118,6 @@ abstract contract LockingRelock is LockingBase {
    */
   function rebalance(uint256 id, address account, uint96 bias, uint96 residue, uint96 newAmount) internal {
     require(residue <= newAmount, "Impossible to relock: less amount, then now is");
-    require(newAmount >= 1e18, "amount is less than minimum");
     uint96 addAmount = newAmount - (residue);
     uint96 amount = accounts[account].amount;
     uint96 balance = amount - (bias);

--- a/contracts/governance/locking/LockingRelock.sol
+++ b/contracts/governance/locking/LockingRelock.sol
@@ -117,6 +117,7 @@ abstract contract LockingRelock is LockingBase {
    */
   function rebalance(uint256 id, address account, uint96 bias, uint96 residue, uint96 newAmount) internal {
     require(residue <= newAmount, "Impossible to relock: less amount, then now is");
+    require(newAmount >= 1e18, "amount is less than minimum");
     uint96 addAmount = newAmount - (residue);
     uint96 amount = accounts[account].amount;
     uint96 balance = amount - (bias);

--- a/contracts/governance/locking/LockingRelock.sol
+++ b/contracts/governance/locking/LockingRelock.sol
@@ -26,6 +26,7 @@ abstract contract LockingRelock is LockingBase {
     uint32 newSlopePeriod,
     uint32 newCliff
   ) external returns (uint256) {
+    require(newAmount >= 1e18, "amount is less than minimum");
     require(newDelegate != address(0), "delegate is zero");
 
     address account = verifyLockOwner(id);
@@ -67,7 +68,6 @@ abstract contract LockingRelock is LockingBase {
     uint32 newCliff,
     uint32 toTime
   ) internal view {
-    require(newAmount >= 1e18, "amount is less than minimum");
     require(newCliff <= MAX_CLIFF_PERIOD, "cliff too big");
     require(newSlopePeriod <= MAX_SLOPE_PERIOD, "slope period too big");
     require(newSlopePeriod > 0, "slope period equal 0");

--- a/contracts/governance/locking/LockingRelock.sol
+++ b/contracts/governance/locking/LockingRelock.sol
@@ -67,7 +67,6 @@ abstract contract LockingRelock is LockingBase {
     uint32 newCliff,
     uint32 toTime
   ) internal view {
-    require(newAmount > 0, "zero amount");
     require(newAmount >= 1e18, "amount is less than minimum");
     require(newCliff <= MAX_CLIFF_PERIOD, "cliff too big");
     require(newSlopePeriod <= MAX_SLOPE_PERIOD, "slope period too big");

--- a/test/unit/governance/Locking/relock.t.sol
+++ b/test/unit/governance/Locking/relock.t.sol
@@ -230,7 +230,7 @@ contract Relock_LockingTest is LockingTest {
     lockId = locking.lock(alice, alice, 38e18, 4, 3);
     _incrementBlock(2 * weekInBlocks);
 
-    vm.expectRevert("zero amount");
+    vm.expectRevert("amount is less than minimum");
     vm.prank(alice);
     locking.relock(lockId, alice, 0, 5, 1);
   }

--- a/test/unit/governance/Locking/relock.t.sol
+++ b/test/unit/governance/Locking/relock.t.sol
@@ -653,10 +653,8 @@ contract Relock_LockingTest is LockingTest {
     vm.prank(alice);
     lockId = locking.lock(alice, alice, 30e18, 3, 3);
 
-    // Wait until lock expires so residue is 0
     _incrementBlock(6 * weekInBlocks);
 
-    // Try to relock with amount less than minimum (1e18)
     vm.expectRevert("amount is less than minimum");
     vm.prank(alice);
     locking.relock(lockId, alice, 0.5e18, 3, 3);
@@ -668,10 +666,8 @@ contract Relock_LockingTest is LockingTest {
     vm.prank(alice);
     lockId = locking.lock(alice, alice, 30e18, 3, 3);
 
-    // Wait until lock expires so residue is 0
     _incrementBlock(6 * weekInBlocks);
 
-    // Should succeed with amount = minimum
     vm.prank(alice);
     locking.relock(lockId, alice, 1e18, 3, 3);
   }

--- a/test/unit/governance/Locking/relock.t.sol
+++ b/test/unit/governance/Locking/relock.t.sol
@@ -646,4 +646,19 @@ contract Relock_LockingTest is LockingTest {
     assertEq(mentoToken.balanceOf(bob), 100e18);
     assertEq(mentoToken.balanceOf(charlie), 100e18);
   }
+
+  function test_relock_whenAmountLessThanMinimum_shouldRevert() public {
+    mentoToken.mint(alice, 100e18);
+
+    vm.prank(alice);
+    lockId = locking.lock(alice, alice, 30e18, 3, 3);
+
+    // Wait until lock expires so residue is 0
+    _incrementBlock(6 * weekInBlocks);
+
+    // Try to relock with amount less than minimum (1e18)
+    vm.expectRevert("amount is less than minimum");
+    vm.prank(alice);
+    locking.relock(lockId, alice, 0.5e18, 3, 3);
+  }
 }

--- a/test/unit/governance/Locking/relock.t.sol
+++ b/test/unit/governance/Locking/relock.t.sol
@@ -661,4 +661,18 @@ contract Relock_LockingTest is LockingTest {
     vm.prank(alice);
     locking.relock(lockId, alice, 0.5e18, 3, 3);
   }
+
+  function test_relock_whenAmountIsMinimum_shouldRelockSuccessfully() public {
+    mentoToken.mint(alice, 100e18);
+
+    vm.prank(alice);
+    lockId = locking.lock(alice, alice, 30e18, 3, 3);
+
+    // Wait until lock expires so residue is 0
+    _incrementBlock(6 * weekInBlocks);
+
+    // Should succeed with amount = minimum
+    vm.prank(alice);
+    locking.relock(lockId, alice, 1e18, 3, 3);
+  }
 }


### PR DESCRIPTION
### Description

[Hats issue #10](https://github.com/hats-finance/Mento-0x2a1b9b1f6fa7c2e73815a7dff0e1688767382694/issues/10) identified that in the event of relocking a completed lock, there was no minimum check that was present in a standard lock, this was given the assumption that relocking would only occur on non expired locks.

