### PR TITLE
feat: fix redemption fee formula calculation

### DIFF
--- a/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
@@ -236,7 +236,7 @@ contract CDPLiquidityStrategy is ICDPLiquidityStrategy, LiquidityStrategy {
       contractionAmount = targetContractionAmount;
     }
 
-    uint256 redemptionFee = decayedBaseFee + (contractionAmount * 1e18 * redemptionBeta) / totalDebtTokenSupply;
+    uint256 redemptionFee = decayedBaseFee + ((contractionAmount * 1e18) / totalDebtTokenSupply) / redemptionBeta;
 
     // redemption fee is capped at 100%
     redemptionFee = redemptionFee > 1e18 ? 1e18 : redemptionFee;


### PR DESCRIPTION
### Description

- Fixes 5.1 from the audit 
<img width="1468" height="1194" alt="image" src="https://github.com/user-attachments/assets/fbb8cf58-95e1-4f41-8939-98a3158241be" />

### Other changes



### Tested

- test didn't need changes because redemptionFee is 1 

### Related issues



### Backwards compatibility



### Documentation


