### PR TITLE
fix: remove deprecated fee-on-transfer tokens functions

### DIFF
--- a/contracts/swap/router/Router.sol
+++ b/contracts/swap/router/Router.sol
@@ -252,45 +252,6 @@ contract Router is IRouter, ERC2771Context {
     _swap(amounts, routes, to);
   }
 
-  // **** SWAP (supporting fee-on-transfer tokens) ****
-  /// @dev requires the initial amount to have already been sent to the first pool
-  function _swapSupportingFeeOnTransferTokens(Route[] memory routes, address _to) internal virtual {
-    uint256 _length = routes.length;
-    for (uint256 i; i < _length; i++) {
-      (address token0, ) = sortTokens(routes[i].from, routes[i].to);
-      address pool = poolFor(routes[i].from, routes[i].to, routes[i].factory);
-      uint256 amountInput;
-      uint256 amountOutput;
-      {
-        // stack too deep
-        // getReserves sorts it for us i.e. reserveA is always for from
-        (uint256 reserveA, ) = getReserves(routes[i].from, routes[i].to, routes[i].factory);
-        amountInput = IERC20(routes[i].from).balanceOf(pool) - reserveA;
-      }
-      amountOutput = IRPool(pool).getAmountOut(amountInput, routes[i].from);
-      (uint256 amount0Out, uint256 amount1Out) = routes[i].from == token0
-        ? (uint256(0), amountOutput)
-        : (amountOutput, uint256(0));
-      address to = i < routes.length - 1 ? poolFor(routes[i + 1].from, routes[i + 1].to, routes[i + 1].factory) : _to;
-      IRPool(pool).swap(amount0Out, amount1Out, to, new bytes(0));
-    }
-  }
-
-  /// @inheritdoc IRouter
-  function swapExactTokensForTokensSupportingFeeOnTransferTokens(
-    uint256 amountIn,
-    uint256 amountOutMin,
-    Route[] calldata routes,
-    address to,
-    uint256 deadline
-  ) external ensure(deadline) {
-    _safeTransferFrom(routes[0].from, _msgSender(), poolFor(routes[0].from, routes[0].to, routes[0].factory), amountIn);
-    uint256 _length = routes.length - 1;
-    uint256 balanceBefore = IERC20(routes[_length].to).balanceOf(to);
-    _swapSupportingFeeOnTransferTokens(routes, to);
-    if (IERC20(routes[_length].to).balanceOf(to) - balanceBefore < amountOutMin) revert InsufficientOutputAmount();
-  }
-
   /// @inheritdoc IRouter
   function zapIn(
     address tokenIn,

--- a/contracts/swap/router/interfaces/IRouter.sol
+++ b/contracts/swap/router/interfaces/IRouter.sol
@@ -180,22 +180,6 @@ interface IRouter {
     uint256 deadline
   ) external returns (uint256[] memory amounts);
 
-  // **** SWAP (supporting fee-on-transfer tokens) ****
-
-  /// @notice Swap one token for another supporting fee-on-transfer tokens
-  /// @param amountIn     Amount of token in
-  /// @param amountOutMin Minimum amount of desired token received
-  /// @param routes       Array of trade routes used in the swap
-  /// @param to           Recipient of the tokens received
-  /// @param deadline     Deadline to receive tokens
-  function swapExactTokensForTokensSupportingFeeOnTransferTokens(
-    uint256 amountIn,
-    uint256 amountOutMin,
-    Route[] calldata routes,
-    address to,
-    uint256 deadline
-  ) external;
-
   /// @notice Zap a token A into a pool (B, C). (A can be equal to B or C).
   ///         Supports standard ERC20 tokens only (i.e. not fee-on-transfer tokens etc).
   ///         Slippage is required for the initial swap.

--- a/test/integration/protocol/FPMM/RouterAdvancedTests.t.sol
+++ b/test/integration/protocol/FPMM/RouterAdvancedTests.t.sol
@@ -338,50 +338,6 @@ contract RouterAdvancedTests is FPMMBaseIntegration {
     vm.stopPrank();
   }
 
-  // ============ FEE-ON-TRANSFER TOKEN TESTS ============
-
-  function test_swapExactTokensForTokensSupportingFeeOnTransferTokens_whenValidSwap_shouldSwapCorrectly() public {
-    address fpmm = _deployFPMM(address(tokenA), address(tokenB));
-    _addInitialLiquidity(address(tokenA), address(tokenB), fpmm);
-
-    IRouter.Route[] memory routes = new IRouter.Route[](1);
-    routes[0] = IRouter.Route({ from: address(tokenA), to: address(tokenB), factory: address(0) });
-
-    vm.startPrank(alice);
-    tokenA.approve(address(router), 1000e18);
-
-    uint256 balanceBefore = tokenB.balanceOf(alice);
-
-    router.swapExactTokensForTokensSupportingFeeOnTransferTokens(1000e18, 0, routes, alice, block.timestamp);
-
-    uint256 expectedAmountB = (1000e18 * 997) / 1000;
-    assertEq(tokenB.balanceOf(alice), balanceBefore + expectedAmountB);
-
-    vm.stopPrank();
-  }
-
-  function test_swapExactTokensForTokensSupportingFeeOnTransferTokens_whenInsufficientOutput_shouldRevert() public {
-    address fpmm = _deployFPMM(address(tokenA), address(tokenB));
-    _addInitialLiquidity(address(tokenA), address(tokenB), fpmm);
-
-    IRouter.Route[] memory routes = new IRouter.Route[](1);
-    routes[0] = IRouter.Route({ from: address(tokenA), to: address(tokenB), factory: address(0) });
-
-    vm.startPrank(alice);
-    tokenA.approve(address(router), 1000e18);
-
-    vm.expectRevert(IRouter.InsufficientOutputAmount.selector);
-    router.swapExactTokensForTokensSupportingFeeOnTransferTokens(
-      1000e18,
-      1000e18, // amountOutMin >= amountIn (impossible due to fees)
-      routes,
-      alice,
-      block.timestamp
-    );
-
-    vm.stopPrank();
-  }
-
   // ============ OTHER TESTS ============
 
   function test_getReserves_whenPoolExists_shouldReturnCorrectReserves() public {

--- a/test/integration/protocol/FPMM/RouterTests.t.sol
+++ b/test/integration/protocol/FPMM/RouterTests.t.sol
@@ -566,27 +566,6 @@ contract RouterTests is FPMMBaseIntegration {
     vm.stopPrank();
   }
 
-  function test_swapExactTokensForTokensSupportingFeeOnTransferTokens_whenValidSwap_shouldSwapTokens() public {
-    address fpmm = _deployFPMM(address(tokenA), address(tokenB));
-    _addInitialLiquidity(address(tokenA), address(tokenB), fpmm);
-
-    uint256 amountIn = 10e18;
-    uint256 expectedAmountOut = (amountIn * 997) / 1000;
-
-    IRouter.Route memory route = _createRoute(address(tokenA), address(tokenB));
-    IRouter.Route[] memory routes = new IRouter.Route[](1);
-    routes[0] = route;
-
-    vm.startPrank(alice);
-
-    router.swapExactTokensForTokensSupportingFeeOnTransferTokens(amountIn, 0, routes, alice, block.timestamp);
-
-    vm.stopPrank();
-
-    assertEq(tokenA.balanceOf(alice), 1000e18 - amountIn);
-    assertEq(tokenB.balanceOf(alice), 1000e18 + expectedAmountOut);
-  }
-
   // ============ ZAP TESTS ============
 
   function test_zapIn_whenValidTokens_shouldZapInTokens() public {


### PR DESCRIPTION
### Description

This fixes the 6.1 issue of the audit by removing the deprecated fee-on-transfer tokens functions and their usages:
* `_swapSupportingFeeOnTransferTokens`
* `swapExactTokensForTokensSupportingFeeOnTransferTokens` 
