### PR TITLE
Feat: Disable Initializer

### DIFF
--- a/contracts/governance/deployers/LockingDeployerLib.sol
+++ b/contracts/governance/deployers/LockingDeployerLib.sol
@@ -10,6 +10,6 @@ library LockingDeployerLib {
    * @return The address of the new Locking contract
    */
   function deploy() external returns (Locking) {
-    return new Locking();
+    return new Locking(false);
   }
 }

--- a/contracts/governance/deployers/LockingDeployerLib.sol
+++ b/contracts/governance/deployers/LockingDeployerLib.sol
@@ -10,6 +10,6 @@ library LockingDeployerLib {
    * @return The address of the new Locking contract
    */
   function deploy() external returns (Locking) {
-    return new Locking(false);
+    return new Locking(true);
   }
 }

--- a/contracts/governance/locking/Locking.sol
+++ b/contracts/governance/locking/Locking.sol
@@ -15,6 +15,12 @@ import "./interfaces/ILocking.sol";
 contract Locking is ILocking, LockingBase, LockingRelock, LockingVotes {
   using LibBrokenLine for LibBrokenLine.BrokenLine;
 
+  constructor(bool disableInitializers) {
+    if (disableInitializers) {
+      _disableInitializers();
+    }
+  }
+
   /**
    * @notice Initializes the locking contract.
    * @dev Sets up the base locking parameters and initializes ownership and context setup

--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -59,7 +59,7 @@ contract LockingUpgradeForkTest is BaseForkTest {
     mentoGovernor = governanceFactory.mentoGovernor();
     mentoToken = governanceFactory.mentoToken();
 
-    newLockingImplementation = address(new Locking(false));
+    newLockingImplementation = address(new Locking(true));
     vm.prank(multisig);
     proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(locking)), newLockingImplementation);
 

--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -59,7 +59,7 @@ contract LockingUpgradeForkTest is BaseForkTest {
     mentoGovernor = governanceFactory.mentoGovernor();
     mentoToken = governanceFactory.mentoToken();
 
-    newLockingImplementation = address(new Locking());
+    newLockingImplementation = address(new Locking(false));
     vm.prank(multisig);
     proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(locking)), newLockingImplementation);
 

--- a/test/integration/governance/GovernanceIntegration.t.sol
+++ b/test/integration/governance/GovernanceIntegration.t.sol
@@ -552,7 +552,7 @@ contract GovernanceIntegrationTest is GovernanceTest {
   function test_governor_propose_whenExecutedForImplementationUpgrade_shouldUpgradeTheContracts() public s_governance {
     // create new implementations
     address[] memory newImplementations = addresses(
-      address(new LockingHarness()),
+      address(new LockingHarness(false)),
       address(new TimelockController()),
       address(new MentoGovernor()),
       address(new Emission(false))

--- a/test/integration/governance/GovernanceIntegration.t.sol
+++ b/test/integration/governance/GovernanceIntegration.t.sol
@@ -552,10 +552,10 @@ contract GovernanceIntegrationTest is GovernanceTest {
   function test_governor_propose_whenExecutedForImplementationUpgrade_shouldUpgradeTheContracts() public s_governance {
     // create new implementations
     address[] memory newImplementations = addresses(
-      address(new LockingHarness(false)),
+      address(new LockingHarness(true)),
       address(new TimelockController()),
       address(new MentoGovernor()),
-      address(new Emission(false))
+      address(new Emission(true))
     );
 
     address[] memory proxies = addresses(

--- a/test/unit/governance/GovernanceFactory.t.sol
+++ b/test/unit/governance/GovernanceFactory.t.sol
@@ -166,7 +166,7 @@ contract GovernanceFactoryTest is GovernanceTest {
     assertEq(initialImpl, precalculatedAddress, "Factory: lockingProxy should have an implementation");
 
     // deploy and upgrade to new implementation
-    LockingHarness newImplContract = new LockingHarness(false);
+    LockingHarness newImplContract = new LockingHarness(true);
     vm.prank(address(factory.governanceTimelock()));
     proxyAdmin.upgrade(proxy, address(newImplContract));
 

--- a/test/unit/governance/GovernanceFactory.t.sol
+++ b/test/unit/governance/GovernanceFactory.t.sol
@@ -166,7 +166,7 @@ contract GovernanceFactoryTest is GovernanceTest {
     assertEq(initialImpl, precalculatedAddress, "Factory: lockingProxy should have an implementation");
 
     // deploy and upgrade to new implementation
-    LockingHarness newImplContract = new LockingHarness();
+    LockingHarness newImplContract = new LockingHarness(false);
     vm.prank(address(factory.governanceTimelock()));
     proxyAdmin.upgrade(proxy, address(newImplContract));
 

--- a/test/unit/governance/Locking/Locking.fuzz.t.sol
+++ b/test/unit/governance/Locking/Locking.fuzz.t.sol
@@ -26,7 +26,7 @@ contract FuzzTestLocking is Test {
     vm.deal(user1, 100 ether);
     testERC20 = new TestERC20("Test", "TST");
 
-    locking = new LockingHarness();
+    locking = new LockingHarness(false);
     locking.__Locking_init(IERC20Upgradeable(address(testERC20)), 0, 1, 3);
     locking.incrementBlock(locking.WEEK() + 1);
   }

--- a/test/unit/governance/Locking/LockingTest.sol
+++ b/test/unit/governance/Locking/LockingTest.sol
@@ -15,7 +15,7 @@ contract LockingTest is GovernanceTest {
 
   function setUp() public virtual {
     mentoToken = new MockMentoToken();
-    locking = new LockingHarness();
+    locking = new LockingHarness(false);
 
     vm.prank(owner);
     locking.__Locking_init(IERC20Upgradeable(address(mentoToken)), 0, 0, 0);

--- a/test/utils/harnesses/LockingHarness.sol
+++ b/test/utils/harnesses/LockingHarness.sol
@@ -7,6 +7,8 @@ contract LockingHarness is Locking {
   uint32 public blockNumberMocked;
   uint32 public epochShift;
 
+  constructor(bool disableInitializers) Locking(disableInitializers) {}
+
   function incrementBlock(uint32 _amount) external {
     blockNumberMocked = blockNumberMocked + _amount;
   }


### PR DESCRIPTION
### Description

This PR addresses the implementation having an exposed and callable, however without any structural risk, initializer in future implementations of the Locking contract