### PR TITLE
fix: mainnet fork tests post pool restructuring

### DIFF
--- a/test/fork/ForkTests.t.sol
+++ b/test/fork/ForkTests.t.sol
@@ -85,7 +85,7 @@ contract Alfajores_P0E17_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 1
 
 contract Alfajores_P0E18_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 18) {}
 
-contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(24)) {}
+contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(19)) {}
 
 contract Celo_P0E00_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 0) {}
 
@@ -124,16 +124,6 @@ contract Celo_P0E16_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 16) {}
 contract Celo_P0E17_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 17) {}
 
 contract Celo_P0E18_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 18) {}
-
-contract Celo_P0E19_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 19) {}
-
-contract Celo_P0E20_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 20) {}
-
-contract Celo_P0E21_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 21) {}
-
-contract Celo_P0E22_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 22) {}
-
-contract Celo_P0E23_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 23) {}
 
 contract Celo_BancorExchangeProviderForkTest is BancorExchangeProviderForkTest(CELO_ID) {}
 


### PR DESCRIPTION
Description
This fixes the mainnet fork tests after executing the pool restructuring CGP 