### PR TITLE
fix: incorrect ERC20Permit initialization

### DIFF
--- a/contracts/tokens/StableTokenV2.sol
+++ b/contracts/tokens/StableTokenV2.sol
@@ -79,7 +79,7 @@ contract StableTokenV2 is ERC20PermitUpgradeable, IStableTokenV2, CalledByVm {
     uint256[] calldata initialBalanceValues
   ) external initializer {
     __ERC20_init_unchained(_name, _symbol);
-    __ERC20Permit_init(_name);
+    __ERC20Permit_init(_symbol);
     _transferOwnership(_msgSender());
 
     require(initialBalanceAddresses.length == initialBalanceValues.length, "Array length mismatch");
@@ -102,7 +102,7 @@ contract StableTokenV2 is ERC20PermitUpgradeable, IStableTokenV2, CalledByVm {
     _setBroker(_broker);
     _setValidators(_validators);
     _setExchange(_exchange);
-    __ERC20Permit_init(name());
+    __ERC20Permit_init(symbol());
   }
 
   /**


### PR DESCRIPTION
### Description

This fixes the 6.3 issue of the audit by initializing the ERC20Permit with the
token name instead of the token symbol for the `StableTokenV2` and `StableTokenV3`, as mentioned in the PDF. 
Also, I found other places where it was using a symbol instead of a name and replaced it.

### Other changes

None.

### Tested

Run the `StableTokenV2` and `StableTokenV3` tests.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_
