### PR TITLE
fix: add initialOwner param to OracleAdapter

### DIFF
--- a/contracts/interfaces/IOracleAdapter.sol
+++ b/contracts/interfaces/IOracleAdapter.sol
@@ -78,8 +78,14 @@ interface IOracleAdapter {
    * @param _sortedOracles The address of the sorted oracles contract
    * @param _breakerBox The address of the breaker box contract
    * @param _marketHoursBreaker The address of the market hours breaker contract
+   * @param _initialOwner The address to transfer ownership to
    */
-  function initialize(address _sortedOracles, address _breakerBox, address _marketHoursBreaker) external;
+  function initialize(
+    address _sortedOracles,
+    address _breakerBox,
+    address _marketHoursBreaker,
+    address _initialOwner
+  ) external;
 
   /**
    * @notice Sets the address of the sorted oracles contract

--- a/contracts/oracles/OracleAdapter.sol
+++ b/contracts/oracles/OracleAdapter.sol
@@ -32,12 +32,19 @@ contract OracleAdapter is IOracleAdapter, OwnableUpgradeable {
   /* ========== INITIALIZATION ========== */
 
   /// @inheritdoc IOracleAdapter
-  function initialize(address _sortedOracles, address _breakerBox, address _marketHoursBreaker) external initializer {
+  function initialize(
+    address _sortedOracles,
+    address _breakerBox,
+    address _marketHoursBreaker,
+    address _initialOwner
+  ) external initializer {
     __Ownable_init();
 
     setSortedOracles(_sortedOracles);
     setBreakerBox(_breakerBox);
     setMarketHoursBreaker(_marketHoursBreaker);
+
+    transferOwnership(_initialOwner);
   }
 
   /* ========== VIEW FUNCTIONS ========== */

--- a/test/integration/protocol/VirtualPool/VirtualPoolBaseIntegration.t.sol
+++ b/test/integration/protocol/VirtualPool/VirtualPoolBaseIntegration.t.sol
@@ -58,7 +58,7 @@ contract VirtualPoolBaseIntegration is ProtocolTest {
     fpmmImplementation = new FPMM(true);
 
     oracleAdapter = new OracleAdapter(false);
-    oracleAdapter.initialize(address(sortedOracles), address(breakerBox), marketHoursBreaker);
+    oracleAdapter.initialize(address(sortedOracles), address(breakerBox), marketHoursBreaker, governance);
     router = new Router(forwarder, factoryRegistry, address(fpmmFactory));
 
     fpmmFactory.initialize(address(oracleAdapter), proxyAdmin, governance, address(fpmmImplementation));

--- a/test/unit/oracles/OracleAdapter.t.sol
+++ b/test/unit/oracles/OracleAdapter.t.sol
@@ -27,8 +27,7 @@ contract OracleAdapterTest is Test {
   }
 
   function test_initialize_shouldSetAllContracts() public {
-    vm.prank(owner);
-    oracleAdapter.initialize(sortedOracles, breakerBox, marketHoursBreaker);
+    oracleAdapter.initialize(sortedOracles, breakerBox, marketHoursBreaker, owner);
 
     assertEq(address(oracleAdapter.sortedOracles()), sortedOracles);
     assertEq(address(oracleAdapter.breakerBox()), breakerBox);
@@ -38,7 +37,7 @@ contract OracleAdapterTest is Test {
 
   function test_initialize_whenCalledTwice_shouldRevert() public initialized {
     vm.expectRevert("Initializable: contract is already initialized");
-    oracleAdapter.initialize(sortedOracles, breakerBox, marketHoursBreaker);
+    oracleAdapter.initialize(sortedOracles, breakerBox, marketHoursBreaker, owner);
   }
 
   function test_sortedOracles_shouldReturnSortedOracles() public initialized {
@@ -281,8 +280,7 @@ contract OracleAdapterTest is Test {
   }
 
   modifier initialized() {
-    vm.prank(owner);
-    oracleAdapter.initialize(sortedOracles, breakerBox, marketHoursBreaker);
+    oracleAdapter.initialize(sortedOracles, breakerBox, marketHoursBreaker, owner);
 
     _;
   }

--- a/test/unit/swap/FPMM/FPMMBaseTest.sol
+++ b/test/unit/swap/FPMM/FPMMBaseTest.sol
@@ -36,7 +36,7 @@ contract FPMMBaseTest is Test {
   function setUp() public virtual {
     fpmm = new FPMM(false);
     oracleAdapter = IOracleAdapter(new OracleAdapter(false));
-    oracleAdapter.initialize(address(sortedOracles), address(breakerBox), address(marketHoursBreaker));
+    oracleAdapter.initialize(address(sortedOracles), address(breakerBox), address(marketHoursBreaker), owner);
 
     vm.prank(fpmm.owner());
 

--- a/test/unit/swap/OneToOneFPMM/OneToOneFPMMBaseTest.sol
+++ b/test/unit/swap/OneToOneFPMM/OneToOneFPMMBaseTest.sol
@@ -36,7 +36,7 @@ contract OneToOneFPMMBaseTest is Test {
   function setUp() public virtual {
     fpmm = new OneToOneFPMM(false);
     oracleAdapter = IOracleAdapter(new OracleAdapter(false));
-    oracleAdapter.initialize(address(sortedOracles), address(breakerBox), address(marketHoursBreaker));
+    oracleAdapter.initialize(address(sortedOracles), address(breakerBox), address(marketHoursBreaker), owner);
 
     vm.prank(fpmm.owner());
 


### PR DESCRIPTION
### Description

Small fix to add the `initialOwner` param to the oracle adapter. See https://github.com/mento-protocol/mento-core/pull/624