### PR TITLE
Test l2 changes with announced blockno and deployed locking impl

### DIFF
--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -8,7 +8,6 @@ import { GovernanceFactory } from "contracts/governance/GovernanceFactory.sol";
 import { MentoGovernor } from "contracts/governance/MentoGovernor.sol";
 import { MentoToken } from "contracts/governance/MentoToken.sol";
 import { ProxyAdmin } from "openzeppelin-contracts-next/contracts/proxy/transparent/ProxyAdmin.sol";
-// import { ITransparentUpgradeableProxy } from "openzeppelin-contracts-next/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { console } from "forge-std/console.sol";
 // used to avoid stack too deep error
 struct LockingSnapshot {
@@ -137,9 +136,6 @@ contract LockingUpgradeForkTest is BaseForkTest {
     // move 5 days forward on L2
     _moveDays({ day: 5, forward: true, isL2: true });
     // we should be at the same week (MONDAY around 03:24)
-    console.log("block.number", block.number);
-    console.log("locking.getWeek()", locking.getWeek());
-
     assertEq(locking.getWeek(), afterSnapshot.weekNo);
 
     // move 1 day forward (TUESDAY around 03:24)
@@ -179,6 +175,9 @@ contract LockingUpgradeForkTest is BaseForkTest {
   }
 
   function test_governance_afterL2Transition_shouldWorkAsBefore() public {
+    vm.roll(L2_TRANSITION_BLOCK);
+    vm.warp(1742959502);
+
     _simulateL2Upgrade();
 
     _moveDays(30 * 7, true, true);

--- a/test/fork/upgrades/LockingUpgradeForkTest.sol
+++ b/test/fork/upgrades/LockingUpgradeForkTest.sol
@@ -43,7 +43,6 @@ contract LockingUpgradeForkTest is BaseForkTest {
   Locking public locking;
   MentoGovernor public mentoGovernor;
   MentoToken public mentoToken;
-  address public timelockController;
 
   address public mentoLabsMultisig = 0x655133d8E90F8190ed5c1F0f3710F602800C0150;
   // proxy admin that will be used temporarily to upgrade the locking contracts during transition
@@ -55,7 +54,6 @@ contract LockingUpgradeForkTest is BaseForkTest {
     super.setUp();
 
     locking = governanceFactory.locking();
-    timelockController = address(governanceFactory.governanceTimelock());
     mentoGovernor = governanceFactory.mentoGovernor();
     mentoToken = governanceFactory.mentoToken();
   }

--- a/test/unit/governance/Locking/LibBrokenLine.t.sol
+++ b/test/unit/governance/Locking/LibBrokenLine.t.sol
@@ -18,7 +18,7 @@ contract LibBrokenLine_Test is GovernanceTest {
   function blockNumber() internal view returns (uint32) {
     return uint32(block.number);
   }
-  
+
   /// forge-config: default.allow_internal_expect_revert = true
   function test_addOneLine_whenSlopeZero_shouldRevert() public {
     //Line(start, bias, slope, cliff)

--- a/test/unit/governance/Locking/LibBrokenLine.t.sol
+++ b/test/unit/governance/Locking/LibBrokenLine.t.sol
@@ -18,7 +18,8 @@ contract LibBrokenLine_Test is GovernanceTest {
   function blockNumber() internal view returns (uint32) {
     return uint32(block.number);
   }
-
+  
+  /// forge-config: default.allow_internal_expect_revert = true
   function test_addOneLine_whenSlopeZero_shouldRevert() public {
     //Line(start, bias, slope, cliff)
     LibBrokenLine.Line memory line = LibBrokenLine.Line(1, 100, 0, 3);
@@ -26,6 +27,7 @@ contract LibBrokenLine_Test is GovernanceTest {
     LibBrokenLine.addOneLine(brokenLine, 0, line, blockNumber());
   }
 
+  /// forge-config: default.allow_internal_expect_revert = true
   function test_addOneLine_whenSlopeLargerThanBias_shouldRevert() public {
     //Line(start, bias, slope, cliff)
     LibBrokenLine.Line memory line = LibBrokenLine.Line(1, 100, 101, 3);
@@ -33,6 +35,7 @@ contract LibBrokenLine_Test is GovernanceTest {
     LibBrokenLine.addOneLine(brokenLine, 0, line, blockNumber());
   }
 
+  /// forge-config: default.allow_internal_expect_revert = true
   function test_addOneLine_whenLineWithIdAlreadyAdded_shouldRevert() public {
     uint256 id = 0;
     //Line(start, bias, slope, cliff)
@@ -351,6 +354,7 @@ contract LibBrokenLine_Test is GovernanceTest {
     assertLineEq(initialBefore, initialAfter);
   }
 
+  /// forge-config: default.allow_internal_expect_revert = true
   function test_update_whenToTimeIsInPast_shouldRevert() public {
     //Line(start, bias, slope, cliff)
     LibBrokenLine.Line memory line = LibBrokenLine.Line(1, 100, 10, 3);
@@ -360,6 +364,7 @@ contract LibBrokenLine_Test is GovernanceTest {
     LibBrokenLine.update(brokenLine, 0);
   }
 
+  /// forge-config: default.allow_internal_expect_revert = true
   function test_update_whenNegativeSlope_shouldRevert() public {
     uint96 slope = 10;
     //Line(start, bias, slope, cliff)
@@ -451,6 +456,7 @@ contract LibBrokenLine_Test is GovernanceTest {
     assertEq(brokenLine.initial.bias, newBias);
   }
 
+  /// forge-config: default.allow_internal_expect_revert = true
   function test_remove_whenLineDoesNotExist_shouldRevert() public {
     vm.expectRevert("Removing Line, which not exists");
     LibBrokenLine.remove(brokenLine, 0, 1, blockNumber());


### PR DESCRIPTION
### Description

New locking implementation is deployed and currently used by the Locking proxy on the mainnet. Also Celo L2 transition block no is announced.
This PR udpates the L2 fork tests to use the announced block number and calculated l2 starting point week and epoch shift.

### How to review
Go through the fork tests, ensure the changes introduced make sense and tests still pass, confirm the l2 starting point week and epoch shift.(epoch shift assumes there won't be down time)

### Other changes

Forge v1.0 breaking changes addressed

### Tested

Fork tests
