### PR TITLE
test: add test getting max gas amount for stable gas payments

### DIFF
--- a/test/unit/tokens/StableTokenV2.t.sol
+++ b/test/unit/tokens/StableTokenV2.t.sol
@@ -290,7 +290,7 @@ contract StableTokenV2Test is Test {
     assertEq(token.totalSupply(), tokenSupplyBefore1 + newlyMinted1 - tipTxFee - baseTxFee);
   }
 
-  function test_intrincisicGasOfStableGasPaymentsWithout0xRecipients() public {
+  function test_intrinsicGasOfStableGasPaymentsWithout0xRecipients() public {
     uint256 refund = 20;
     uint256 tipTxFee = 30;
     uint256 gatewayFee = 10;


### PR DESCRIPTION
### Description

This Pr adds a test for stableTokenV2 gas payments. This test case logs the max intrinsic gas amount for paying gas with stables. 
The max is achieved by setting all fee recipients,  because `_transfer()` consumes more gas than addition and a single burn. 
When all recipients are set and all amounts are greater than 0, the total gas for both calls is 91410. 
If we apply an additional buffer of 10%, the intrinsic gas costs are  91410 * 1.1 = 100551. 
After merging this PR I will inform cLABS about the value.   


### Other changes

- n/a

### Tested

- n/a

### Related issues

- n/a

### Backwards compatibility

- n/a

### Documentation

- n/a
