### PR TITLE
feat: add explicit owner initialization to be compatible with CreateX

### DIFF
--- a/contracts/governance/Emission.sol
+++ b/contracts/governance/Emission.sol
@@ -55,13 +55,18 @@ contract Emission is OwnableUpgradeable {
    * @param emissionTarget_ The address of the emission target.
    * @param emissionSupply_ The total amount of tokens that can be emitted.
    */
-  function initialize(address mentoToken_, address emissionTarget_, uint256 emissionSupply_) public initializer {
+  function initialize(
+    address mentoToken_,
+    address emissionTarget_,
+    uint256 emissionSupply_,
+    address initialOwner_
+  ) public initializer {
     emissionStartTime = block.timestamp;
     mentoToken = MentoToken(mentoToken_);
     // slither-disable-next-line missing-zero-check
     emissionTarget = emissionTarget_;
     emissionSupply = emissionSupply_;
-    __Ownable_init();
+    _transferOwnership(initialOwner_);
   }
 
   /**

--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -121,14 +121,13 @@ contract GovernanceFactory is Ownable {
 
     PrecalculatedAddresses memory addr = getPrecalculatedAddresses();
 
-    deployProxyAdmin();
+    deployProxyAdmin(addr.governanceTimelock);
     deployMentoToken(allocationParams, addr);
     deployEmission(addr);
     deployAirgrab(airgrabRoot, fractalSigner, addr);
     deployLocking(addr);
     deployTimelock(addr);
     deployMentoGovernor(addr);
-    transferOwnership();
 
     emit GovernanceCreated(
       address(proxyAdmin),
@@ -144,11 +143,11 @@ contract GovernanceFactory is Ownable {
   /**
    * @notice Deploys the ProxyAdmin contract.
    */
-  function deployProxyAdmin() internal {
+  function deployProxyAdmin(address owner) internal {
     // =========================================
     // ========== Deploy 1: ProxyAdmin =========
     // =========================================
-    proxyAdmin = ProxyDeployerLib.deployAdmin(); // NONCE:1
+    proxyAdmin = ProxyDeployerLib.deployAdmin(owner); // NONCE:1
   }
 
   /**
@@ -330,19 +329,6 @@ contract GovernanceFactory is Ownable {
     // slither-disable-next-line reentrancy-benign
     mentoGovernor = MentoGovernor(payable(mentoGovernorProxy));
     assert(address(mentoGovernor) == addr.mentoGovernor);
-  }
-
-  /**
-   * @notice Transfers the ownership of the contracts to the governance timelock.
-   */
-  function transferOwnership() internal {
-    // =============================================
-    // =========== Configure Ownership =============
-    // =============================================
-    emission.transferOwnership(address(governanceTimelock));
-    locking.transferOwnership(address(governanceTimelock));
-    proxyAdmin.transferOwnership(address(governanceTimelock));
-    mentoToken.transferOwnership(address(governanceTimelock));
   }
 
   /**

--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -120,7 +120,7 @@ contract GovernanceFactory is Ownable {
     watchdogMultiSig = watchdogMultiSig_;
 
     PrecalculatedAddresses memory addr = getPrecalculatedAddresses();
-
+    // slither-disable-start reentrancy-benign
     deployProxyAdmin(addr.governanceTimelock);
     deployMentoToken(allocationParams, addr);
     deployEmission(addr);
@@ -128,7 +128,7 @@ contract GovernanceFactory is Ownable {
     deployLocking(addr);
     deployTimelock(addr);
     deployMentoGovernor(addr);
-
+    // slither-disable-end reentrancy-benign
     emit GovernanceCreated(
       address(proxyAdmin),
       address(emission),

--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -177,7 +177,13 @@ contract GovernanceFactory is Ownable {
       allocationAmounts[i + 2] = allocationParams.additionalAllocationAmounts[i];
     }
 
-    mentoToken = MentoTokenDeployerLib.deploy(allocationRecipients, allocationAmounts, addr.emission, addr.locking); // NONCE:2
+    mentoToken = MentoTokenDeployerLib.deploy(
+      allocationRecipients,
+      allocationAmounts,
+      addr.emission,
+      addr.locking,
+      addr.governanceTimelock
+    ); // NONCE:2
 
     assert(address(mentoToken) == addr.mentoToken);
   }
@@ -193,15 +199,16 @@ contract GovernanceFactory is Ownable {
     Emission emissionImpl = EmissionDeployerLib.deploy(); // NONCE:3
     // slither-disable-next-line reentrancy-benign
     TransparentUpgradeableProxy emissionProxy = ProxyDeployerLib.deployProxy( // NONCE:4
-      address(emissionImpl),
-      address(proxyAdmin),
-      abi.encodeWithSelector(
-        emissionImpl.initialize.selector,
-        addr.mentoToken, ///               @param mentoToken_ The address of the MentoToken contract.
-        addr.governanceTimelock, ///  @param governanceTimelock_ The address of the mento treasury contract.
-        mentoToken.emissionSupply() ///       @param emissionSupply_ The total amount of tokens that can be emitted.
-      )
-    );
+        address(emissionImpl),
+        address(proxyAdmin),
+        abi.encodeWithSelector(
+          emissionImpl.initialize.selector,
+          addr.mentoToken, ///               @param mentoToken_ The address of the MentoToken contract.
+          addr.governanceTimelock, ///  @param governanceTimelock_ The address of the mento treasury contract.
+          mentoToken.emissionSupply(), ///       @param emissionSupply_ The total amount of tokens that can be emitted.
+          addr.governanceTimelock ///       @param initialOwner_ The initial owner of the emission contract.
+        )
+      );
 
     emission = Emission(address(emissionProxy));
     assert(address(emission) == addr.emission);
@@ -220,16 +227,16 @@ contract GovernanceFactory is Ownable {
     airgrabEnds = block.timestamp + AIRGRAB_DURATION;
     // slither-disable-next-line reentrancy-benign
     airgrab = AirgrabDeployerLib.deploy( // NONCE:5
-      airgrabRoot,
-      fractalSigner,
-      FRACTAL_MAX_AGE,
-      airgrabEnds,
-      AIRGRAB_LOCK_CLIFF,
-      AIRGRAB_LOCK_SLOPE,
-      addr.mentoToken,
-      addr.locking,
-      payable(addr.governanceTimelock)
-    );
+        airgrabRoot,
+        fractalSigner,
+        FRACTAL_MAX_AGE,
+        airgrabEnds,
+        AIRGRAB_LOCK_CLIFF,
+        AIRGRAB_LOCK_SLOPE,
+        addr.mentoToken,
+        addr.locking,
+        payable(addr.governanceTimelock)
+      );
     assert(address(airgrab) == addr.airgrab);
   }
 
@@ -245,16 +252,17 @@ contract GovernanceFactory is Ownable {
     uint32 startingPointWeek = uint32(Locking(lockingImpl).getWeek() - 1);
     // slither-disable-next-line reentrancy-benign
     TransparentUpgradeableProxy lockingProxy = ProxyDeployerLib.deployProxy( // NONCE:7
-      address(lockingImpl),
-      address(proxyAdmin),
-      abi.encodeWithSelector(
-        lockingImpl.__Locking_init.selector,
-        address(mentoToken), /// @param _token The token to be locked in exchange for voting power in form of veTokens.
-        startingPointWeek, ///   @param _startingPointWeek The locking epoch start in weeks. We start the locking contract from week 1 with min slope duration of 1
-        0, ///                   @param _minCliffPeriod minimum cliff period in weeks.
-        1 ///                    @param _minSlopePeriod minimum slope period in weeks.
-      )
-    );
+        address(lockingImpl),
+        address(proxyAdmin),
+        abi.encodeWithSelector(
+          lockingImpl.__Locking_init.selector,
+          address(mentoToken), /// @param _token The token to be locked in exchange for voting power in form of veTokens.
+          startingPointWeek, ///   @param _startingPointWeek The locking epoch start in weeks. We start the locking contract from week 1 with min slope duration of 1
+          0, ///                   @param _minCliffPeriod minimum cliff period in weeks.
+          1, ///                   @param _minSlopePeriod minimum slope period in weeks.
+          addr.governanceTimelock /// @param _initialOwner The initial owner of the locking contract.
+        )
+      );
     locking = Locking(address(lockingProxy));
     assert(address(locking) == addr.locking);
   }
@@ -280,17 +288,17 @@ contract GovernanceFactory is Ownable {
 
     // slither-disable-next-line reentrancy-benign
     TransparentUpgradeableProxy governanceTimelockProxy = ProxyDeployerLib.deployProxy( // NONCE:9
-      address(timelockControllerImpl),
-      address(proxyAdmin),
-      abi.encodeWithSelector(
-        timelockControllerImpl.__MentoTimelockController_init.selector,
-        GOVERNANCE_TIMELOCK_DELAY, /// @param minDelay The minimum delay before a proposal can be executed.
-        governanceProposers, ///       @param proposers List of addresses that are allowed to queue AND cancel operations.
-        governanceExecutors, ///       @param executors List of addresses that are allowed to execute proposals.
-        address(0), ///                @param admin No admin necessary as proposers are preset upon deployment.
-        watchdogMultiSig ///           @param canceller An additional canceller address with the rights to cancel awaiting proposals.
-      )
-    );
+        address(timelockControllerImpl),
+        address(proxyAdmin),
+        abi.encodeWithSelector(
+          timelockControllerImpl.__MentoTimelockController_init.selector,
+          GOVERNANCE_TIMELOCK_DELAY, /// @param minDelay The minimum delay before a proposal can be executed.
+          governanceProposers, ///       @param proposers List of addresses that are allowed to queue AND cancel operations.
+          governanceExecutors, ///       @param executors List of addresses that are allowed to execute proposals.
+          address(0), ///                @param admin No admin necessary as proposers are preset upon deployment.
+          watchdogMultiSig ///           @param canceller An additional canceller address with the rights to cancel awaiting proposals.
+        )
+      );
     governanceTimelock = TimelockController(payable(governanceTimelockProxy));
     assert(address(governanceTimelock) == addr.governanceTimelock);
   }
@@ -306,18 +314,18 @@ contract GovernanceFactory is Ownable {
     // slither-disable-next-line reentrancy-benign
     MentoGovernor mentoGovernorImpl = MentoGovernorDeployerLib.deploy(); // NONCE:10
     TransparentUpgradeableProxy mentoGovernorProxy = ProxyDeployerLib.deployProxy( // NONCE: 11
-      address(mentoGovernorImpl),
-      address(proxyAdmin),
-      abi.encodeWithSelector(
-        mentoGovernorImpl.__MentoGovernor_init.selector,
-        address(locking), ///       @param veToken The escrowed Mento Token used for voting.
-        address(governanceTimelock), ///     @param timelockController The timelock controller used by the governor.
-        GOVERNOR_VOTING_DELAY, ///       @param votingDelay_ The delay time in blocks between the proposal creation and the start of voting.
-        GOVERNOR_VOTING_PERIOD, ///      @param votingPeriod_ The voting duration in blocks between the vote start and vote end.
-        GOVERNOR_PROPOSAL_THRESHOLD, /// @param threshold_ The number of votes required in order for a voter to become a proposer.
-        GOVERNOR_QUORUM ///              @param quorum_ The minimum number of votes in percent of total supply required in order for a proposal to succeed.
-      )
-    );
+        address(mentoGovernorImpl),
+        address(proxyAdmin),
+        abi.encodeWithSelector(
+          mentoGovernorImpl.__MentoGovernor_init.selector,
+          address(locking), ///       @param veToken The escrowed Mento Token used for voting.
+          address(governanceTimelock), ///     @param timelockController The timelock controller used by the governor.
+          GOVERNOR_VOTING_DELAY, ///       @param votingDelay_ The delay time in blocks between the proposal creation and the start of voting.
+          GOVERNOR_VOTING_PERIOD, ///      @param votingPeriod_ The voting duration in blocks between the vote start and vote end.
+          GOVERNOR_PROPOSAL_THRESHOLD, /// @param threshold_ The number of votes required in order for a voter to become a proposer.
+          GOVERNOR_QUORUM ///              @param quorum_ The minimum number of votes in percent of total supply required in order for a proposal to succeed.
+        )
+      );
 
     // slither-disable-next-line reentrancy-benign
     mentoGovernor = MentoGovernor(payable(mentoGovernorProxy));

--- a/contracts/governance/GovernanceFactory.sol
+++ b/contracts/governance/GovernanceFactory.sol
@@ -193,15 +193,15 @@ contract GovernanceFactory is Ownable {
     Emission emissionImpl = EmissionDeployerLib.deploy(); // NONCE:3
     // slither-disable-next-line reentrancy-benign
     TransparentUpgradeableProxy emissionProxy = ProxyDeployerLib.deployProxy( // NONCE:4
-        address(emissionImpl),
-        address(proxyAdmin),
-        abi.encodeWithSelector(
-          emissionImpl.initialize.selector,
-          addr.mentoToken, ///               @param mentoToken_ The address of the MentoToken contract.
-          addr.governanceTimelock, ///  @param governanceTimelock_ The address of the mento treasury contract.
-          mentoToken.emissionSupply() ///       @param emissionSupply_ The total amount of tokens that can be emitted.
-        )
-      );
+      address(emissionImpl),
+      address(proxyAdmin),
+      abi.encodeWithSelector(
+        emissionImpl.initialize.selector,
+        addr.mentoToken, ///               @param mentoToken_ The address of the MentoToken contract.
+        addr.governanceTimelock, ///  @param governanceTimelock_ The address of the mento treasury contract.
+        mentoToken.emissionSupply() ///       @param emissionSupply_ The total amount of tokens that can be emitted.
+      )
+    );
 
     emission = Emission(address(emissionProxy));
     assert(address(emission) == addr.emission);
@@ -220,16 +220,16 @@ contract GovernanceFactory is Ownable {
     airgrabEnds = block.timestamp + AIRGRAB_DURATION;
     // slither-disable-next-line reentrancy-benign
     airgrab = AirgrabDeployerLib.deploy( // NONCE:5
-        airgrabRoot,
-        fractalSigner,
-        FRACTAL_MAX_AGE,
-        airgrabEnds,
-        AIRGRAB_LOCK_CLIFF,
-        AIRGRAB_LOCK_SLOPE,
-        addr.mentoToken,
-        addr.locking,
-        payable(addr.governanceTimelock)
-      );
+      airgrabRoot,
+      fractalSigner,
+      FRACTAL_MAX_AGE,
+      airgrabEnds,
+      AIRGRAB_LOCK_CLIFF,
+      AIRGRAB_LOCK_SLOPE,
+      addr.mentoToken,
+      addr.locking,
+      payable(addr.governanceTimelock)
+    );
     assert(address(airgrab) == addr.airgrab);
   }
 
@@ -245,16 +245,16 @@ contract GovernanceFactory is Ownable {
     uint32 startingPointWeek = uint32(Locking(lockingImpl).getWeek() - 1);
     // slither-disable-next-line reentrancy-benign
     TransparentUpgradeableProxy lockingProxy = ProxyDeployerLib.deployProxy( // NONCE:7
-        address(lockingImpl),
-        address(proxyAdmin),
-        abi.encodeWithSelector(
-          lockingImpl.__Locking_init.selector,
-          address(mentoToken), /// @param _token The token to be locked in exchange for voting power in form of veTokens.
-          startingPointWeek, ///   @param _startingPointWeek The locking epoch start in weeks. We start the locking contract from week 1 with min slope duration of 1
-          0, ///                   @param _minCliffPeriod minimum cliff period in weeks.
-          1 ///                    @param _minSlopePeriod minimum slope period in weeks.
-        )
-      );
+      address(lockingImpl),
+      address(proxyAdmin),
+      abi.encodeWithSelector(
+        lockingImpl.__Locking_init.selector,
+        address(mentoToken), /// @param _token The token to be locked in exchange for voting power in form of veTokens.
+        startingPointWeek, ///   @param _startingPointWeek The locking epoch start in weeks. We start the locking contract from week 1 with min slope duration of 1
+        0, ///                   @param _minCliffPeriod minimum cliff period in weeks.
+        1 ///                    @param _minSlopePeriod minimum slope period in weeks.
+      )
+    );
     locking = Locking(address(lockingProxy));
     assert(address(locking) == addr.locking);
   }
@@ -280,17 +280,17 @@ contract GovernanceFactory is Ownable {
 
     // slither-disable-next-line reentrancy-benign
     TransparentUpgradeableProxy governanceTimelockProxy = ProxyDeployerLib.deployProxy( // NONCE:9
-        address(timelockControllerImpl),
-        address(proxyAdmin),
-        abi.encodeWithSelector(
-          timelockControllerImpl.__MentoTimelockController_init.selector,
-          GOVERNANCE_TIMELOCK_DELAY, /// @param minDelay The minimum delay before a proposal can be executed.
-          governanceProposers, ///       @param proposers List of addresses that are allowed to queue AND cancel operations.
-          governanceExecutors, ///       @param executors List of addresses that are allowed to execute proposals.
-          address(0), ///                @param admin No admin necessary as proposers are preset upon deployment.
-          watchdogMultiSig ///           @param canceller An additional canceller address with the rights to cancel awaiting proposals.
-        )
-      );
+      address(timelockControllerImpl),
+      address(proxyAdmin),
+      abi.encodeWithSelector(
+        timelockControllerImpl.__MentoTimelockController_init.selector,
+        GOVERNANCE_TIMELOCK_DELAY, /// @param minDelay The minimum delay before a proposal can be executed.
+        governanceProposers, ///       @param proposers List of addresses that are allowed to queue AND cancel operations.
+        governanceExecutors, ///       @param executors List of addresses that are allowed to execute proposals.
+        address(0), ///                @param admin No admin necessary as proposers are preset upon deployment.
+        watchdogMultiSig ///           @param canceller An additional canceller address with the rights to cancel awaiting proposals.
+      )
+    );
     governanceTimelock = TimelockController(payable(governanceTimelockProxy));
     assert(address(governanceTimelock) == addr.governanceTimelock);
   }
@@ -306,18 +306,18 @@ contract GovernanceFactory is Ownable {
     // slither-disable-next-line reentrancy-benign
     MentoGovernor mentoGovernorImpl = MentoGovernorDeployerLib.deploy(); // NONCE:10
     TransparentUpgradeableProxy mentoGovernorProxy = ProxyDeployerLib.deployProxy( // NONCE: 11
-        address(mentoGovernorImpl),
-        address(proxyAdmin),
-        abi.encodeWithSelector(
-          mentoGovernorImpl.__MentoGovernor_init.selector,
-          address(locking), ///       @param veToken The escrowed Mento Token used for voting.
-          address(governanceTimelock), ///     @param timelockController The timelock controller used by the governor.
-          GOVERNOR_VOTING_DELAY, ///       @param votingDelay_ The delay time in blocks between the proposal creation and the start of voting.
-          GOVERNOR_VOTING_PERIOD, ///      @param votingPeriod_ The voting duration in blocks between the vote start and vote end.
-          GOVERNOR_PROPOSAL_THRESHOLD, /// @param threshold_ The number of votes required in order for a voter to become a proposer.
-          GOVERNOR_QUORUM ///              @param quorum_ The minimum number of votes in percent of total supply required in order for a proposal to succeed.
-        )
-      );
+      address(mentoGovernorImpl),
+      address(proxyAdmin),
+      abi.encodeWithSelector(
+        mentoGovernorImpl.__MentoGovernor_init.selector,
+        address(locking), ///       @param veToken The escrowed Mento Token used for voting.
+        address(governanceTimelock), ///     @param timelockController The timelock controller used by the governor.
+        GOVERNOR_VOTING_DELAY, ///       @param votingDelay_ The delay time in blocks between the proposal creation and the start of voting.
+        GOVERNOR_VOTING_PERIOD, ///      @param votingPeriod_ The voting duration in blocks between the vote start and vote end.
+        GOVERNOR_PROPOSAL_THRESHOLD, /// @param threshold_ The number of votes required in order for a voter to become a proposer.
+        GOVERNOR_QUORUM ///              @param quorum_ The minimum number of votes in percent of total supply required in order for a proposal to succeed.
+      )
+    );
 
     // slither-disable-next-line reentrancy-benign
     mentoGovernor = MentoGovernor(payable(mentoGovernorProxy));

--- a/contracts/governance/MentoToken.sol
+++ b/contracts/governance/MentoToken.sol
@@ -40,8 +40,10 @@ contract MentoToken is Ownable, Pausable, ERC20Burnable {
     address[] memory allocationRecipients_,
     uint256[] memory allocationAmounts_,
     address emission_,
-    address locking_
+    address locking_,
+    address initialOwner_
   ) ERC20("Mento Token", "MENTO") Ownable() {
+    _transferOwnership(initialOwner_);
     require(emission_ != address(0), "MentoToken: emission is zero address");
     require(locking_ != address(0), "MentoToken: locking is zero address");
     require(

--- a/contracts/governance/deployers/MentoTokenDeployerLib.sol
+++ b/contracts/governance/deployers/MentoTokenDeployerLib.sol
@@ -17,8 +17,9 @@ library MentoTokenDeployerLib {
     address[] memory allocationRecipients,
     uint256[] memory allocationAmounts,
     address emission,
-    address locking
+    address locking,
+    address owner
   ) external returns (MentoToken) {
-    return new MentoToken(allocationRecipients, allocationAmounts, emission, locking);
+    return new MentoToken(allocationRecipients, allocationAmounts, emission, locking, owner);
   }
 }

--- a/contracts/governance/deployers/ProxyDeployerLib.sol
+++ b/contracts/governance/deployers/ProxyDeployerLib.sol
@@ -12,8 +12,9 @@ library ProxyDeployerLib {
    * @notice Deploys a new ProxyAdmin contract
    * @return admin The address of the new ProxyAdmin contract
    */
-  function deployAdmin() external returns (ProxyAdmin admin) {
+  function deployAdmin(address owner) external returns (ProxyAdmin admin) {
     admin = new ProxyAdmin();
+    admin.transferOwnership(owner);
   }
 
   /**

--- a/contracts/governance/locking/Locking.sol
+++ b/contracts/governance/locking/Locking.sol
@@ -33,11 +33,13 @@ contract Locking is ILocking, LockingBase, LockingRelock, LockingVotes {
     IERC20Upgradeable _token,
     uint32 _startingPointWeek,
     uint32 _minCliffPeriod,
-    uint32 _minSlopePeriod
+    uint32 _minSlopePeriod,
+    address _initialOwner
   ) external initializer {
     __LockingBase_init_unchained(_token, _startingPointWeek, _minCliffPeriod, _minSlopePeriod);
     __Ownable_init_unchained();
     __Context_init_unchained();
+    _transferOwnership(_initialOwner);
   }
 
   /**

--- a/contracts/oracles/BreakerBox.sol
+++ b/contracts/oracles/BreakerBox.sol
@@ -56,10 +56,10 @@ contract BreakerBox is IBreakerBox, Ownable {
    * @param _rateFeedIDs rateFeedIDs to be added.
    * @param _sortedOracles The address of the Celo sorted oracles contract.
    */
-  constructor(address[] memory _rateFeedIDs, ISortedOracles _sortedOracles) public {
-    _transferOwnership(msg.sender);
+  constructor(address[] memory _rateFeedIDs, ISortedOracles _sortedOracles, address owner) public {
     setSortedOracles(_sortedOracles);
     addRateFeeds(_rateFeedIDs);
+    _transferOwnership(owner);
   }
 
   /* ==================== Mutative Functions ==================== */

--- a/contracts/oracles/breakers/MedianDeltaBreaker.sol
+++ b/contracts/oracles/breakers/MedianDeltaBreaker.sol
@@ -52,9 +52,9 @@ contract MedianDeltaBreaker is IBreaker, WithCooldown, WithThreshold, Ownable {
     address _breakerBox,
     address[] memory rateFeedIDs,
     uint256[] memory rateChangeThresholds,
-    uint256[] memory cooldownTimes
+    uint256[] memory cooldownTimes,
+    address owner
   ) public {
-    _transferOwnership(msg.sender);
     setSortedOracles(_sortedOracles);
     setBreakerBox(_breakerBox);
 
@@ -62,6 +62,7 @@ contract MedianDeltaBreaker is IBreaker, WithCooldown, WithThreshold, Ownable {
     _setDefaultRateChangeThreshold(_defaultRateChangeThreshold);
     _setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
     _setCooldownTimes(rateFeedIDs, cooldownTimes);
+    _transferOwnership(owner);
   }
 
   /* ==================== Restricted Functions ==================== */

--- a/contracts/oracles/breakers/ValueDeltaBreaker.sol
+++ b/contracts/oracles/breakers/ValueDeltaBreaker.sol
@@ -42,15 +42,16 @@ contract ValueDeltaBreaker is IBreaker, WithCooldown, WithThreshold, Ownable {
     ISortedOracles _sortedOracles,
     address[] memory rateFeedIDs,
     uint256[] memory rateChangeThresholds,
-    uint256[] memory cooldownTimes
+    uint256[] memory cooldownTimes,
+    address owner
   ) public {
-    _transferOwnership(msg.sender);
     setSortedOracles(_sortedOracles);
 
     _setDefaultCooldownTime(_defaultCooldownTime);
     _setDefaultRateChangeThreshold(_defaultRateChangeThreshold);
     _setRateChangeThresholds(rateFeedIDs, rateChangeThresholds);
     _setCooldownTimes(rateFeedIDs, cooldownTimes);
+    _transferOwnership(owner);
   }
 
   /* ==================== Restricted Functions ==================== */

--- a/test/integration/protocol/ProtocolTest.sol
+++ b/test/integration/protocol/ProtocolTest.sol
@@ -230,7 +230,9 @@ contract ProtocolTest is Test, WithRegistry {
       eXOF_bridgedEUROC_referenceRateFeedID
     );
 
-    breakerBox = IBreakerBox(deployCode("BreakerBox", abi.encode(rateFeedIDs, ISortedOracles(address(sortedOracles)))));
+    breakerBox = IBreakerBox(
+      deployCode("BreakerBox", abi.encode(rateFeedIDs, ISortedOracles(address(sortedOracles)), address(this)))
+    );
     sortedOracles.setBreakerBox(breakerBox);
 
     // set rate feed dependencies
@@ -278,7 +280,8 @@ contract ProtocolTest is Test, WithRegistry {
           address(breakerBox),
           medianDeltaBreakerRateFeedIDs,
           medianDeltaBreakerRateChangeThresholds,
-          medianDeltaBreakerCooldownTimes
+          medianDeltaBreakerCooldownTimes,
+          address(this)
         )
       )
     );
@@ -320,7 +323,8 @@ contract ProtocolTest is Test, WithRegistry {
           ISortedOracles(address(sortedOracles)),
           valueDeltaBreakerRateFeedIDs,
           valueDeltaBreakerRateChangeThresholds,
-          valueDeltaBreakerCooldownTimes
+          valueDeltaBreakerCooldownTimes,
+          address(this)
         )
       )
     );

--- a/test/integration/protocol/eXOFIntegration.t.sol
+++ b/test/integration/protocol/eXOFIntegration.t.sol
@@ -43,7 +43,8 @@ contract EXOFIntegrationTest is ProtocolTest {
           sortedOracles,
           rateFeed,
           rateChangeThreshold,
-          cooldownTime
+          cooldownTime,
+          address(this)
         )
       )
     );

--- a/test/unit/governance/Emission.t.sol
+++ b/test/unit/governance/Emission.t.sol
@@ -24,7 +24,7 @@ contract EmissionTest is GovernanceTest {
 
     emission = new Emission(false);
     vm.prank(owner);
-    emission.initialize(address(mentoToken), emissionTarget, EMISSION_SUPPLY);
+    emission.initialize(address(mentoToken), emissionTarget, EMISSION_SUPPLY, owner);
   }
 
   function test_initialize_shouldSetOwner() public view {

--- a/test/unit/governance/Locking/Locking.fuzz.t.sol
+++ b/test/unit/governance/Locking/Locking.fuzz.t.sol
@@ -27,7 +27,7 @@ contract FuzzTestLocking is Test {
     testERC20 = new TestERC20("Test", "TST");
 
     locking = new LockingHarness(false);
-    locking.__Locking_init(IERC20Upgradeable(address(testERC20)), 0, 1, 3);
+    locking.__Locking_init(IERC20Upgradeable(address(testERC20)), 0, 1, 3, address(this));
     locking.incrementBlock(locking.WEEK() + 1);
   }
 

--- a/test/unit/governance/Locking/LockingTest.sol
+++ b/test/unit/governance/Locking/LockingTest.sol
@@ -18,7 +18,7 @@ contract LockingTest is GovernanceTest {
     locking = new LockingHarness(false);
 
     vm.prank(owner);
-    locking.__Locking_init(IERC20Upgradeable(address(mentoToken)), 0, 0, 0);
+    locking.__Locking_init(IERC20Upgradeable(address(mentoToken)), 0, 0, 0, owner);
 
     weekInBlocks = uint32(locking.WEEK());
 

--- a/test/unit/governance/MentoToken.t.sol
+++ b/test/unit/governance/MentoToken.t.sol
@@ -28,22 +28,22 @@ contract MentoTokenTest is GovernanceTest {
   }
 
   function setUp() public {
-    mentoToken = new MentoToken(allocationRecipients, allocationAmounts, emission, locking);
+    mentoToken = new MentoToken(allocationRecipients, allocationAmounts, emission, locking, address(this));
   }
 
   function test_constructor_whenEmissionIsZero_shouldRevert() public {
     vm.expectRevert("MentoToken: emission is zero address");
-    mentoToken = new MentoToken(allocationRecipients, allocationAmounts, address(0), locking);
+    mentoToken = new MentoToken(allocationRecipients, allocationAmounts, address(0), locking, address(this));
   }
 
   function test_constructor_whenLockingIsZero_shouldRevert() public {
     vm.expectRevert("MentoToken: locking is zero address");
-    mentoToken = new MentoToken(allocationRecipients, allocationAmounts, emission, address(0));
+    mentoToken = new MentoToken(allocationRecipients, allocationAmounts, emission, address(0), address(this));
   }
 
   function test_constructor_whenAllocationRecipientsAndAmountsLengthMismatch_shouldRevert() public {
     vm.expectRevert("MentoToken: recipients and amounts length mismatch");
-    mentoToken = new MentoToken(allocationRecipients, uints(80, 120, 50), emission, locking);
+    mentoToken = new MentoToken(allocationRecipients, uints(80, 120, 50), emission, locking, address(this));
   }
 
   function test_constructor_whenAllocationRecipientIsZero_shouldRevert() public {
@@ -52,19 +52,20 @@ contract MentoTokenTest is GovernanceTest {
       addresses(mentoLabsMultiSig, mentoLabsTreasuryTimelock, airgrab, address(0)),
       allocationAmounts,
       emission,
-      locking
+      locking,
+      address(this)
     );
   }
 
   function test_constructor_whenTotalAllocationExceeds1000_shouldRevert() public {
     vm.expectRevert("MentoToken: total allocation exceeds 100%");
-    mentoToken = new MentoToken(allocationRecipients, uints(80, 120, 50, 1000), emission, locking);
+    mentoToken = new MentoToken(allocationRecipients, uints(80, 120, 50, 1000), emission, locking, address(this));
   }
 
   function test_constructor_shouldPauseTheContract() public {
     vm.expectEmit(true, true, true, true);
     emit Paused(address(this));
-    mentoToken = new MentoToken(allocationRecipients, uints(80, 120, 50, 100), emission, locking);
+    mentoToken = new MentoToken(allocationRecipients, uints(80, 120, 50, 100), emission, locking, address(this));
 
     assertEq(mentoToken.paused(), true);
   }

--- a/test/unit/oracles/BreakerBox.t.sol
+++ b/test/unit/oracles/BreakerBox.t.sol
@@ -56,7 +56,7 @@ contract BreakerBoxTest is Test {
     sortedOracles.addOracle(rateFeedID1, makeAddr("oracleClient1"));
     sortedOracles.addOracle(rateFeedID2, makeAddr("oracleClient1"));
 
-    breakerBox = IBreakerBox(deployCode("BreakerBox", abi.encode(testRateFeedIDs, sortedOracles)));
+    breakerBox = IBreakerBox(deployCode("BreakerBox", abi.encode(testRateFeedIDs, sortedOracles, address(this))));
     breakerBox.addBreaker(address(mockBreaker1), 1);
   }
 

--- a/test/unit/oracles/breakers/MedianDeltaBreaker.t.sol
+++ b/test/unit/oracles/breakers/MedianDeltaBreaker.t.sol
@@ -64,7 +64,8 @@ contract MedianDeltaBreakerTest is Test {
           breakerBox,
           rateFeedIDs,
           rateChangeThresholds,
-          cooldownTimes
+          cooldownTimes,
+          address(this)
         )
       )
     );

--- a/test/unit/oracles/breakers/ValueDeltaBreaker.t.sol
+++ b/test/unit/oracles/breakers/ValueDeltaBreaker.t.sol
@@ -62,7 +62,8 @@ contract ValueDeltaBreakerTest is Test {
           ISortedOracles(address(sortedOracles)),
           rateFeedIDs,
           rateChangeThresholds,
-          cooldownTimes
+          cooldownTimes,
+          address(this)
         )
       )
     );


### PR DESCRIPTION
## Summary

This PR adds explicit owner initialization to various contracts to make them compatible with CreateX deployment:

- **MentoToken**: Added `initialOwner_` parameter to constructor
- **Emission**: Added `initialOwner_` parameter to `initialize` function and replaced `__Ownable_init()` with `_transferOwnership(initialOwner_)`
- **Locking**: Added `_initialOwner` parameter to `__Locking_init` function
- **BreakerBox**: Added `owner` parameter to constructor and moved ownership transfer to end
- **MedianDeltaBreaker**: Added `owner` parameter to constructor and moved ownership transfer to end
- **ValueDeltaBreaker**: Added `owner` parameter to constructor and moved ownership transfer to end

These changes ensure that ownership can be set to the correct address during deployment when using CreateX, rather than defaulting to `msg.sender`.

## Test plan

- [x] Verify all contracts compile successfully
- [x] Run existing test suite to ensure no regressions
- [x] Test deployment flow with CreateX
- [x] Verify ownership is correctly set after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)