### PR TITLE
fix: alfajores fork tests post pool restructuring

### DIFF
--- a/test/fork/BaseForkTest.sol
+++ b/test/fork/BaseForkTest.sol
@@ -99,6 +99,7 @@ abstract contract BaseForkTest is Test {
     rateFeedDependenciesCount[toRateFeed("EUROCXOF")] = 2;
     rateFeedDependenciesCount[toRateFeed("USDCEUR")] = 1;
     rateFeedDependenciesCount[toRateFeed("USDCBRL")] = 1;
+    rateFeedDependenciesCount[toRateFeed("relayed:XOFUSD")] = 1;
   }
 
   // TODO: Broker setup can be removed after the Broker changes have been deployed to Mainnet

--- a/test/fork/ExchangeForkTest.sol
+++ b/test/fork/ExchangeForkTest.sol
@@ -56,8 +56,15 @@ abstract contract ExchangeForkTest is SwapAssertions, CircuitBreakerAssertions, 
     );
     for (uint256 i = 0; i < COLLATERAL_ASSETS_COUNT; i++) {
       address collateralAsset = mentoReserve.collateralAssets(i);
+      if (collateralAsset == lookup("GoldToken")) {
+        // CELO is already in the reserve, so no need to do anything.
+        // In case we need additional CELO for the trading limit tests we can
+        // add a manual transfer from an address that has some, e.g. Celo Governance
+        continue;
+      }
+
       vm.label(collateralAsset, IERC20(collateralAsset).symbol());
-      mint(collateralAsset, address(mentoReserve), uint256(25_000_000).toSubunits(collateralAsset), true);
+      mint(collateralAsset, address(mentoReserve), uint256(20_000_000).toSubunits(collateralAsset), true);
     }
   }
 

--- a/test/fork/ForkTests.t.sol
+++ b/test/fork/ForkTests.t.sol
@@ -45,7 +45,7 @@ import { GoodDollarTradingLimitsForkTest } from "./GoodDollar/TradingLimitsForkT
 import { GoodDollarSwapForkTest } from "./GoodDollar/SwapForkTest.sol";
 import { GoodDollarExpansionForkTest } from "./GoodDollar/ExpansionForkTest.sol";
 
-contract Alfajores_ChainForkTest is ChainForkTest(ALFAJORES_ID, 1, uints(24)) {}
+contract Alfajores_ChainForkTest is ChainForkTest(ALFAJORES_ID, 1, uints(19)) {}
 
 contract Alfajores_P0E00_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 0) {}
 
@@ -84,16 +84,6 @@ contract Alfajores_P0E16_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 1
 contract Alfajores_P0E17_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 17) {}
 
 contract Alfajores_P0E18_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 18) {}
-
-contract Alfajores_P0E19_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 19) {}
-
-contract Alfajores_P0E20_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 20) {}
-
-contract Alfajores_P0E21_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 21) {}
-
-contract Alfajores_P0E22_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 22) {}
-
-contract Alfajores_P0E23_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 23) {}
 
 contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(24)) {}
 


### PR DESCRIPTION
### Description

This fixes the alfajores fork tests after executing the pool restructuring CGP. We now have 19 total exchanges, and a new dependency on the XOF/USD feed.
