### PR TITLE
feat: add FX03 token launches fork tests

### DIFF
--- a/test/fork/BaseForkTest.sol
+++ b/test/fork/BaseForkTest.sol
@@ -129,7 +129,8 @@ abstract contract BaseForkTest is Test {
   }
 
   function transferCeloFromReserve(address to, uint256 amount) internal {
-    vm.prank(address(mentoReserve));
+    vm.startPrank(address(mentoReserve));
     IERC20(lookup("GoldToken")).transfer(to, amount);
+    vm.stopPrank();
   }
 }

--- a/test/fork/ForkTests.t.sol
+++ b/test/fork/ForkTests.t.sol
@@ -95,7 +95,7 @@ contract Alfajores_P0E22_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 2
 
 contract Alfajores_P0E23_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 23) {}
 
-contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(21)) {}
+contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(24)) {}
 
 contract Celo_P0E00_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 0) {}
 
@@ -138,6 +138,12 @@ contract Celo_P0E18_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 18) {}
 contract Celo_P0E19_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 19) {}
 
 contract Celo_P0E20_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 20) {}
+
+contract Celo_P0E21_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 21) {}
+
+contract Celo_P0E22_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 22) {}
+
+contract Celo_P0E23_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 23) {}
 
 contract Celo_BancorExchangeProviderForkTest is BancorExchangeProviderForkTest(CELO_ID) {}
 


### PR DESCRIPTION
### Description

Add fork-tests for the latest token launches (cCHF, cNGN & cJPY)

### Other changes

Changed the `transferCeloFromReserve` function to use `startPrank()` instead as otherwise it fails in the latest version of foundry to interrupting an ongoing prank.

### Tested

Tests are green
