### PR TITLE
fix: index address parameters in fpmm events

### DIFF
--- a/contracts/interfaces/IFPMM.sol
+++ b/contracts/interfaces/IFPMM.sol
@@ -178,7 +178,7 @@ interface IFPMM is IRPool {
    * @param oldRecipient Previous recipient of the protocol fee
    * @param newRecipient New recipient of the protocol fee
    */
-  event ProtocolFeeRecipientUpdated(address oldRecipient, address newRecipient);
+  event ProtocolFeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
 
   /**
    * @notice Emitted when the rebalance incentive is updated
@@ -213,14 +213,14 @@ interface IFPMM is IRPool {
    * @param oldRateFeedID Previous rate feed ID
    * @param newRateFeedID New rate feed ID
    */
-  event ReferenceRateFeedIDUpdated(address oldRateFeedID, address newRateFeedID);
+  event ReferenceRateFeedIDUpdated(address indexed oldRateFeedID, address indexed newRateFeedID);
 
   /**
    * @notice Emitted when the OracleAdapter contract is updated
    * @param oldOracleAdapter Previous OracleAdapter address
    * @param newOracleAdapter New OracleAdapter address
    */
-  event OracleAdapterUpdated(address oldOracleAdapter, address newOracleAdapter);
+  event OracleAdapterUpdated(address indexed oldOracleAdapter, address indexed newOracleAdapter);
 
   /**
    * @notice Emitted when the invert rate feed flag is updated

--- a/test/unit/swap/FPMM/FPMMAdmin.t.sol
+++ b/test/unit/swap/FPMM/FPMMAdmin.t.sol
@@ -9,9 +9,9 @@ import { ITradingLimitsV2 } from "contracts/interfaces/ITradingLimitsV2.sol";
 contract FPMMAdminTest is FPMMBaseTest {
   event LPFeeUpdated(uint256 oldFee, uint256 newFee);
   event ProtocolFeeUpdated(uint256 oldFee, uint256 newFee);
-  event ProtocolFeeRecipientUpdated(address oldRecipient, address newRecipient);
-  event ReferenceRateFeedIDUpdated(address oldRateFeedID, address newRateFeedID);
-  event OracleAdapterUpdated(address oldOracleAdapter, address newOracleAdapter);
+  event ProtocolFeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+  event ReferenceRateFeedIDUpdated(address indexed oldRateFeedID, address indexed newRateFeedID);
+  event OracleAdapterUpdated(address indexed oldOracleAdapter, address indexed newOracleAdapter);
   event LiquidityStrategyUpdated(address indexed strategy, bool status);
   event InvertRateFeedUpdated(bool oldInvertRateFeed, bool newInvertRateFeed);
   event TradingLimitConfigured(address indexed token, ITradingLimitsV2.Config config);


### PR DESCRIPTION
### Description

This fixes the 6.11 issue of the audit, where some parameters in fpmm configuration events where unindexed
