### PR TITLE
test: update alfajores fork tests to incl. cGBP, cZAR, cAUD and cCAD

### DIFF
--- a/test/fork/ForkTests.t.sol
+++ b/test/fork/ForkTests.t.sol
@@ -47,7 +47,7 @@ import { GoodDollarExpansionForkTest } from "./GoodDollar/ExpansionForkTest.sol"
 import { LockingUpgradeForkTest } from "./upgrades/LockingUpgradeForkTest.sol";
 import { GHSRenameForkTest } from "./GHSRenameForkTest.sol";
 
-contract Alfajores_ChainForkTest is ChainForkTest(ALFAJORES_ID, 1, uints(17)) {}
+contract Alfajores_ChainForkTest is ChainForkTest(ALFAJORES_ID, 1, uints(21)) {}
 
 contract Alfajores_P0E00_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 0) {}
 
@@ -82,6 +82,14 @@ contract Alfajores_P0E14_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 1
 contract Alfajores_P0E15_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 15) {}
 
 contract Alfajores_P0E16_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 16) {}
+
+contract Alfajores_P0E17_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 17) {}
+
+contract Alfajores_P0E18_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 18) {}
+
+contract Alfajores_P0E19_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 19) {}
+
+contract Alfajores_P0E20_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 20) {}
 
 contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(17)) {}
 


### PR DESCRIPTION
### Description

This updates the fork tests on Alfajores to include the new pools from the FX01 proposal

### Tested

Ran them on Alfajores

> Ran 23 test suites in 69.63s (672.74s CPU time): 303 tests passed, 0 failed, 0 skipped (303 total tests)
✨  Done in 85.52s.