### PR TITLE
Feat: Liquidity Strategies

### DIFF
--- a/contracts/interfaces/IFPMM.sol
+++ b/contracts/interfaces/IFPMM.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+interface IFPMM {
+  function getPrice(uint256 price) external;
+}

--- a/contracts/interfaces/IFPMM.sol
+++ b/contracts/interfaces/IFPMM.sol
@@ -22,8 +22,6 @@ interface IFPMM {
     view
     returns (uint256 dec0, uint256 dec1, uint256 r0, uint256 r1, address t0, address t1);
 
-  // t0 is always the stable token and token 1 is the collateral token. 
-
   // TODO: To be added to the FPMM contract.
   function getPrices() external view returns (uint256 oraclePrice, uint256 poolPrice);
 

--- a/contracts/interfaces/IFPMM.sol
+++ b/contracts/interfaces/IFPMM.sol
@@ -1,6 +1,33 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+// TODO: To be removed once FPMM interface is done
 interface IFPMM {
-  function getPrice(uint256 price) external;
+  function token0() external view returns (address);
+
+  function token1() external view returns (address);
+
+  function decimals0() external view returns (uint256);
+
+  function decimals1() external view returns (uint256);
+
+  function protocolFee() external view returns (uint256);
+
+  function metadata()
+    external
+    view
+    returns (uint256 dec0, uint256 dec1, uint256 r0, uint256 r1, address t0, address t1);
+
+  // TODO: Funtions below should be added to the interface.
+  function stableToken() external view returns (address);
+
+  function collateralToken() external view returns (address);
+
+  function stableReserve() external view returns (uint256);
+
+  function collateralReserve() external view returns (uint256);
+
+  function getPrices() external view returns (uint256 oraclePrice, uint256 poolPrice);
+
+  function moveTokensOut(address token, uint256 amount, address to, bytes calldata callback) external;
 }

--- a/contracts/interfaces/IFPMM.sol
+++ b/contracts/interfaces/IFPMM.sol
@@ -7,6 +7,10 @@ interface IFPMM {
 
   function token1() external view returns (address);
 
+  function reserve0() external view returns (uint256);
+
+  function reserve1() external view returns (uint256);
+
   function decimals0() external view returns (uint256);
 
   function decimals1() external view returns (uint256);
@@ -18,16 +22,10 @@ interface IFPMM {
     view
     returns (uint256 dec0, uint256 dec1, uint256 r0, uint256 r1, address t0, address t1);
 
-  // TODO: Funtions below should be added to the interface.
-  function stableToken() external view returns (address);
+  // t0 is always the stable token and token 1 is the collateral token. 
 
-  function collateralToken() external view returns (address);
-
-  function stableReserve() external view returns (uint256);
-
-  function collateralReserve() external view returns (uint256);
-
+  // TODO: To be added to the FPMM contract.
   function getPrices() external view returns (uint256 oraclePrice, uint256 poolPrice);
 
-  function moveTokensOut(address token, uint256 amount, address to, bytes calldata callback) external;
+  function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
 }

--- a/contracts/interfaces/ILiquidityStrategy.sol
+++ b/contracts/interfaces/ILiquidityStrategy.sol
@@ -18,8 +18,9 @@ interface ILiquidityStrategy {
    */
   struct FPMMConfig {
     uint256 lastRebalance;
-    uint256 rebalanceCooldown;
-    uint256 rebalanceThreshold; // TODO: Do we need more granularity here? (upper & lower).
+    uint256 rebalanceCooldown; // seconds
+    // TODO: Do we need more granularity here? (upper & lower).
+    uint256 rebalanceThreshold; // 18-decimal fixed point (e.g., 0.05e18 = 5%)
   }
 
   /**
@@ -42,7 +43,7 @@ interface ILiquidityStrategy {
    * @param priceBefore The pool price before the rebalance.
    * @param priceAfter The pool price after the rebalance.
    */
-  event Rebalance(address indexed pool, uint256 priceBefore, uint256 priceAfter);
+  event RebalanceExecuted(address indexed pool, uint256 priceBefore, uint256 priceAfter);
 
   /**
    * @notice Emitted when a rebalance is skipped because the cooldown period has not elapsed.
@@ -55,12 +56,6 @@ interface ILiquidityStrategy {
    * @param pool The address of the pool that was skipped.
    */
   event RebalanceSkippedPriceInRange(address indexed pool);
-
-  /**
-   * @notice Emitted when the reserve address is set.
-   * @param reserve The address of the reserve that was set.
-   */
-  event ReserveSet(address indexed reserve);
 
   /**
    * @notice Triggers the liquidity rebalancing mechanism.

--- a/contracts/interfaces/ILiquidityStrategy.sol
+++ b/contracts/interfaces/ILiquidityStrategy.sol
@@ -3,20 +3,64 @@ pragma solidity ^0.8.0;
 
 interface ILiquidityStrategy {
   /**
-   * @notice Struct holding the state of a pool.
-   * @param lastRebalance The timestamp of the last rebalance for this pool.
+   * @notice Enum representing the direction of price deviation from the oracle price.
+   * @dev Used to determine the direction of the price movement when rebalancing.
    */
-  struct PoolState {
+  enum PriceDirection {
+    ABOVE_ORACLE,
+    BELOW_ORACLE
+  }
+  /**
+   * @notice Struct holding the configuration of an FPMM pool.
+   * @param lastRebalance The timestamp of the last rebalance for this pool.
+   * @param rebalanceCooldown The cooldown period for the next rebalance.
+   * @param rebalanceThreshold The threshold of the price change that triggers a rebalance.
+   */
+  struct FPMMConfig {
     uint256 lastRebalance;
+    uint256 rebalanceCooldown;
+    uint256 rebalanceThreshold; // TODO: Do we need more granularity here? (upper & lower).
   }
 
   /**
-   * @notice Emitted when a pool is rebalanced.
+   * @notice Emitted after an FPMM pool is added.
+   * @param pool The address of the pool that was added.
+   * @param rebalanceThreshold The threshold of the price change that triggers a rebalance.
+   * @param rebalanceCooldown The cooldown period for the next rebalance.
+   */
+  event FPMMPoolAdded(address indexed pool, uint256 rebalanceThreshold, uint256 rebalanceCooldown);
+
+  /**
+   * @notice Emitted when an FPMM pool is removed.
+   * @param pool The address of the pool that was removed.
+   */
+  event FPMMPoolRemoved(address indexed pool);
+
+  /**
+   * @notice Emitted when an FPMM pool is rebalanced.
    * @param pool The address of the pool that was rebalanced.
    * @param priceBefore The pool price before the rebalance.
    * @param priceAfter The pool price after the rebalance.
    */
   event Rebalance(address indexed pool, uint256 priceBefore, uint256 priceAfter);
+
+  /**
+   * @notice Emitted when a rebalance is skipped because the cooldown period has not elapsed.
+   * @param pool The address of the pool that was skipped.
+   */
+  event RebalanceSkippedNotCool(address indexed pool);
+
+  /**
+   * @notice Emitted when a rebalance is skipped because the price is within the threshold.
+   * @param pool The address of the pool that was skipped.
+   */
+  event RebalanceSkippedPriceInRange(address indexed pool);
+
+  /**
+   * @notice Emitted when the reserve address is set.
+   * @param reserve The address of the reserve that was set.
+   */
+  event ReserveSet(address indexed reserve);
 
   /**
    * @notice Triggers the liquidity rebalancing mechanism.

--- a/contracts/interfaces/ILiquidityStrategy.sol
+++ b/contracts/interfaces/ILiquidityStrategy.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+interface ILiquidityStrategy {
+  /**
+   * @notice Struct holding the state of a pool.
+   * @param lastRebalance The timestamp of the last rebalance for this pool.
+   */
+  struct PoolState {
+    uint256 lastRebalance;
+  }
+
+  /**
+   * @notice Emitted when a pool is rebalanced.
+   * @param pool The address of the pool that was rebalanced.
+   * @param priceBefore The pool price before the rebalance.
+   * @param priceAfter The pool price after the rebalance.
+   */
+  event Rebalance(address indexed pool, uint256 priceBefore, uint256 priceAfter);
+
+  /**
+   * @notice Triggers the liquidity rebalancing mechanism.
+   * @param pool The address of the pool to rebalance.
+   */
+  function rebalance(address pool) external;
+}

--- a/contracts/interfaces/ILiquidityStrategy.sol
+++ b/contracts/interfaces/ILiquidityStrategy.sol
@@ -38,6 +38,22 @@ interface ILiquidityStrategy {
   event FPMMPoolRemoved(address indexed pool);
 
   /**
+   * @notice Emitted when a rebalance is initiated by the strategy.
+   * @param pool The pool being rebalanced.
+   * @param stableOut Amount of stable token being taken out of the pool.
+   * @param collateralOut Amount of collateral being taken out of the pool.
+   * @param inputAmount The amount the strategy is supplying in the callback.
+   * @param direction ABOVE_ORACLE for contraction, BELOW_ORACLE for expansion.
+   */
+  event RebalanceInitiated(
+    address indexed pool,
+    uint256 stableOut,
+    uint256 collateralOut,
+    uint256 inputAmount,
+    PriceDirection direction
+  );
+
+  /**
    * @notice Emitted when an FPMM pool is rebalanced.
    * @param pool The address of the pool that was rebalanced.
    * @param priceBefore The pool price before the rebalance.

--- a/contracts/swap/LiquidityStrategy.sol
+++ b/contracts/swap/LiquidityStrategy.sol
@@ -133,7 +133,6 @@ abstract contract LiquidityStrategy is OwnableUpgradeable, ILiquidityStrategy {
    *             - Token out address
    *             - Amount out
    *             - Price direction
-   *             - Amount to send from liquidity source
    */
   function onRebalanceCallback(bytes calldata data) external virtual;
 

--- a/contracts/swap/LiquidityStrategy.sol
+++ b/contracts/swap/LiquidityStrategy.sol
@@ -88,7 +88,7 @@ abstract contract LiquidityStrategy is OwnableUpgradeable, ILiquidityStrategy {
     FPMMConfig memory config = fpmmPoolConfigs[pool];
     if (block.timestamp <= config.lastRebalance + config.rebalanceCooldown) {
       emit RebalanceSkippedNotCool(pool);
-      revert("Rebalance cooldown not elapsed");
+      return;
     }
 
     IFPMM fpm = IFPMM(pool);
@@ -100,8 +100,8 @@ abstract contract LiquidityStrategy is OwnableUpgradeable, ILiquidityStrategy {
     UD60x18 poolP = ud(poolPrice);
     UD60x18 threshold = ud(config.rebalanceThreshold);
 
-    UD60x18 upperBound = oracleP.mul(ud(1e18).add(threshold));
-    UD60x18 lowerBound = oracleP.mul(ud(1e18).sub(threshold));
+    UD60x18 upperBound = oracleP.mul(ud(1).add(threshold));
+    UD60x18 lowerBound = oracleP.mul(ud(1).sub(threshold));
 
     PriceDirection priceDirection;
 

--- a/contracts/swap/LiquidityStrategy.sol
+++ b/contracts/swap/LiquidityStrategy.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import { ILiquidityStrategy } from "../interfaces/ILiquidityStrategy.sol";
+import { UD60x18, unwrap, wrap } from "prb/math/UD60x18.sol";
+
+// Notes:
+// We need to have a reference to the pool, especially if a strategy is used by multiple pools.
+// Get price
+// The callback is called by the fpmm after it executes the transfer out
+// Once we have moved tokens out, we don't want to make anothe call, we need to be sure that no transfers are done so we can see that the
+// The callback function calls another function that calls the mint function
+// There won't
+
+interface IFPMM {
+  function getPrices()
+    external
+    view
+    returns (uint256 reserve0, uint256 reserve1, uint256 oraclePrice, uint256 rebalanceFee);
+  function token0() external view returns (address);
+  function token1() external view returns (address);
+}
+
+abstract contract LiquidityStrategy is Ownable, ILiquidityStrategy {
+  // Maps a pool address to its state.
+
+
+  // Create mapping for pooladdress to rebalancing config
+  // - Config can include rebalcing cooldown, rebalancing thresholds (upper and lower), etc.
+
+  mapping(address => PoolState) public poolStates;
+  mapping(address => uint256) public tokenPrecisionMultipliers;
+
+  /**
+   * @notice Registers a pool to initialize its state.
+   * @param pool The address of the pool to register.
+   */
+  function registerPool(address pool) external onlyOwner {
+    require(poolStates[pool].lastRebalance == 0, "Pool already registered");
+    poolStates[pool] = PoolState({ lastRebalance: block.timestamp });
+  }
+
+  /**
+   * @notice Unregisters a pool.
+   * @param pool The address of the pool to unregister.
+   */
+  function unregisterPool(address pool) external onlyOwner {
+    delete poolStates[pool];
+  }
+
+  /**
+   * @notice Triggers the rebalancing process for a pool.
+   *         It obtains the pre-rebalance price, executes rebalancing logic,
+   *         updates the pool's state, and emits an event with the pricing information.
+   * @param pool The address of the pool to rebalance.
+   */
+  function rebalance(address pool) external {
+    // Cast the pool to IFPMM
+    // Get the price from the pool
+    // Calculate the pool price using the reserves
+    // Determine what sort of rebalance to do
+    // If pool price is greater than oracle price:
+    // - Move stable tokens out of the pool and burn them
+    // - FPMM calls the call back function
+    // - We move collateral tokens out of the pool, and into the liquidity source
+    // If pool price is less than oracle price:
+    // - Move collateral tokens out of the pool
+    // - FPMM calls the call back function
+    // - We mint stable tokens into the pool
+
+    IFPMM fpm = IFPMM(pool);
+
+    (uint256 reserve0, uint256 reserve1, uint256 oraclePrice, uint256 rebalanceFee) = fpm.getPrices();
+    uint256 priceBefore = _calculatePoolPrice(reserve0, reserve1, fpm.token0(), fpm.token1());
+
+    _executeRebalance(pool, priceBefore, oraclePrice, callback);
+
+    // 4) read back the new on‑chain price
+    uint256 priceAfter = fpm.getPrice();
+
+    poolStates[pool].lastRebalance = block.timestamp;
+    emit Rebalance(pool, priceBefore, priceAfter);
+  }
+
+  function callback(address pool, uint256 amount0, uint256 amount1) external virtual {
+    // TODO: Implement the callback logic
+  }
+
+
+  // TODO: It would be better if the pool just returned the price
+  function _calculatePoolPrice(
+    uint256 reserve0,
+    uint256 reserve1,
+    address token0,
+    address token1
+  ) internal view returns (uint256) {
+
+    // TODO: Confirm that token0 is the stable token)
+
+    require(reserve0 > 0 && reserve1 > 0, "Invalid reserves when calculating pool price");
+
+    uint256 scaledReserve0 = reserve0 * tokenPrecisionMultipliers[token0];
+    uint256 scaledReserve1 = reserve1 * tokenPrecisionMultipliers[token1];
+
+    UD60x18 numerator = wrap(scaledReserve1);
+    UD60x18 denominator = wrap(scaledReserve0);
+ 
+    // Price = reserve1/reserve0
+    uint256 priceScaled = unwrap(numerator.div(denominator));
+
+    // Adjust price for token decimal differences
+    return priceScaled / tokenPrecisionMultipliers[token1];
+  }
+
+  /**
+   * @notice Contains the specific logic that executes the rebalancing.
+   * @dev Implementations should perform any token movements, minting, or burning here.
+   * @param pool The address of the pool to rebalance.
+   * @param priceBefore The on‑chain price before any action.
+   * @param oraclePrice The off‑chain target price.
+   */
+  function _executeRebalance(address pool, uint256 priceBefore, uint256 oraclePrice, function ) internal virtual;
+}

--- a/contracts/swap/LiquidityStrategy.sol
+++ b/contracts/swap/LiquidityStrategy.sol
@@ -64,7 +64,7 @@ abstract contract LiquidityStrategy is Ownable, ILiquidityStrategy {
     (uint256 reserve0, uint256 reserve1, uint256 oraclePrice, uint256 rebalanceFee) = fpm.getPrices();
     uint256 priceBefore = _calculatePoolPrice(reserve0, reserve1, fpm.token0(), fpm.token1());
 
-    _executeRebalance(pool, priceBefore, oraclePrice);
+    _executeRebalance(pool, priceBefore, oraclePrice, rebalanceFee);
 
     (uint256 reserve0After, uint256 reserve1After, , ) = fpm.getPrices();
     uint256 priceAfter = _calculatePoolPrice(reserve0After, reserve1After, fpm.token0(), fpm.token1());
@@ -107,7 +107,12 @@ abstract contract LiquidityStrategy is Ownable, ILiquidityStrategy {
    * @param priceBefore The on‑chain price before any action.
    * @param oraclePrice The off‑chain target price.
    */
-  function _executeRebalance(address pool, uint256 priceBefore, uint256 oraclePrice) internal virtual;
+  function _executeRebalance(
+    address pool,
+    uint256 priceBefore,
+    uint256 oraclePrice,
+    uint256 rebalanceFee
+  ) internal virtual;
 
   // TODO: Implement the callback logic
   // - This finishes the rebalance and should be implemented by the concrete strategy

--- a/contracts/swap/LiquidityStrategy.sol
+++ b/contracts/swap/LiquidityStrategy.sol
@@ -117,7 +117,7 @@ abstract contract LiquidityStrategy is OwnableUpgradeable, ILiquidityStrategy {
     fpmmPoolConfigs[pool].lastRebalance = block.timestamp;
 
     // Execute the rebalance
-    _executeRebalance(pool, poolPrice, oraclePrice, priceDirection);
+    _executeRebalance(pool, oraclePrice, priceDirection);
 
     // Get final price for event emission
     (, uint256 priceAfterRebalance) = fpm.getPrices();
@@ -129,16 +129,10 @@ abstract contract LiquidityStrategy is OwnableUpgradeable, ILiquidityStrategy {
   /**
    * @notice Contains the specific logic that executes the rebalancing.
    * @param pool The address of the pool to rebalance.
-   * @param poolPrice The on‑chain price before any action.
    * @param oraclePrice The off‑chain target price.
    * @param priceDirection The direction of the price movement.
    */
-  function _executeRebalance(
-    address pool,
-    uint256 poolPrice,
-    uint256 oraclePrice,
-    PriceDirection priceDirection
-  ) internal virtual;
+  function _executeRebalance(address pool, uint256 oraclePrice, PriceDirection priceDirection) internal virtual;
 
   /* ==================== View Functions ==================== */
 

--- a/contracts/swap/LiquidityStrategy.sol
+++ b/contracts/swap/LiquidityStrategy.sol
@@ -12,6 +12,7 @@ interface IFPMM {
     returns (uint256 reserve0, uint256 reserve1, uint256 oraclePrice, uint256 rebalanceFee);
 
   function token0() external view returns (address);
+
   function token1() external view returns (address);
 }
 
@@ -84,7 +85,7 @@ abstract contract LiquidityStrategy is Ownable, ILiquidityStrategy {
 
     require(reserve0 > 0 && reserve1 > 0, "Invalid reserves when calculating pool price");
 
-    // TODO: Price calculation should be consistent with oracle price. 
+    // TODO: Price calculation should be consistent with oracle price
     // e.g. are we pricing stable in collateral or collateral in stable?
     uint256 scaledReserve0 = reserve0 * tokenPrecisionMultipliers[token0];
     uint256 scaledReserve1 = reserve1 * tokenPrecisionMultipliers[token1];

--- a/contracts/swap/ReserveLiquidityStrategy.sol
+++ b/contracts/swap/ReserveLiquidityStrategy.sol
@@ -58,11 +58,8 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
     address stableToken = fpm.token0();
     address collateralToken = fpm.token1();
 
-    uint256 stableReserveRaw = fpm.reserve0();
-    uint256 collateralReserveRaw = fpm.reserve1();
-
-    UD60x18 stableReserve = ud(stableReserveRaw * tokenPrecisionMultipliers[stableToken]);
-    UD60x18 collateralReserve = ud(collateralReserveRaw * tokenPrecisionMultipliers[collateralToken]);
+    UD60x18 stableReserve = ud(fpm.reserve0() * tokenPrecisionMultipliers[stableToken]);
+    UD60x18 collateralReserve = ud(fpm.reserve1() * tokenPrecisionMultipliers[collateralToken]);
 
     UD60x18 oraclePriceUD = ud(oraclePrice); 
 

--- a/contracts/swap/ReserveLiquidityStrategy.sol
+++ b/contracts/swap/ReserveLiquidityStrategy.sol
@@ -52,11 +52,7 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
    * @param oraclePrice The off‑chain target price.
    * @param priceDirection The direction of the price movement.
    */
-  function _executeRebalance(
-    address pool,
-    uint256 oraclePrice,
-    PriceDirection priceDirection
-  ) internal override {
+  function _executeRebalance(address pool, uint256 oraclePrice, PriceDirection priceDirection) internal override {
     IFPMM fpm = IFPMM(pool);
 
     address stableToken = fpm.token0();

--- a/contracts/swap/ReserveLiquidityStrategy.sol
+++ b/contracts/swap/ReserveLiquidityStrategy.sol
@@ -38,12 +38,15 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
   }
 
   /**
-   * @notice Executes the rebalance logic using the reserve as a liquidity source. This function will initiate moving tokens out of the pool.
-   *         The actual token transfers will be completed in the onRebalanceCallback function, which will be called by the pool.
-   * @dev If the pool price is above the oracle price, meaning the stable token is undervalued(too much stable for the collateral),
-   *      we buy stables from the pool, using collateral from the reserve, to be burned.
-   *      If the pool price is below the oracle price, meaning the stable token is overvalued(too much collateral for the stable),
-   *      we buy collateral from the pool, using newly minted stables, to be transferred to the reserve.
+   * @notice Executes the rebalance logic using the reserve as a liquidity source. This function
+   *         will initiate moving tokens out of the pool. The actual token transfers will be completed
+   *         in the onRebalanceCallback function, which will be called by the pool.
+   * @dev If the pool price is above the oracle price, meaning the stable token
+   *      is undervalued(too much stable for the collateral), we buy stables from
+   *      the pool, using collateral from the reserve, to be burned.
+   *      If the pool price is below the oracle price, meaning the stable token
+   *      is overvalued(too much collateral for the stable), we buy collateral
+   *      from the pool, using newly minted stables, to be transferred to the reserve.
    * @param pool The address of the pool.
    * @param poolPrice The on‑chain price before any action.
    * @param oraclePrice The off‑chain target price.

--- a/contracts/swap/ReserveLiquidityStrategy.sol
+++ b/contracts/swap/ReserveLiquidityStrategy.sol
@@ -63,8 +63,8 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
 
     UD60x18 oraclePriceUD = ud(oraclePrice);
 
-    uint256 stableOut = 0;
-    uint256 collateralOut = 0;
+    uint256 stableOut;
+    uint256 collateralOut;
     uint256 inputAmount;
 
     if (priceDirection == PriceDirection.ABOVE_ORACLE) {
@@ -72,7 +72,7 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
       // Y = (S - P * C) / (2 * P)
       // X = Y * P
       UD60x18 numerator = stableReserve.sub(oraclePriceUD.mul(collateralReserve));
-      UD60x18 collateralToSell = numerator.div(oraclePriceUD.mul(ud(2e18)));
+      UD60x18 collateralToSell = numerator.div(oraclePriceUD.mul(ud(2)));
       UD60x18 stablesToBuy = collateralToSell.mul(oraclePriceUD);
 
       stableOut = stablesToBuy.div(ud(tokenPrecisionMultipliers[stableToken])).unwrap();
@@ -81,7 +81,7 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
       // Expansion: Buy collateral from the pool using newly minted stables
       // X = (C * P - S) / 2
       // Y = X / P
-      UD60x18 stablesToSell = (collateralReserve.mul(oraclePriceUD).sub(stableReserve)).div(ud(2e18));
+      UD60x18 stablesToSell = (collateralReserve.mul(oraclePriceUD).sub(stableReserve)).div(ud(2));
       UD60x18 collateralToBuy = stablesToSell.div(oraclePriceUD);
 
       collateralOut = collateralToBuy.div(ud(tokenPrecisionMultipliers[collateralToken])).unwrap();
@@ -110,6 +110,8 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
 
     address stableToken = fpm.token0();
     address collateralToken = fpm.token1();
+
+    // TODO: What are the implications of transferring total balances of this contract vs exact amounts?
 
     if (priceDirection == PriceDirection.ABOVE_ORACLE) {
       // Contraction: burn stables, pull collateral from reserve and send to FPMM

--- a/contracts/swap/ReserveLiquidityStrategy.sol
+++ b/contracts/swap/ReserveLiquidityStrategy.sol
@@ -90,6 +90,7 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
 
     bytes memory callbackData = abi.encode(pool, inputAmount, priceDirection);
 
+    emit RebalanceInitiated(pool, stableOut, collateralOut, inputAmount, priceDirection);
     fpm.swap(stableOut, collateralOut, address(this), callbackData);
   }
 
@@ -97,7 +98,7 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
    * @notice Handles the callback from the pool after a rebalance.
    * @param data The encoded data from the pool.
    */
-  function hook(address, uint256 amount0Out, uint256 amount1Out, bytes calldata data) external {
+  function hook(address, uint256 amount0Out, uint256 amount1Out, bytes calldata data) external nonReentrant {
     (address pool, uint256 amountIn, PriceDirection priceDirection) = abi.decode(
       data,
       (address, uint256, PriceDirection)

--- a/contracts/swap/ReserveLiquidityStrategy.sol
+++ b/contracts/swap/ReserveLiquidityStrategy.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import { SafeERC20MintableBurnable } from "contracts/common/SafeERC20MintableBurnable.sol";
+import { IERC20MintableBurnable as IERC20 } from "contracts/common/IERC20MintableBurnable.sol";
+
+import { LiquidityStrategy } from "./LiquidityStrategy.sol";
+import { IFPMM } from "../interfaces/IFPMM.sol";
+import { IReserve } from "../interfaces/IReserve.sol";
+
+/**
+ * @title ReserveLiquidityStrategy
+ * @notice Liquidity strategy that uses the reserve as a liquidity source.
+ */
+contract ReserveLiquidityStrategy is LiquidityStrategy {
+  using SafeERC20MintableBurnable for IERC20;
+
+  /**
+   * @notice Emitted when the reserve address is set.
+   * @param reserve The address of the reserve that was set.
+   */
+  event ReserveSet(address indexed reserve);
+
+  IReserve public reserve;
+
+  constructor(bool disableInitializers, address _reserve) LiquidityStrategy(disableInitializers) {
+    setReserve(_reserve);
+  }
+
+  /**
+   * @notice Sets the reserve address.
+   * @param _reserve The address of the reserve.
+   */
+  function setReserve(address _reserve) public onlyOwner {
+    require(_reserve != address(0), "Reserve cannot be the zero address");
+    reserve = IReserve(_reserve);
+    emit ReserveSet(_reserve);
+  }
+
+  /**
+   * @notice Executes the rebalance logic using the reserve as a liquidity source. This function will initiate moving tokens out of the pool.
+   *         The actual token transfers will be completed in the onRebalanceCallback function, which will be called by the pool.
+   * @dev If the pool price is above the oracle price, meaning the stable token is undervalued(too much stable for the collateral),
+   *      we buy stables from the pool, using collateral from the reserve, to be burned.
+   *      If the pool price is below the oracle price, meaning the stable token is overvalued(too much collateral for the stable),
+   *      we buy collateral from the pool, using newly minted stables, to be transferred to the reserve.
+   * @param pool The address of the pool.
+   * @param poolPrice The on‑chain price before any action.
+   * @param oraclePrice The off‑chain target price.
+   * @param priceDirection The direction of the price movement.
+   */
+  function _executeRebalance(
+    address pool,
+    uint256 poolPrice,
+    uint256 oraclePrice,
+    PriceDirection priceDirection
+  ) internal override {
+    IFPMM fpm = IFPMM(pool);
+
+    uint256 stableReserve = fpm.reserve0();
+    uint256 amountIn;
+    uint256 stableOut;
+    uint256 collateralOut;
+
+    if (priceDirection == PriceDirection.ABOVE_ORACLE) {
+      // Contraction: Buy stables from the pool using collateral from the reserve
+      uint256 diff = poolPrice - oraclePrice;
+
+      stableOut = (diff * stableReserve) / oraclePrice;
+      amountIn = stableOut * oraclePrice; // Amount of collateral to be sent to the pool
+    } else {
+      // Expansion: Buy collateral from the pool using newly minted stables
+      uint256 diff = oraclePrice - poolPrice;
+
+      collateralOut = (diff * stableReserve) / oraclePrice;
+      amountIn = collateralOut * oraclePrice; // Amount of stables to be sent to the pool
+    }
+
+    bytes memory callbackData = abi.encode(pool, amountIn, priceDirection);
+
+    // TODO: Maybe an event, initiate rebalance
+
+    // Start the swap
+    fpm.swap(stableOut, collateralOut, address(this), callbackData);
+  }
+
+  /**
+   * @notice Handles the callback from the pool after a rebalance.
+   * @param data The encoded data from the pool.
+   */
+  function hook(address, uint256, uint256, bytes calldata data) external {
+    (address pool, uint256 amountIn, PriceDirection priceDirection) = abi.decode(
+      data,
+      (address, uint256, PriceDirection)
+    );
+
+    require(msg.sender == pool, "Caller is not the pool");
+    require(isPoolRegistered(pool), "Unregistered pool");
+
+    IFPMM fpm = IFPMM(pool);
+
+    address stableToken = fpm.token0();
+    address collateralToken = fpm.token1();
+
+    if (priceDirection == PriceDirection.ABOVE_ORACLE) {
+      // Contraction: burn stables, pull collateral from reserve and send to FPMM
+      IERC20(stableToken).safeBurn(IERC20(stableToken).balanceOf(address(this)));
+      reserve.transferExchangeCollateralAsset(collateralToken, payable(pool), amountIn);
+    } else {
+      // Expansion: mint stables to FPMM, transfer received collateral to reserve
+      IERC20(stableToken).safeMint(pool, amountIn);
+      IERC20(collateralToken).transfer(address(reserve), IERC20(collateralToken).balanceOf(address(this)));
+    }
+  }
+}

--- a/contracts/swap/ReserveLiquidityStrategy.sol
+++ b/contracts/swap/ReserveLiquidityStrategy.sol
@@ -61,7 +61,7 @@ contract ReserveLiquidityStrategy is LiquidityStrategy {
     UD60x18 stableReserve = ud(fpm.reserve0() * tokenPrecisionMultipliers[stableToken]);
     UD60x18 collateralReserve = ud(fpm.reserve1() * tokenPrecisionMultipliers[collateralToken]);
 
-    UD60x18 oraclePriceUD = ud(oraclePrice); 
+    UD60x18 oraclePriceUD = ud(oraclePrice);
 
     uint256 stableOut = 0;
     uint256 collateralOut = 0;


### PR DESCRIPTION
### Description

This PR adds an extensible “liquidity strategy” framework to Mento v3 and a concrete Reserve-based implementation. The new contracts decouple the core rebalancing flow from specific liquidity sources, enabling future strategies (CDP, custom, cross-chain, etc.) to be added easily.

Key features:
- `ILiquidityStrategy` interface with a unified rebalance(pool) entry point and lifecycle events.
- `LiquidityStrategy` abstract base handling pool registration, cooldowns, price/threshold checks, and skip logic.
- `ReserveLiquidityStrategy` implementation that uses the on-chain Reserve:
  - Performs flash-swap rebalances (contraction/expansion) by minting/burning Mento stables and moving collateral.
  - Emits `RebalanceInitiated` and `RebalanceExecuted` for full traceability.

### Tested
- Unit tests covering the abstract `LiquidityStrategy` contract
- Unit tests covering the `ReserveLiquidityStrategy` - WIP

