### PR TITLE
Fix/rebalancing towards thresholds

### DIFF
--- a/contracts/interfaces/ICDPLiquidityStrategy.sol
+++ b/contracts/interfaces/ICDPLiquidityStrategy.sol
@@ -39,13 +39,38 @@ interface ICDPLiquidityStrategy is ILiquidityStrategy {
   struct CDPConfig {
     address stabilityPool;
     address collateralRegistry;
-    address systemParams;
-    uint256 stabilityPoolPercentage;
-    uint256 maxIterations;
-    uint128 liquiditySourceIncentiveBpsContraction;
-    uint128 protocolIncentiveBpsContraction;
-    uint128 liquiditySourceIncentiveBpsExpansion;
-    uint128 protocolIncentiveBpsExpansion;
+    uint16 stabilityPoolPercentage;
+    uint16 maxIterations;
+  }
+
+  /**
+   * @notice Parameters for adding a new pool to the CDP strategy
+   * @param pool The address of the FPMM pool to add
+   * @param debtToken The address of the debt token (stable asset)
+   * @param cooldown The cooldown period between rebalances in seconds
+   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
+   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
+   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
+   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
+   * @param protocolFeeRecipient The recipient of the protocol fee
+   * @param stabilityPool The address of the stability pool used for swapping collateral to stable
+   * @param collateralRegistry The address of the collateral registry for redemptions
+   * @param stabilityPoolPercentage The percentage of stability pool balance available for rebalancing (in bps)
+   * @param maxIterations The maximum number of iterations for redemption operations
+   */
+  struct AddPoolParams {
+    address pool;
+    address debtToken;
+    uint64 cooldown;
+    uint16 liquiditySourceIncentiveBpsExpansion;
+    uint16 protocolIncentiveBpsExpansion;
+    uint16 liquiditySourceIncentiveBpsContraction;
+    uint16 protocolIncentiveBpsContraction;
+    address protocolFeeRecipient;
+    address stabilityPool;
+    address collateralRegistry;
+    uint16 stabilityPoolPercentage;
+    uint16 maxIterations;
   }
 
   /* ============================================================ */
@@ -54,33 +79,9 @@ interface ICDPLiquidityStrategy is ILiquidityStrategy {
 
   /**
    * @notice Adds a new liquidity pool to be managed by the CDP strategy
-   * @param pool The address of the FPMM pool to add
-   * @param debtToken The address of the debt token (stable asset)
-   * @param cooldown The cooldown period between rebalances in seconds
-   * @param stabilityPool The address of the stability pool for this debt token
-   * @param collateralRegistry The address of the collateral registry for redemptions
-   * @param systemParams The address of the system params contract for reading redemption beta
-   * @param stabilityPoolPercentage The percentage of stability pool balance to use (in bps)
-   * @param maxIterations The maximum number of iterations for redemption operations
-   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
-   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
-   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
-   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
+   * @param params The parameters for adding a pool
    */
-  function addPool(
-    address pool,
-    address debtToken,
-    uint64 cooldown,
-    address stabilityPool,
-    address collateralRegistry,
-    address systemParams,
-    uint256 stabilityPoolPercentage,
-    uint256 maxIterations,
-    uint128 liquiditySourceIncentiveBpsContraction,
-    uint128 protocolIncentiveBpsContraction,
-    uint128 liquiditySourceIncentiveBpsExpansion,
-    uint128 protocolIncentiveBpsExpansion
-  ) external;
+  function addPool(AddPoolParams calldata params) external;
 
   /**
    * @notice Removes a pool from the strategy

--- a/contracts/interfaces/ICDPLiquidityStrategy.sol
+++ b/contracts/interfaces/ICDPLiquidityStrategy.sol
@@ -42,6 +42,10 @@ interface ICDPLiquidityStrategy is ILiquidityStrategy {
     address systemParams;
     uint256 stabilityPoolPercentage;
     uint256 maxIterations;
+    uint128 liquiditySourceIncentiveBpsContraction;
+    uint128 protocolIncentiveBpsContraction;
+    uint128 liquiditySourceIncentiveBpsExpansion;
+    uint128 protocolIncentiveBpsExpansion;
   }
 
   /* ============================================================ */
@@ -53,23 +57,29 @@ interface ICDPLiquidityStrategy is ILiquidityStrategy {
    * @param pool The address of the FPMM pool to add
    * @param debtToken The address of the debt token (stable asset)
    * @param cooldown The cooldown period between rebalances in seconds
-   * @param incentiveBps The rebalance incentive in basis points
    * @param stabilityPool The address of the stability pool for this debt token
    * @param collateralRegistry The address of the collateral registry for redemptions
    * @param systemParams The address of the system params contract for reading redemption beta
    * @param stabilityPoolPercentage The percentage of stability pool balance to use (in bps)
    * @param maxIterations The maximum number of iterations for redemption operations
+   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
+   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
+   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
+   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
    */
   function addPool(
     address pool,
     address debtToken,
     uint64 cooldown,
-    uint32 incentiveBps,
     address stabilityPool,
     address collateralRegistry,
     address systemParams,
     uint256 stabilityPoolPercentage,
-    uint256 maxIterations
+    uint256 maxIterations,
+    uint128 liquiditySourceIncentiveBpsContraction,
+    uint128 protocolIncentiveBpsContraction,
+    uint128 liquiditySourceIncentiveBpsExpansion,
+    uint128 protocolIncentiveBpsExpansion
   ) external;
 
   /**

--- a/contracts/interfaces/ICDPLiquidityStrategy.sol
+++ b/contracts/interfaces/ICDPLiquidityStrategy.sol
@@ -43,36 +43,6 @@ interface ICDPLiquidityStrategy is ILiquidityStrategy {
     uint16 maxIterations;
   }
 
-  /**
-   * @notice Parameters for adding a new pool to the CDP strategy
-   * @param pool The address of the FPMM pool to add
-   * @param debtToken The address of the debt token (stable asset)
-   * @param cooldown The cooldown period between rebalances in seconds
-   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
-   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
-   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
-   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
-   * @param protocolFeeRecipient The recipient of the protocol fee
-   * @param stabilityPool The address of the stability pool used for swapping collateral to stable
-   * @param collateralRegistry The address of the collateral registry for redemptions
-   * @param stabilityPoolPercentage The percentage of stability pool balance available for rebalancing (in bps)
-   * @param maxIterations The maximum number of iterations for redemption operations
-   */
-  struct AddPoolParams {
-    address pool;
-    address debtToken;
-    uint64 cooldown;
-    uint16 liquiditySourceIncentiveBpsExpansion;
-    uint16 protocolIncentiveBpsExpansion;
-    uint16 liquiditySourceIncentiveBpsContraction;
-    uint16 protocolIncentiveBpsContraction;
-    address protocolFeeRecipient;
-    address stabilityPool;
-    address collateralRegistry;
-    uint16 stabilityPoolPercentage;
-    uint16 maxIterations;
-  }
-
   /* ============================================================ */
   /* ==================== Mutative Functions ==================== */
   /* ============================================================ */
@@ -80,8 +50,9 @@ interface ICDPLiquidityStrategy is ILiquidityStrategy {
   /**
    * @notice Adds a new liquidity pool to be managed by the CDP strategy
    * @param params The parameters for adding a pool
+   * @param config The CDP configuration
    */
-  function addPool(AddPoolParams calldata params) external;
+  function addPool(AddPoolParams calldata params, CDPConfig calldata config) external;
 
   /**
    * @notice Removes a pool from the strategy

--- a/contracts/interfaces/IFPMM.sol
+++ b/contracts/interfaces/IFPMM.sol
@@ -369,6 +369,27 @@ interface IFPMM is IRPool {
     );
 
   /**
+   * @notice Gets the rebalancing state of the pool
+   * @return targetNum The numerator of the target price.
+   * @return targetDen The denominator of the target price.
+   * @return reservePriceNumerator The numerator of the pool reserve price.
+   * @return reservePriceDenominator The denominator of the pool reserve price.
+   * @return reservePriceAboveOraclePrice Whether the pool reserve price is above the oracle price.
+   * @return canBeRebalanced Whether the pool can be rebalanced.
+   */
+  function getRebalancingState()
+    external
+    view
+    returns (
+      uint256 targetNum,
+      uint256 targetDen,
+      uint256 reservePriceNumerator,
+      uint256 reservePriceDenominator,
+      bool reservePriceAboveOraclePrice,
+      bool canBeRebalanced
+    );
+
+  /**
    * @notice Gets trading limits config and state for a token
    * @param token Address of the token
    * @return config Trading limits config for the token

--- a/contracts/interfaces/IFPMM.sol
+++ b/contracts/interfaces/IFPMM.sol
@@ -119,10 +119,12 @@ interface IFPMM is IRPool {
   error OneOutputAmountRequired();
   // @notice Throw when trying to rebalance when the price difference is too small
   error PriceDifferenceTooSmall();
-  // @notice Throw when the price difference doesnt improve after rebalance
+  // @notice Throw when the price difference doesn't improve after rebalance
   error PriceDifferenceNotImproved();
   // @notice Throw when a rebalance operation moves the price difference in the wrong direction
   error PriceDifferenceMovedInWrongDirection();
+  // @notice Throw when trying to rebalance and price is moved to far from thesholds
+  error PriceDifferenceMovedTooFarFromThresholds();
   // @notice Throw when trying to rebalance with an insufficient amount of token0 input
   error InsufficientAmount0In();
   // @notice Throw when trying to rebalance with an insufficient amount of token1 input
@@ -370,23 +372,25 @@ interface IFPMM is IRPool {
 
   /**
    * @notice Gets the rebalancing state of the pool
-   * @return targetNum The numerator of the target price.
-   * @return targetDen The denominator of the target price.
+   * @return oraclePriceNumerator The numerator of the oracle price.
+   * @return oraclePriceDenominator The denominator of the oracle price.
    * @return reservePriceNumerator The numerator of the pool reserve price.
    * @return reservePriceDenominator The denominator of the pool reserve price.
    * @return reservePriceAboveOraclePrice Whether the pool reserve price is above the oracle price.
-   * @return canBeRebalanced Whether the pool can be rebalanced.
+   * @return rebalanceThreshold The rebalance threshold in basis points.
+   * @return priceDifference The price difference between the oracle and pool reserve prices in basis points.
    */
   function getRebalancingState()
     external
     view
     returns (
-      uint256 targetNum,
-      uint256 targetDen,
+      uint256 oraclePriceNumerator,
+      uint256 oraclePriceDenominator,
       uint256 reservePriceNumerator,
       uint256 reservePriceDenominator,
       bool reservePriceAboveOraclePrice,
-      bool canBeRebalanced
+      uint16 rebalanceThreshold,
+      uint256 priceDifference
     );
 
   /**

--- a/contracts/interfaces/ILiquidityStrategy.sol
+++ b/contracts/interfaces/ILiquidityStrategy.sol
@@ -9,6 +9,28 @@ interface ILiquidityStrategy {
   /* ============================================================ */
 
   /**
+   * @notice Struct holding the configuration of a pool
+   * @param pool The address of the pool
+   * @param debtToken The address of the debt token
+   * @param cooldown The cooldown period between rebalances in seconds
+   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
+   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
+   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
+   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
+   * @param protocolFeeRecipient The recipient of the protocol fee
+   */
+  struct AddPoolParams {
+    address pool;
+    address debtToken;
+    uint64 cooldown;
+    uint16 liquiditySourceIncentiveBpsExpansion;
+    uint16 protocolIncentiveBpsExpansion;
+    uint16 liquiditySourceIncentiveBpsContraction;
+    uint16 protocolIncentiveBpsContraction;
+    address protocolFeeRecipient;
+  }
+
+  /**
    * @notice Struct holding the complete configuration of an FPMM pool,
    *         in the context of liquidity management.
    * @param isToken0Debt Whether token0 is the debt token (true) or token1 is the debt token (false)
@@ -69,7 +91,7 @@ interface ILiquidityStrategy {
   error LS_DEBT_TOKEN_NOT_IN_POOL();
   /// @notice Thrown when trying to add a pool with a protocol fee recipient that is zero address
   error LS_PROTOCOL_FEE_RECIPIENT_REQUIRED();
-  /// @notice Thrown when the incentive is to high for expansion or contraction
+  /// @notice Thrown when the incentive is too high for expansion or contraction
   error LS_INCENTIVE_TOO_HIGH();
 
   /* ============================================================ */
@@ -79,10 +101,9 @@ interface ILiquidityStrategy {
   /**
    * @notice Emitted when a new pool is added to the strategy
    * @param pool The address of the pool
-   * @param isToken0Debt Whether token0 is the debt token
-   * @param cooldown The rebalance cooldown period
+   * @param params The parameters for adding a pool
    */
-  event PoolAdded(address indexed pool, bool isToken0Debt, uint64 cooldown);
+  event PoolAdded(address indexed pool, AddPoolParams params);
 
   /**
    * @notice Emitted when a pool is removed from the strategy

--- a/contracts/interfaces/ILiquidityStrategy.sol
+++ b/contracts/interfaces/ILiquidityStrategy.sol
@@ -24,10 +24,10 @@ interface ILiquidityStrategy {
     bool isToken0Debt;
     uint64 lastRebalance;
     uint64 rebalanceCooldown;
-    uint128 liquiditySourceIncentiveBpsExpansion;
-    uint128 protocolIncentiveBpsExpansion;
-    uint128 liquiditySourceIncentiveBpsContraction;
-    uint128 protocolIncentiveBpsContraction;
+    uint16 liquiditySourceIncentiveBpsExpansion;
+    uint16 protocolIncentiveBpsExpansion;
+    uint16 liquiditySourceIncentiveBpsContraction;
+    uint16 protocolIncentiveBpsContraction;
     address protocolFeeRecipient;
   }
 

--- a/contracts/interfaces/ILiquidityStrategy.sol
+++ b/contracts/interfaces/ILiquidityStrategy.sol
@@ -14,11 +14,21 @@ interface ILiquidityStrategy {
    * @param isToken0Debt Whether token0 is the debt token (true) or token1 is the debt token (false)
    * @param lastRebalance The timestamp of the last rebalance for this pool
    * @param rebalanceCooldown The cooldown period that must pass before the next rebalance
+   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
+   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
+   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
+   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
+   * @param protocolFeeRecipient The recipient of the protocol fee
    */
   struct PoolConfig {
     bool isToken0Debt;
     uint64 lastRebalance;
     uint64 rebalanceCooldown;
+    uint128 liquiditySourceIncentiveBpsExpansion;
+    uint128 protocolIncentiveBpsExpansion;
+    uint128 liquiditySourceIncentiveBpsContraction;
+    uint128 protocolIncentiveBpsContraction;
+    address protocolFeeRecipient;
   }
 
   /* ============================================================ */
@@ -49,12 +59,18 @@ interface ILiquidityStrategy {
   error LS_INVALID_DECIMAL();
   /// @notice Thrown when oracle prices are invalid
   error LS_INVALID_PRICES();
+  /// @notice Thrown when the pool cannot be rebalanced
+  error LS_POOL_NOT_REBALANCEABLE();
   /// @notice Thrown when the hook callback isn't called during a rebalance from the FPMM
   error LS_HOOK_NOT_CALLED();
   /// @notice Thrown when the same pool is rebalanced twice in a single transaction
   error LS_CAN_ONLY_REBALANCE_ONCE(address pool);
   /// @notice Thrown when trying to add a pool with a debt token that's not a part of the pool
   error LS_DEBT_TOKEN_NOT_IN_POOL();
+  /// @notice Thrown when trying to add a pool with a protocol fee recipient that is zero address
+  error LS_PROTOCOL_FEE_RECIPIENT_REQUIRED();
+  /// @notice Thrown when the incentive is to high for expansion or contraction
+  error LS_INCENTIVE_TOO_HIGH();
 
   /* ============================================================ */
   /* ======================== Events ============================ */
@@ -65,9 +81,8 @@ interface ILiquidityStrategy {
    * @param pool The address of the pool
    * @param isToken0Debt Whether token0 is the debt token
    * @param cooldown The rebalance cooldown period
-   * @param incentiveBps The rebalance incentive in basis points
    */
-  event PoolAdded(address indexed pool, bool isToken0Debt, uint64 cooldown, uint32 incentiveBps);
+  event PoolAdded(address indexed pool, bool isToken0Debt, uint64 cooldown);
 
   /**
    * @notice Emitted when a pool is removed from the strategy

--- a/contracts/interfaces/IReserveLiquidityStrategy.sol
+++ b/contracts/interfaces/IReserveLiquidityStrategy.sol
@@ -54,10 +54,10 @@ interface IReserveLiquidityStrategy is ILiquidityStrategy {
     address pool,
     address debtToken,
     uint64 cooldown,
-    uint128 liquiditySourceIncentiveBpsExpansion,
-    uint128 protocolIncentiveBpsExpansion,
-    uint128 liquiditySourceIncentiveBpsContraction,
-    uint128 protocolIncentiveBpsContraction,
+    uint16 liquiditySourceIncentiveBpsExpansion,
+    uint16 protocolIncentiveBpsExpansion,
+    uint16 liquiditySourceIncentiveBpsContraction,
+    uint16 protocolIncentiveBpsContraction,
     address protocolFeeRecipient
   ) external;
 

--- a/contracts/interfaces/IReserveLiquidityStrategy.sol
+++ b/contracts/interfaces/IReserveLiquidityStrategy.sol
@@ -44,9 +44,22 @@ interface IReserveLiquidityStrategy is ILiquidityStrategy {
    * @param pool The address of the FPMM pool to add
    * @param debtToken The address of the debt token (stable asset)
    * @param cooldown The cooldown period between rebalances in seconds
-   * @param incentiveBps The rebalance incentive in basis points
+   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
+   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
+   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
+   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
+   * @param protocolFeeRecipient The recipient of the protocol fee
    */
-  function addPool(address pool, address debtToken, uint64 cooldown, uint32 incentiveBps) external;
+  function addPool(
+    address pool,
+    address debtToken,
+    uint64 cooldown,
+    uint128 liquiditySourceIncentiveBpsExpansion,
+    uint128 protocolIncentiveBpsExpansion,
+    uint128 liquiditySourceIncentiveBpsContraction,
+    uint128 protocolIncentiveBpsContraction,
+    address protocolFeeRecipient
+  ) external;
 
   /**
    * @notice Removes a pool from the strategy

--- a/contracts/interfaces/IReserveLiquidityStrategy.sol
+++ b/contracts/interfaces/IReserveLiquidityStrategy.sol
@@ -41,25 +41,9 @@ interface IReserveLiquidityStrategy is ILiquidityStrategy {
 
   /**
    * @notice Adds a new liquidity pool to be managed by the strategy
-   * @param pool The address of the FPMM pool to add
-   * @param debtToken The address of the debt token (stable asset)
-   * @param cooldown The cooldown period between rebalances in seconds
-   * @param liquiditySourceIncentiveBpsExpansion The incentive for the liquidity source in basis points for expansion
-   * @param protocolIncentiveBpsExpansion The incentive for the protocol in basis points for expansion
-   * @param liquiditySourceIncentiveBpsContraction The incentive for the liquidity source in basis points for contraction
-   * @param protocolIncentiveBpsContraction The incentive for the protocol in basis points for contraction
-   * @param protocolFeeRecipient The recipient of the protocol fee
+   * @param params The parameters for adding a pool
    */
-  function addPool(
-    address pool,
-    address debtToken,
-    uint64 cooldown,
-    uint16 liquiditySourceIncentiveBpsExpansion,
-    uint16 protocolIncentiveBpsExpansion,
-    uint16 liquiditySourceIncentiveBpsContraction,
-    uint16 protocolIncentiveBpsContraction,
-    address protocolFeeRecipient
-  ) external;
+  function addPool(AddPoolParams calldata params) external;
 
   /**
    * @notice Removes a pool from the strategy

--- a/contracts/interfaces/IReserveV2.sol
+++ b/contracts/interfaces/IReserveV2.sol
@@ -118,6 +118,19 @@ interface IReserveV2 {
   );
 
   /**
+   * @notice Emitted when a stable asset is transferred
+   * @param stableAsset The address of the stable asset
+   * @param to The address to transfer the stable asset to
+   * @param value The amount of stable asset to transfer
+   */
+  event StableAssetTransferred(
+    address indexed reserveManagerSpender,
+    address indexed stableAsset,
+    address indexed to,
+    uint256 value
+  );
+
+  /**
    * @notice Emitted when a collateral asset is transferred by a liquidity strategy spender
    * @param liquidityStrategySpender The address of the liquidity strategy spender
    * @param collateralAsset The address of the collateral asset
@@ -297,4 +310,15 @@ interface IReserveV2 {
    * @return True if the transaction succeeds
    */
   function transferCollateralAsset(address collateralAsset, address to, uint256 value) external returns (bool);
+
+  /**
+   * @notice Transfers stable asset by a reserve manager spender
+   * @dev This function will be used to drain stable assets from the reserve that can accumulate during rebalancing
+   *      as part of the rebalancing liquidity source incentive.
+   * @param stableAsset The address of the stable asset
+   * @param to The address to transfer the stable asset to
+   * @param value The amount of stable asset to transfer
+   * @return True if the transaction succeeds
+   */
+  function transferStableAsset(address stableAsset, address to, uint256 value) external returns (bool);
 }

--- a/contracts/libraries/LiquidityStrategyTypes.sol
+++ b/contracts/libraries/LiquidityStrategyTypes.sol
@@ -140,7 +140,7 @@ library LiquidityStrategyTypes {
         uint256 priceDifference
       ) = fpmm.getRebalancingState();
 
-      if (!(priceDifference > rebalanceThreshold)) revert ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE();
+      if (priceDifference <= rebalanceThreshold) revert ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE();
 
       ctx.reserves = Reserves({ reserveNum: reserveNum, reserveDen: reserveDen });
       ctx.prices = Prices({

--- a/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
@@ -141,6 +141,7 @@ contract CDPLiquidityStrategy is ICDPLiquidityStrategy, LiquidityStrategy {
     if (cb.dir == LQ.Direction.Expand) {
       uint256 collAmount = amount0Out > 0 ? amount0Out : amount1Out;
 
+      // slither-disable-next-line uninitialized-local
       uint256 protocolIncentive;
       // transfer protocol incentive to protocol fee recipient
       if (config.protocolIncentiveBpsExpansion > 0) {
@@ -158,8 +159,11 @@ contract CDPLiquidityStrategy is ICDPLiquidityStrategy, LiquidityStrategy {
     } else {
       uint256 collateralBalanceBefore = IERC20(cb.collToken).balanceOf(address(this));
       uint256 debtAmount = amount0Out > 0 ? amount0Out : amount1Out;
+
+      // slither-disable-start uninitialized-local
       uint256 redemptionFee;
       uint256 protocolIncentive;
+      // slither-disable-end uninitialized-local
 
       // transfer protocol incentive to protocol fee recipient
       if (config.protocolIncentiveBpsContraction > 0) {

--- a/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
@@ -222,8 +222,8 @@ contract CDPLiquidityStrategy is ICDPLiquidityStrategy, LiquidityStrategy {
   /**
    * @notice Calculates the redemption fee for a CDP pool
    * @dev When both incentives are greater than 0 the the redemption fee is:
-   *      (protocolIncentiveBpsContraction * BPS_DENOMINATOR * BPS_TO_FEE_SCALER) /
-   *      (BPS_DENOMINATOR - liquiditySourceIncentiveBpsContraction)
+   *      (liquiditySourceIncentiveBpsContraction * BPS_DENOMINATOR * BPS_TO_FEE_SCALER) /
+   *      (BPS_DENOMINATOR - protocolIncentiveBpsContraction)
    *       This is necesarry because the liquidity source incentive is a percentage of the
    *       total amount of debt being moved out of the pool and not just the amount minus the protocol incentive.
    * @param liquiditySourceIncentiveBpsContraction The liquidity source incentive in basis points for contraction
@@ -236,8 +236,8 @@ contract CDPLiquidityStrategy is ICDPLiquidityStrategy, LiquidityStrategy {
   ) private pure returns (uint256 redemptionFee) {
     if (protocolIncentiveBpsContraction > 0 && liquiditySourceIncentiveBpsContraction > 0) {
       redemptionFee =
-        (protocolIncentiveBpsContraction * BPS_DENOMINATOR * BPS_TO_FEE_SCALER) /
-        (BPS_DENOMINATOR - liquiditySourceIncentiveBpsContraction);
+        (liquiditySourceIncentiveBpsContraction * BPS_DENOMINATOR * BPS_TO_FEE_SCALER) /
+        (BPS_DENOMINATOR - protocolIncentiveBpsContraction);
     } else {
       redemptionFee = liquiditySourceIncentiveBpsContraction * BPS_TO_FEE_SCALER;
     }

--- a/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
@@ -44,25 +44,40 @@ contract CDPLiquidityStrategy is ICDPLiquidityStrategy, LiquidityStrategy {
     address pool,
     address debtToken,
     uint64 cooldown,
-    uint32 incentiveBps,
     address stabilityPool,
     address collateralRegistry,
     address systemParams,
     uint256 stabilityPoolPercentage,
-    uint256 maxIterations
+    uint256 maxIterations,
+    uint128 liquiditySourceIncentiveBpsExpansion,
+    uint128 protocolIncentiveBpsExpansion,
+    uint128 liquiditySourceIncentiveBpsContraction,
+    uint128 protocolIncentiveBpsContraction
   ) external onlyOwner {
     if (!(0 < stabilityPoolPercentage && stabilityPoolPercentage < BPS_DENOMINATOR))
       revert CDPLS_INVALID_STABILITY_POOL_PERCENTAGE();
     if (collateralRegistry == address(0)) revert CDPLS_COLLATERAL_REGISTRY_IS_ZERO();
     if (stabilityPool == address(0)) revert CDPLS_STABILITY_POOL_IS_ZERO();
 
-    LiquidityStrategy._addPool(pool, debtToken, cooldown, incentiveBps);
+    LiquidityStrategy._addPool(
+      pool,
+      debtToken,
+      cooldown,
+      liquiditySourceIncentiveBpsExpansion,
+      protocolIncentiveBpsExpansion,
+      liquiditySourceIncentiveBpsContraction,
+      protocolIncentiveBpsContraction
+    );
     cdpConfigs[pool] = CDPConfig({
       stabilityPool: stabilityPool,
       collateralRegistry: collateralRegistry,
       systemParams: systemParams,
       stabilityPoolPercentage: stabilityPoolPercentage,
-      maxIterations: maxIterations
+      maxIterations: maxIterations,
+      liquiditySourceIncentiveBpsContraction: liquiditySourceIncentiveBpsContraction,
+      protocolIncentiveBpsContraction: protocolIncentiveBpsContraction,
+      liquiditySourceIncentiveBpsExpansion: liquiditySourceIncentiveBpsExpansion,
+      protocolIncentiveBpsExpansion: protocolIncentiveBpsExpansion
     });
   }
 

--- a/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/CDPLiquidityStrategy.sol
@@ -39,27 +39,14 @@ contract CDPLiquidityStrategy is ICDPLiquidityStrategy, LiquidityStrategy {
   /* ============================================================ */
 
   // @inheritdoc ICDPLiquidityStrategy
-  function addPool(AddPoolParams calldata params) external onlyOwner {
-    if (!(0 < params.stabilityPoolPercentage && params.stabilityPoolPercentage < BPS_DENOMINATOR))
+  function addPool(AddPoolParams calldata params, CDPConfig calldata config) external onlyOwner {
+    if (!(0 < config.stabilityPoolPercentage && config.stabilityPoolPercentage < BPS_DENOMINATOR))
       revert CDPLS_INVALID_STABILITY_POOL_PERCENTAGE();
-    if (params.collateralRegistry == address(0)) revert CDPLS_COLLATERAL_REGISTRY_IS_ZERO();
-    if (params.stabilityPool == address(0)) revert CDPLS_STABILITY_POOL_IS_ZERO();
-    LiquidityStrategy._addPool(
-      params.pool,
-      params.debtToken,
-      params.cooldown,
-      params.liquiditySourceIncentiveBpsExpansion,
-      params.protocolIncentiveBpsExpansion,
-      params.liquiditySourceIncentiveBpsContraction,
-      params.protocolIncentiveBpsContraction,
-      params.protocolFeeRecipient
-    );
-    cdpConfigs[params.pool] = CDPConfig({
-      stabilityPool: params.stabilityPool,
-      collateralRegistry: params.collateralRegistry,
-      stabilityPoolPercentage: params.stabilityPoolPercentage,
-      maxIterations: params.maxIterations
-    });
+    if (config.collateralRegistry == address(0)) revert CDPLS_COLLATERAL_REGISTRY_IS_ZERO();
+    if (config.stabilityPool == address(0)) revert CDPLS_STABILITY_POOL_IS_ZERO();
+
+    LiquidityStrategy._addPool(params);
+    cdpConfigs[params.pool] = config;
   }
 
   /// @inheritdoc ICDPLiquidityStrategy

--- a/contracts/liquidityStrategies/LiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/LiquidityStrategy.sol
@@ -312,6 +312,7 @@ abstract contract LiquidityStrategy is
    * @return action The constructed rebalance action
    */
   function _handlePoolPriceAbove(LQ.Context memory ctx) internal view returns (LQ.Action memory action) {
+    // slither-disable-start divide-before-multiply
     uint256 targetNumerator = (ctx.prices.oracleNum * (LQ.BASIS_POINTS_DENOMINATOR + ctx.prices.rebalanceThreshold)) /
       LQ.BASIS_POINTS_DENOMINATOR;
     uint256 targetDenominator = ctx.prices.oracleDen;
@@ -324,6 +325,7 @@ abstract contract LiquidityStrategy is
     uint256 denominator = (ctx.prices.oracleDen * (LQ.BASIS_POINTS_DENOMINATOR - totalIncentiveBps) * targetNumerator) /
       (LQ.BASIS_POINTS_DENOMINATOR * ctx.prices.oracleNum) +
       targetDenominator;
+    // slither-disable-end divide-before-multiply
 
     uint256 token1Out = LQ.scaleFromTo(numerator, denominator, 1e18, ctx.token1Dec);
 
@@ -359,6 +361,7 @@ abstract contract LiquidityStrategy is
    * @return action The constructed rebalance action
    */
   function _handlePoolPriceBelow(LQ.Context memory ctx) internal view returns (LQ.Action memory action) {
+    // slither-disable-start divide-before-multiply
     uint256 targetNumerator = (ctx.prices.oracleNum * (LQ.BASIS_POINTS_DENOMINATOR - ctx.prices.rebalanceThreshold)) /
       LQ.BASIS_POINTS_DENOMINATOR;
     uint256 targetDenominator = ctx.prices.oracleDen;
@@ -373,6 +376,7 @@ abstract contract LiquidityStrategy is
       targetDenominator) /
       (LQ.BASIS_POINTS_DENOMINATOR * ctx.prices.oracleDen) +
       targetNumerator;
+    // slither-disable-end divide-before-multiply
 
     uint256 token0Out = LQ.scaleFromTo(numerator, denominator, 1e18, ctx.token0Dec);
     uint256 token1In = LQ.convertWithRateScalingAndFee(

--- a/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
@@ -49,26 +49,8 @@ contract ReserveLiquidityStrategy is IReserveLiquidityStrategy, LiquidityStrateg
   /* ============================================================ */
 
   /// @inheritdoc IReserveLiquidityStrategy
-  function addPool(
-    address pool,
-    address debtToken,
-    uint64 cooldown,
-    uint16 liquiditySourceIncentiveBpsExpansion,
-    uint16 protocolIncentiveBpsExpansion,
-    uint16 liquiditySourceIncentiveBpsContraction,
-    uint16 protocolIncentiveBpsContraction,
-    address protocolFeeRecipient
-  ) external onlyOwner {
-    LiquidityStrategy._addPool(
-      pool,
-      debtToken,
-      cooldown,
-      liquiditySourceIncentiveBpsExpansion,
-      protocolIncentiveBpsExpansion,
-      liquiditySourceIncentiveBpsContraction,
-      protocolIncentiveBpsContraction,
-      protocolFeeRecipient
-    );
+  function addPool(AddPoolParams calldata params) external onlyOwner {
+    LiquidityStrategy._addPool(params);
   }
 
   /// @inheritdoc IReserveLiquidityStrategy

--- a/contracts/swap/FPMM.sol
+++ b/contracts/swap/FPMM.sol
@@ -844,7 +844,7 @@ contract FPMM is IRPool, IFPMM, ReentrancyGuardUpgradeable, ERC20Upgradeable, Ow
         BASIS_POINTS_DENOMINATOR
       );
       // allow for 10 wei difference due to rounding and precision loss
-      if (swapData.amount0In + 10 < minAmount0In) revert InsufficientAmount0In();
+      if (swapData.amount0In < minAmount0In) revert InsufficientAmount0In();
     } else {
       uint256 minAmount1In = _convertWithRateAndFee(
         swapData.amount0Out,
@@ -856,7 +856,7 @@ contract FPMM is IRPool, IFPMM, ReentrancyGuardUpgradeable, ERC20Upgradeable, Ow
         BASIS_POINTS_DENOMINATOR
       );
       // allow for 10 wei difference due to rounding and precision loss
-      if (swapData.amount1In + 10 < minAmount1In) revert InsufficientAmount1In();
+      if (swapData.amount1In < minAmount1In) revert InsufficientAmount1In();
     }
   }
 

--- a/test/integration/v3/CDPFPMM.DoS.t.sol
+++ b/test/integration/v3/CDPFPMM.DoS.t.sol
@@ -26,11 +26,20 @@ contract CDPFPMM_Test_SP_REBALANCE_FRONTRUN is
     _deployLiquity();
     _configureCDPLiquidityStrategy({
       cooldown: 60,
-      incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100
+      maxIterations: 100,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
     });
-    _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
+    _configureReserveLiquidityStrategy({
+      cooldown: 0,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
+    });
     // skip 20 days to allow the base rate to decay
     skip(20 days);
     _refreshOracleRates();

--- a/test/integration/v3/CDPFPMM.t.sol
+++ b/test/integration/v3/CDPFPMM.t.sol
@@ -300,7 +300,9 @@ contract CDPFPMM_Token0Debt_Test is CDPFPMM_BaseTest {
       cooldown: 60,
       incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
     _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
     // skip 20 days to allow the base rate to decay
@@ -327,7 +329,9 @@ contract CDPFPMM_Token1Debt_Test is CDPFPMM_BaseTest {
       cooldown: 60,
       incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
     _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
     // skip 20 days to allow the base rate to decay

--- a/test/integration/v3/CDPFPMM.t.sol
+++ b/test/integration/v3/CDPFPMM.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-
+// solhint-disable max-line-length
 pragma solidity 0.8.24;
 
 import { TokenDeployer } from "test/integration/v3/TokenDeployer.sol";
@@ -18,26 +18,68 @@ abstract contract CDPFPMM_BaseTest is
   LiquityDeployer
 {
   address reserveMultisig = makeAddr("reserveMultisig");
+}
+
+contract CDPFPMM_Token0Debt_Test is CDPFPMM_BaseTest {
+  function setUp() public {
+    _deployTokens({ isCollateralTokenToken0: false, isDebtTokenToken0: true });
+    _deployOracleAdapter();
+    _deployMentoV2();
+    _deployLiquidityStrategies();
+    _deployFPMM({ invertCDPFPMMRate: true, invertReserveFPMMRate: false });
+    _deployLiquity();
+    _configureCDPLiquidityStrategy({
+      cooldown: 60,
+      stabilityPoolPercentage: 9000, // 90%
+      maxIterations: 100,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
+    });
+    _configureReserveLiquidityStrategy({
+      cooldown: 0,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
+    });
+    // skip 20 days to allow the base rate to decay
+    skip(20 days);
+    _refreshOracleRates();
+    _checkSetup();
+  }
 
   function test_expansion() public {
     // Price is 2:1
     _mintCDPCollToken(reserveMultisig, 10_000_000e18); // USD.m
-    _mintCDPDebtToken(reserveMultisig, 10_000_000e18); // EUR.m
+    _mintCDPDebtToken(reserveMultisig, 15_000_000e18); // EUR.m
 
     _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, 3_000_000e18, 10_000_000e18);
 
     vm.prank(reserveMultisig);
-    $liquity.stabilityPool.provideToSP(5_000_000e18, false);
+    $liquity.stabilityPool.provideToSP(10_000_000e18, false);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be above oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
 
     $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
 
     (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmCDP);
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Expansion should always rebalance perfectly towards the threshold");
 
-    // amountGivenToPool: 4500000000000000000000000
-    // debt = 3_000_000e18 + 4500000000000000000000000
-    // coll = 10_000_000e18 - 4500000000000000000000000 / 2 * 9950 / 10_000
-    assertEq(fpmmDebtAfter, 3_000_000e18 + 4500000000000000000000000);
-    assertEq(fpmmCollAfter, 10_000_000e18 - uint256((4500000000000000000000000 / 2) * 10000) / 9950);
+    // amountTakenFromPool: 4120308106125443208216163
+    // debt = 3_000_000e18 + 4120308106125443208216163 * 2 * 9950 / 10000
+    // coll = 10_000_000e18 - 4120308106125443208216163
+    assertEq(fpmmCollAfter, 10_000_000e18 - 4120308106125443208216163);
+    assertEq(fpmmDebtAfter, 3_000_000e18 + uint256(4120308106125443208216163 * 2 * 9950) / 10000);
   }
 
   function test_clampedExpansion() public {
@@ -50,18 +92,32 @@ abstract contract CDPFPMM_BaseTest is
     vm.prank(reserveMultisig);
     $liquity.stabilityPool.provideToSP(500_000e18, false);
 
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be above oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
     $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
 
     (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmCDP);
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertGt(
+      pricesAfter.priceDifference,
+      500,
+      "Price difference should be more then then threshold away from oracle price due to clamping"
+    );
 
-    // amountGivenToPool: 450000000000000000000000
+    // amountGivenToPool: 450000000000000000000000 (clamped)
     // debt = 3_000_000e18 + 450000000000000000000000
     // coll = 10_000_000e18 - 450000000000000000000000 / 2 * 9950 / 10_000
     assertEq(fpmmDebtAfter, 3_000_000e18 + 450000000000000000000000);
     assertEq(fpmmCollAfter, 10_000_000e18 - uint256((450000000000000000000000 / 2) * 10000) / 9950);
   }
 
-  /// forge-config: default.fuzz.runs = 10000
   function testFuzz_expansionIntegrationTest(uint256 fpmmDebt, uint256 fpmmColl, uint256 spDebt) public {
     fpmmDebt = bound(fpmmDebt, 3000e18, 100_000_000e18);
     fpmmColl = bound(fpmmColl, (fpmmDebt * 25) / 10, 1_000_000_000e18);
@@ -72,6 +128,13 @@ abstract contract CDPFPMM_BaseTest is
 
     _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, fpmmDebt, fpmmColl);
     FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+
+    assertTrue(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be above oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
 
     // bound spDebt to be at least 1% of fpmmColl and at most the total fpmm collateral reserve
     spDebt = bound(spDebt, $liquity.systemParams.MIN_BOLD_AFTER_REBALANCE() + (fpmmColl * 5) / 100, fpmmColl);
@@ -86,6 +149,9 @@ abstract contract CDPFPMM_BaseTest is
     $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
 
     FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference, "Expansion should reduce price difference");
+
     uint256 spDebtBalanceAfter = $tokens.eurm.balanceOf(address($liquity.stabilityPool));
     uint256 spCollBalanceAfter = $tokens.usdm.balanceOf(address($liquity.stabilityPool));
 
@@ -101,40 +167,21 @@ abstract contract CDPFPMM_BaseTest is
       assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference, "Expansion should reduce price difference");
     }
 
-    bool isDebtToken0 = $fpmm.fpmmCDP.token0() == address($tokens.eurm);
-    if (isDebtToken0) {
-      assertGt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be more of asset0 (debt)"
-      );
-      assertLt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be less of asset1 (coll)"
-      );
-      assertEq(
-        pricesAfter.reservePriceDenominator - pricesBefore.reservePriceDenominator,
-        spDebtBalanceBefore - spDebtBalanceAfter,
-        "Debt should move from SP to Pool"
-      );
-    } else {
-      assertLt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be less of asset0 (coll)"
-      );
-      assertGt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be more of asset1 (debt)"
-      );
-      assertEq(
-        pricesAfter.reservePriceNumerator - pricesBefore.reservePriceNumerator,
-        spDebtBalanceBefore - spDebtBalanceAfter,
-        "Debt should move from SP to Pool"
-      );
-    }
+    assertGt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be more of asset0 (debt)"
+    );
+    assertLt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be less of asset1 (coll)"
+    );
+    assertEq(
+      pricesAfter.reservePriceDenominator - pricesBefore.reservePriceDenominator,
+      spDebtBalanceBefore - spDebtBalanceAfter,
+      "Debt should move from SP to Pool"
+    );
   }
 
   function test_targetContraction() public {
@@ -147,96 +194,45 @@ abstract contract CDPFPMM_BaseTest is
 
     FPMMPrices memory pricesBeforeRebalance = _snapshotPrices($fpmm.fpmmCDP);
 
-    // Debt amount to redeem :=  (ON*RD - OD*RN)/(ON*(2-i)) = 2005012531328320802005012
-    uint256 expectedDebtToRedeem = 2005012531328320802005012;
+    uint256 expectedDebtToRedeem = 1799485861182519280205655;
 
-    uint256 expectedCollInflow;
-    if ($fpmm.fpmmCDP.token0() == address($tokens.eurm)) {
-      expectedCollInflow =
-        (expectedDebtToRedeem * (1e18 - 0.005e18) * pricesBeforeRebalance.oraclePriceNumerator) /
-        (pricesBeforeRebalance.oraclePriceDenominator * 1e18);
-    } else {
-      expectedCollInflow =
-        (expectedDebtToRedeem * (1e18 - 0.005e18) * pricesBeforeRebalance.oraclePriceDenominator) /
-        (pricesBeforeRebalance.oraclePriceNumerator * 1e18);
-    }
+    uint256 expectedCollInflow = uint256(
+      expectedDebtToRedeem * (1e18 - 0.005e18) * pricesBeforeRebalance.oraclePriceNumerator
+    ) / (pricesBeforeRebalance.oraclePriceDenominator * 1e18);
 
-    uint256 targetSupply = (expectedDebtToRedeem * 1e18) / (0.0025e18);
-    _mintCDPDebtToken(makeAddr("alice"), targetSupply - $tokens.eurm.totalSupply());
-
-    $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
-
-    FPMMPrices memory pricesAfterRebalance = _snapshotPrices($fpmm.fpmmCDP);
-    // base rate has decayed to min 0.25% so the amount redeemed is equal to 0.25% of the total supply.
-    // in order for the total redemption fee to be equal to the incentive( 0.50%)
-
-    uint256 reserveDebtOutflow;
-    uint256 reserveCollInflow;
-    if ($fpmm.fpmmCDP.token0() == address($tokens.eurm)) {
-      reserveDebtOutflow = pricesBeforeRebalance.reservePriceDenominator - pricesAfterRebalance.reservePriceDenominator;
-      reserveCollInflow = pricesAfterRebalance.reservePriceNumerator - pricesBeforeRebalance.reservePriceNumerator;
-    } else {
-      reserveDebtOutflow = pricesBeforeRebalance.reservePriceNumerator - pricesAfterRebalance.reservePriceNumerator;
-      reserveCollInflow = pricesAfterRebalance.reservePriceDenominator - pricesBeforeRebalance.reservePriceDenominator;
-    }
-
-    assertEq(pricesAfterRebalance.priceDifference, 0);
-    assertEq(reserveDebtOutflow, expectedDebtToRedeem);
-    assertEq(reserveCollInflow, expectedCollInflow);
-  }
-
-  function test_clampedContraction() public {
-    // Price is 2:1
-    _mintCDPCollToken(reserveMultisig, 10_000_000e18); // USD.m
-    _openDemoTroves(11_000_000e18, $liquity.systemParams.MIN_ANNUAL_INTEREST_RATE(), 1e14, reserveMultisig, 10);
-
-    // price is 10:3 below oracle price
-    _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, 10_000_000e18, 3_000_000e18);
-
-    FPMMPrices memory pricesBeforeRebalance = _snapshotPrices($fpmm.fpmmCDP);
-
-    uint256 expectedDebtToRedeem = ($tokens.eurm.totalSupply() * 25) / 10_000;
-
-    uint256 expectedRedemptionFee = $liquity.collateralRegistry.getRedemptionRateForRedeemedAmount(
-      expectedDebtToRedeem
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+    assertFalse(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be below oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
     );
 
-    uint256 expectedCollInflow;
-    if ($fpmm.fpmmCDP.token0() == address($tokens.eurm)) {
-      expectedCollInflow =
-        (expectedDebtToRedeem * (1e18 - expectedRedemptionFee) * pricesBeforeRebalance.oraclePriceNumerator) /
-        (pricesBeforeRebalance.oraclePriceDenominator * 1e18);
-    } else {
-      expectedCollInflow =
-        (expectedDebtToRedeem * (1e18 - expectedRedemptionFee) * pricesBeforeRebalance.oraclePriceDenominator) /
-        (pricesBeforeRebalance.oraclePriceNumerator * 1e18);
-    }
-
     $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
 
     FPMMPrices memory pricesAfterRebalance = _snapshotPrices($fpmm.fpmmCDP);
 
-    // base rate has decayed to min 0.25% so the amount redeemed is equal to 0.25% of the total supply.
-    // in order for the total redemption fee to be equal to the incentive( 0.50%)
-    uint256 reserveDebtOutflow;
-    uint256 reserveCollInflow;
-    if ($fpmm.fpmmCDP.token0() == address($tokens.eurm)) {
-      reserveDebtOutflow = pricesBeforeRebalance.reservePriceDenominator - pricesAfterRebalance.reservePriceDenominator;
-      reserveCollInflow = pricesAfterRebalance.reservePriceNumerator - pricesBeforeRebalance.reservePriceNumerator;
-    } else {
-      reserveDebtOutflow = pricesBeforeRebalance.reservePriceNumerator - pricesAfterRebalance.reservePriceNumerator;
-      reserveCollInflow = pricesAfterRebalance.reservePriceDenominator - pricesBeforeRebalance.reservePriceDenominator;
-    }
+    uint256 reserveDebtOutflow = pricesBeforeRebalance.reservePriceDenominator -
+      pricesAfterRebalance.reservePriceDenominator;
+    uint256 reserveCollInflow = pricesAfterRebalance.reservePriceNumerator -
+      pricesBeforeRebalance.reservePriceNumerator;
 
+    assertApproxEqAbs(
+      pricesAfterRebalance.priceDifference,
+      500,
+      1,
+      "Price difference should be at the threshold with 1 Bps wiggle room due to rounding"
+    );
     assertEq(reserveDebtOutflow, expectedDebtToRedeem);
-    // allow for 1 wei difference due to rounding errors from calculating expected collateral inflow:
-    //  based on debt to redeem vs iterating over touched troves and calculating collateral received from each trove.
-    assertApproxEqAbs(reserveCollInflow, expectedCollInflow, 1);
-    assertLt(pricesAfterRebalance.priceDifference, pricesBeforeRebalance.priceDifference);
+    assertApproxEqAbs(
+      reserveCollInflow,
+      expectedCollInflow,
+      1,
+      "Coll inflow should be equal to the expected coll inflow with 1 wei difference due to rounding when hitting multiple troves"
+    );
   }
 
-  /// forge-config: default.fuzz.runs = 10000
-  function testFuzz_contractionIntegrationTest(uint256 fpmmDebt, uint256 fpmmColl, uint256 targetSupply) public {
+  function testFuzz_contractionIntegrationTest(uint256 fpmmDebt, uint256 fpmmColl) public {
     fpmmColl = bound(fpmmColl, 300e18, 100_000_000e18);
     fpmmDebt = bound(fpmmDebt, (fpmmColl * 25) / 10, 1_000_000_000e18);
 
@@ -245,70 +241,36 @@ abstract contract CDPFPMM_BaseTest is
     _openDemoTroves(fpmmDebt, $liquity.systemParams.MIN_ANNUAL_INTEREST_RATE(), 1e14, reserveMultisig, 10); // eur.m
 
     _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, fpmmDebt, fpmmColl);
+
     FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
-
-    // bound targetSupply to allow for at least 20% of debt reserve to be redeemed
-    uint256 supplyLowerBound = (((fpmmDebt * 20) / 100) * 1e18) /
-      (50 * 1e14 - $liquity.collateralRegistry.getRedemptionRateWithDecay());
-    uint256 supplyUpperBound = (((fpmmDebt * 80) / 100) * 1e18) /
-      (50 * 1e14 - $liquity.collateralRegistry.getRedemptionRateWithDecay());
-    targetSupply = bound(targetSupply, supplyLowerBound, supplyUpperBound);
-
-    _mintCDPDebtToken(reserveMultisig, targetSupply - $tokens.eurm.totalSupply());
+    assertFalse(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be below oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
 
     $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
 
     FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertFalse(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still below oracle price");
+    assertApproxEqAbs(
+      pricesAfter.priceDifference,
+      500,
+      1,
+      "Price difference should be at the threshold with 1 Bps wiggle room due to rounding"
+    );
 
-    assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference);
-
-    if ($fpmm.fpmmCDP.token0() == address($tokens.eurm)) {
-      assertLt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be less of asset0 (debt)"
-      );
-      assertGt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be more of asset1 (coll)"
-      );
-    } else {
-      assertLt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be less of asset1 (debt)"
-      );
-      assertGt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be more of asset0 (coll)"
-      );
-    }
-  }
-}
-
-contract CDPFPMM_Token0Debt_Test is CDPFPMM_BaseTest {
-  function setUp() public {
-    _deployTokens({ isCollateralTokenToken0: false, isDebtTokenToken0: true });
-    _deployOracleAdapter();
-    _deployMentoV2();
-    _deployLiquidityStrategies();
-    _deployFPMM({ invertCDPFPMMRate: true, invertReserveFPMMRate: false });
-    _deployLiquity();
-    _configureCDPLiquidityStrategy({
-      cooldown: 60,
-      incentiveBps: 50,
-      stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100,
-      troveOwnerRedemptionFee: 25,
-      protocolRedemptionFee: 25
-    });
-    _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
-    // skip 20 days to allow the base rate to decay
-    skip(20 days);
-    _refreshOracleRates();
-    _checkSetup();
+    assertLt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be less of asset0 (debt)"
+    );
+    assertGt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be more of asset1 (coll)"
+    );
   }
 
   function _checkSetup() internal {
@@ -327,17 +289,253 @@ contract CDPFPMM_Token1Debt_Test is CDPFPMM_BaseTest {
     _deployLiquity();
     _configureCDPLiquidityStrategy({
       cooldown: 60,
-      incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
       maxIterations: 100,
-      troveOwnerRedemptionFee: 25,
-      protocolRedemptionFee: 25
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
     });
-    _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
+    _configureReserveLiquidityStrategy({
+      cooldown: 0,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
+    });
     // skip 20 days to allow the base rate to decay
     skip(20 days);
     _refreshOracleRates();
     _checkSetup();
+  }
+
+  function test_expansion() public {
+    // Price is 2:1
+    _mintCDPCollToken(reserveMultisig, 10_000_000e18); // USD.m
+    _mintCDPDebtToken(reserveMultisig, 15_000_000e18); // EUR.m
+
+    _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, 3_000_000e18, 10_000_000e18);
+
+    vm.prank(reserveMultisig);
+    $liquity.stabilityPool.provideToSP(10_000_000e18, false);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+    assertFalse(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be below oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
+
+    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmCDP);
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertFalse(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still below oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Expansion should always rebalance perfectly towards the threshold");
+
+    // amountTakenFromPool: 4113110539845758354755784
+    // debt = 3_000_000e18 + 4113110539845758354755784 * 2 * 9950 / 10000
+    // coll = 10_000_000e18 - 4113110539845758354755784
+    assertEq(fpmmCollAfter, 10_000_000e18 - 4113110539845758354755784);
+    assertEq(fpmmDebtAfter, 3_000_000e18 + uint256(4113110539845758354755784 * 2 * 9950) / 10000);
+  }
+  function test_clampedExpansion() public {
+    // Price is 2:1
+    _mintCDPCollToken(reserveMultisig, 10_000_000e18); // USD.m
+    _mintCDPDebtToken(reserveMultisig, 10_000_000e18); // EUR.m
+
+    _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, 3_000_000e18, 10_000_000e18);
+
+    vm.prank(reserveMultisig);
+    $liquity.stabilityPool.provideToSP(500_000e18, false);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+    assertFalse(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be below oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
+
+    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmCDP);
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertFalse(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still below oracle price");
+    assertGt(
+      pricesAfter.priceDifference,
+      500,
+      "Price difference should be more then then threshold away from oracle price due to clamping"
+    );
+
+    // amountGivenToPool: 450000000000000000000000 (clamped)
+    // debt = 3_000_000e18 + 450000000000000000000000
+    // coll = 10_000_000e18 - 450000000000000000000000 / 2 * 9950 / 10_000
+    assertEq(fpmmDebtAfter, 3_000_000e18 + 450000000000000000000000);
+    assertEq(fpmmCollAfter, 10_000_000e18 - uint256((450000000000000000000000 / 2) * 10000) / 9950);
+  }
+
+  function testFuzz_expansionIntegrationTest(uint256 fpmmDebt, uint256 fpmmColl, uint256 spDebt) public {
+    fpmmDebt = bound(fpmmDebt, 3000e18, 100_000_000e18);
+    fpmmColl = bound(fpmmColl, (fpmmDebt * 25) / 10, 1_000_000_000e18);
+
+    _mintCDPCollToken(reserveMultisig, fpmmColl); // USD.m
+
+    _openDemoTroves(fpmmDebt, $liquity.systemParams.MIN_ANNUAL_INTEREST_RATE(), 1e14, reserveMultisig, 10); // eur.m
+
+    _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, fpmmDebt, fpmmColl);
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+
+    assertFalse(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be below oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    // bound spDebt to be at least 1% of fpmmColl and at most the total fpmm collateral reserve
+    spDebt = bound(spDebt, $liquity.systemParams.MIN_BOLD_AFTER_REBALANCE() + (fpmmColl * 5) / 100, fpmmColl);
+
+    _mintCDPDebtToken(reserveMultisig, spDebt); // EUR.m
+    vm.prank(reserveMultisig);
+    $liquity.stabilityPool.provideToSP(spDebt, false);
+
+    uint256 spDebtBalanceBefore = $tokens.eurm.balanceOf(address($liquity.stabilityPool));
+    uint256 spCollBalanceBefore = $tokens.usdm.balanceOf(address($liquity.stabilityPool));
+
+    $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertFalse(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still below oracle price");
+    assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference, "Expansion should reduce price difference");
+
+    uint256 spDebtBalanceAfter = $tokens.eurm.balanceOf(address($liquity.stabilityPool));
+    uint256 spCollBalanceAfter = $tokens.usdm.balanceOf(address($liquity.stabilityPool));
+
+    assertGt(spCollBalanceAfter, spCollBalanceBefore, "SP should have more coll token");
+    assertLt(spDebtBalanceAfter, spDebtBalanceBefore, "SP should have less debt token");
+
+    uint256 minDebtLeftInSPPercentage = (spDebt * 9000) / 10000; // spool percentage is 90%
+    uint256 minDebtLeftInSPHardFloor = $liquity.systemParams.MIN_BOLD_AFTER_REBALANCE();
+
+    if (spDebtBalanceAfter > minDebtLeftInSPPercentage && spDebtBalanceAfter > minDebtLeftInSPHardFloor) {
+      assertEq(pricesAfter.priceDifference, 0, "Expansion should be perfect, if we have more debt left in the SP");
+    } else {
+      assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference, "Expansion should reduce price difference");
+    }
+
+    assertLt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be less of asset0 (coll)"
+    );
+    assertGt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be more of asset1 (debt)"
+    );
+    assertEq(
+      pricesAfter.reservePriceNumerator - pricesBefore.reservePriceNumerator,
+      spDebtBalanceBefore - spDebtBalanceAfter,
+      "Debt should move from SP to Pool"
+    );
+  }
+
+  function test_targetContraction() public {
+    // Price is 2:1
+    _mintCDPCollToken(reserveMultisig, 10_000_000e18); // USD.m
+    _openDemoTroves(11_000_000e18, $liquity.systemParams.MIN_ANNUAL_INTEREST_RATE(), 1e14, reserveMultisig, 10);
+
+    // price is 10:3 below oracle price
+    _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, 10_000_000e18, 3_000_000e18);
+
+    FPMMPrices memory pricesBeforeRebalance = _snapshotPrices($fpmm.fpmmCDP);
+
+    uint256 expectedDebtToRedeem = 1809512165301381586991074;
+
+    uint256 expectedCollInflow = uint256(
+      expectedDebtToRedeem * (1e18 - 0.005e18) * pricesBeforeRebalance.oraclePriceDenominator
+    ) / (pricesBeforeRebalance.oraclePriceNumerator * 1e18);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be above oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
+
+    FPMMPrices memory pricesAfterRebalance = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesAfterRebalance.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertApproxEqAbs(
+      pricesAfterRebalance.priceDifference,
+      500,
+      1,
+      "Price difference should be at the threshold with 1 Bps wiggle room due to rounding"
+    );
+
+    uint256 reserveDebtOutflow = pricesBeforeRebalance.reservePriceNumerator -
+      pricesAfterRebalance.reservePriceNumerator;
+    uint256 reserveCollInflow = pricesAfterRebalance.reservePriceDenominator -
+      pricesBeforeRebalance.reservePriceDenominator;
+
+    assertApproxEqAbs(
+      pricesAfterRebalance.priceDifference,
+      500,
+      1,
+      "Price difference should be at the threshold with 1 Bps wiggle room due to rounding"
+    );
+    assertEq(reserveDebtOutflow, expectedDebtToRedeem);
+    assertApproxEqAbs(
+      reserveCollInflow,
+      expectedCollInflow,
+      1,
+      "Coll inflow should be equal to the expected coll inflow with 1 wei difference due to rounding when hitting multiple troves"
+    );
+  }
+
+  function testFuzz_contractionIntegrationTest(uint256 fpmmDebt, uint256 fpmmColl) public {
+    fpmmColl = bound(fpmmColl, 300e18, 100_000_000e18);
+    fpmmDebt = bound(fpmmDebt, (fpmmColl * 25) / 10, 1_000_000_000e18);
+
+    _mintCDPCollToken(reserveMultisig, fpmmColl); // USD.m
+
+    _openDemoTroves(fpmmDebt, $liquity.systemParams.MIN_ANNUAL_INTEREST_RATE(), 1e14, reserveMultisig, 10); // eur.m
+
+    _provideLiquidityToFPMM($fpmm.fpmmCDP, reserveMultisig, fpmmDebt, fpmmColl);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be above oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.cdpLiquidityStrategy.rebalance(address($fpmm.fpmmCDP));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmCDP);
+    assertTrue(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertApproxEqAbs(
+      pricesAfter.priceDifference,
+      500,
+      1,
+      "Price difference should be at the threshold with 1 Bps wiggle room due to rounding"
+    );
+
+    assertLt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be less of asset1 (debt)"
+    );
+    assertGt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be more of asset0 (coll)"
+    );
   }
 
   function _checkSetup() internal {

--- a/test/integration/v3/Integration.t.sol
+++ b/test/integration/v3/Integration.t.sol
@@ -36,13 +36,20 @@ contract IntegrationTest is
 
     _configureCDPLiquidityStrategy({
       cooldown: 60,
-      incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
       maxIterations: 100,
-      troveOwnerRedemptionFee: 25,
-      protocolRedemptionFee: 25
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
     });
-    _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
+    _configureReserveLiquidityStrategy({
+      cooldown: 0,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
+    });
 
     _checkSetup();
   }

--- a/test/integration/v3/Integration.t.sol
+++ b/test/integration/v3/Integration.t.sol
@@ -38,7 +38,9 @@ contract IntegrationTest is
       cooldown: 60,
       incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
     _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
 

--- a/test/integration/v3/LiquidityStrategyDeployer.sol
+++ b/test/integration/v3/LiquidityStrategyDeployer.sol
@@ -36,7 +36,9 @@ contract LiquidityStrategyDeployer is TestStorage {
     uint64 cooldown,
     uint32 incentiveBps,
     uint256 stabilityPoolPercentage,
-    uint256 maxIterations
+    uint256 maxIterations,
+    uint256 troveOwnerRedemptionFee,
+    uint256 protocolRedemptionFee
   ) internal {
     require($liquidityStrategies.deployed, "LIQUIDITY_STRATEGY_DEPLOYER: liquidity strategies not deployed");
     require($liquity.deployed, "LIQUIDITY_STRATEGY_DEPLOYER: liquity not deployed");
@@ -51,7 +53,9 @@ contract LiquidityStrategyDeployer is TestStorage {
       address($liquity.collateralRegistry),
       address($liquity.systemParams),
       stabilityPoolPercentage,
-      maxIterations
+      maxIterations,
+      troveOwnerRedemptionFee,
+      protocolRedemptionFee
     );
     vm.stopPrank();
   }

--- a/test/integration/v3/LiquityDeployer.sol
+++ b/test/integration/v3/LiquityDeployer.sol
@@ -295,7 +295,7 @@ contract LiquityDeployer is TestStorage, LiquityHelpers {
       vars.collaterals,
       vars.troveManagers,
       systemParamsArray[0],
-      vars.addressesRegistries[0]
+      address($liquidityStrategies.cdpLiquidityStrategy)
     );
     hintHelpers = new HintHelpers(collateralRegistry, systemParamsArray[0]);
     multiTroveGetter = new MultiTroveGetter(collateralRegistry);

--- a/test/integration/v3/LiquityDeployer.sol
+++ b/test/integration/v3/LiquityDeployer.sol
@@ -294,7 +294,8 @@ contract LiquityDeployer is TestStorage, LiquityHelpers {
       IBoldToken(address(debtToken)),
       vars.collaterals,
       vars.troveManagers,
-      systemParamsArray[0]
+      systemParamsArray[0],
+      vars.addressesRegistries[0]
     );
     hintHelpers = new HintHelpers(collateralRegistry, systemParamsArray[0]);
     multiTroveGetter = new MultiTroveGetter(collateralRegistry);

--- a/test/integration/v3/ReserveFPMM.t.sol
+++ b/test/integration/v3/ReserveFPMM.t.sol
@@ -223,7 +223,9 @@ contract ReserveFPMM_Token1Debt_Test is ReserveFPMM_BaseTest {
       cooldown: 60,
       incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
     _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
 
@@ -259,7 +261,9 @@ contract ReserveFPMM_Token0Debt_Test is ReserveFPMM_BaseTest {
       cooldown: 60,
       incentiveBps: 50,
       stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
     _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
 

--- a/test/integration/v3/ReserveFPMM.t.sol
+++ b/test/integration/v3/ReserveFPMM.t.sol
@@ -18,189 +18,6 @@ abstract contract ReserveFPMM_BaseTest is
   LiquityDeployer
 {
   address reserveMultisig = makeAddr("reserveMultisig");
-
-  function test_expansion() public {
-    _mintResCollToken(reserveMultisig, 10_000_000e6);
-    _mintResDebtToken(reserveMultisig, 10_000_000e18);
-    uint256 fpmmDebt = 5_000_000e18;
-    uint256 fpmmColl = 10_000_000e6;
-    bool isDebtToken0 = $fpmm.fpmmReserve.token0() == address($tokens.usdm);
-    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
-    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
-
-    // amountGivenToPool: 2506265664160
-    // reserve0 = 10_000_000e6 - 2506265664160
-    // reserve1 = 5_000_000e18 + ((2506265664160 * 9950) / 10_000) * 1e12
-    uint256 fpmmDebtAfter = isDebtToken0 ? $fpmm.fpmmReserve.reserve0() : $fpmm.fpmmReserve.reserve1();
-    uint256 fpmmCollAfter = isDebtToken0 ? $fpmm.fpmmReserve.reserve1() : $fpmm.fpmmReserve.reserve0();
-    assertEq(fpmmCollAfter, 10_000_000e6 - 2506265664160);
-    assertEq(fpmmDebtAfter, 5_000_000e18 + ((2506265664160 * 9950) / 10_000) * 1e12);
-  }
-
-  function test_contraction() public {
-    _mintResCollToken(address($liquidityStrategies.reserveV2), 10_000_000e6);
-    _mintResCollToken(reserveMultisig, 10_000_000e6);
-    _mintResDebtToken(reserveMultisig, 10_000_000e18);
-
-    uint256 fpmmDebt = 10_000_000e18;
-    uint256 fpmmColl = 5_000_000e6;
-    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
-    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
-
-    // amountTakenFromPool: 2506265664160401002506265
-    // reserve0 = 5_000_000e6 + 2506265664160401002506265 * 9950 / 10000 / 1e12
-    // reserve1 = 10_000_000e18 - 2506265664160401002506265
-    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmReserve);
-    assertEq(fpmmCollAfter, 5_000_000e6 + uint256(2506265664160401002506265 * 9950) / 1e16);
-    assertEq(fpmmDebtAfter, 10_000_000e18 - 2506265664160401002506265);
-  }
-
-  // reserveDebt (USDm)
-  // reserveColl (USDC)
-
-  // cdpColl (== reserveDebt, USDm)
-  // cdpDebt (EURm)
-
-  function test_clampedContraction() public {
-    _mintResCollToken(address($liquidityStrategies.reserveV2), 1_000_000e6);
-    _mintResCollToken(reserveMultisig, 10_000_000e6);
-    _mintResDebtToken(reserveMultisig, 10_000_000e18);
-    uint256 fpmmDebt = 10_000_000e18;
-    uint256 fpmmColl = 5_000_000e6;
-    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
-    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
-
-    // amountGivenToPool: 1_000_000e6 (reserve0)
-    // amountTakenFromPool: 1_000_000 * 1e18 * 10000 / 9950 = 1005025125628140703517587
-    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmReserve);
-    assertEq(fpmmCollAfter, 5_000_000e6 + 1_000_000e6);
-    assertEq(fpmmDebtAfter, 10_000_000e18 - 1005025125628140703517587);
-  }
-
-  /// forge-config: default.fuzz.runs = 10000
-  function testFuzz_expansion(uint256 fpmmDebt, uint256 fpmmColl) public {
-    fpmmDebt = bound(fpmmDebt, 1e18, 100_000_000e18);
-    fpmmColl = bound(fpmmColl, ((fpmmDebt / 1e12) * 3) / 2, 1_000_001_000e6);
-
-    _mintResCollToken(reserveMultisig, fpmmColl);
-    _mintResDebtToken(reserveMultisig, fpmmDebt);
-
-    bool isDebtToken0 = $fpmm.fpmmReserve.token0() == address($tokens.usdm);
-    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
-
-    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmReserve);
-    uint256 reserveBalanceBefore = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
-    uint256 usdmTotalSupplyBefore = $tokens.usdm.totalSupply();
-    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
-    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
-    uint256 reserveBalanceAfter = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
-    uint256 usdmTotalSupplyAfter = $tokens.usdm.totalSupply();
-
-    assertGt(reserveBalanceAfter, reserveBalanceBefore, "Reserve should have more collateral");
-    assertEq(pricesAfter.priceDifference, 0, "Expansion should always rebalance perfectly");
-
-    assertGt(usdmTotalSupplyAfter, usdmTotalSupplyBefore, "USD.m should be minted");
-    uint256 usdmTotalSupplyDelta = usdmTotalSupplyAfter - usdmTotalSupplyBefore;
-
-    if (isDebtToken0) {
-      assertGt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be more of asset0 (debt)"
-      );
-      assertLt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be less of asset1 (coll)"
-      );
-      assertEq(
-        pricesAfter.reservePriceDenominator - pricesBefore.reservePriceDenominator,
-        usdmTotalSupplyDelta,
-        "Minted amount should equal reserve delta"
-      );
-    } else {
-      assertLt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be less of asset0 (coll)"
-      );
-      assertGt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be more of asset1 (debt)"
-      );
-      assertEq(
-        pricesAfter.reservePriceNumerator - pricesBefore.reservePriceNumerator,
-        usdmTotalSupplyDelta,
-        "Minted amount should equal reserve delta"
-      );
-    }
-  }
-
-  function testFuzz_contraction(uint256 fpmmDebt, uint256 fpmmColl, uint256 reserveColl) public {
-    fpmmColl = bound(fpmmColl, 1e6, 100_000_000e6);
-    fpmmDebt = bound(fpmmDebt, ((fpmmColl * 1e12) * 3) / 2, 1_000_000_000e18);
-    // Ensure there's enough collateral to improve the price
-    reserveColl = bound(reserveColl, (fpmmDebt * 1) / 3 / 1e12, fpmmDebt / 1e12);
-
-    _mintResCollToken(reserveMultisig, fpmmColl);
-    _mintResDebtToken(reserveMultisig, fpmmDebt);
-    _mintResCollToken(address($liquidityStrategies.reserveV2), reserveColl);
-
-    bool isDebtToken0 = $fpmm.fpmmReserve.token0() == address($tokens.usdm);
-    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
-
-    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmReserve);
-    uint256 reserveBalanceBefore = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
-    uint256 usdmTotalSupplyBefore = $tokens.usdm.totalSupply();
-    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
-    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
-    uint256 reserveBalanceAfter = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
-    uint256 usdmTotalSupplyAfter = $tokens.usdm.totalSupply();
-
-    assertLt(reserveBalanceAfter, reserveBalanceBefore, "Reserve should have less collateral");
-    if (reserveBalanceAfter > 0) {
-      assertEq(pricesAfter.priceDifference, 0, "Contraction should always rebalance perfectly, if enough collateral");
-    } else {
-      assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference, "Countration should reduce price difference");
-    }
-    assertLt(usdmTotalSupplyAfter, usdmTotalSupplyBefore, "USD.m should be burned");
-    uint256 usdmTotalSupplyDelta = usdmTotalSupplyBefore - usdmTotalSupplyAfter;
-
-    if (isDebtToken0) {
-      assertLt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be less of asset0 (debt)"
-      );
-      assertGt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be more of asset1 (coll)"
-      );
-      assertEq(
-        pricesBefore.reservePriceDenominator - pricesAfter.reservePriceDenominator,
-        usdmTotalSupplyDelta,
-        "Burned amount should equal reserve delta"
-      );
-    } else {
-      assertGt(
-        pricesAfter.reservePriceDenominator,
-        pricesBefore.reservePriceDenominator,
-        "There should be more of asset0 (coll)"
-      );
-      assertLt(
-        pricesAfter.reservePriceNumerator,
-        pricesBefore.reservePriceNumerator,
-        "There should be less of asset1 (debt)"
-      );
-      assertEq(
-        pricesBefore.reservePriceNumerator - pricesAfter.reservePriceNumerator,
-        usdmTotalSupplyDelta,
-        "Burned amount should equal reserve delta"
-      );
-    }
-  }
 }
 
 contract ReserveFPMM_Token1Debt_Test is ReserveFPMM_BaseTest {
@@ -217,19 +34,198 @@ contract ReserveFPMM_Token1Debt_Test is ReserveFPMM_BaseTest {
 
     _deployFPMM({ invertCDPFPMMRate: false, invertReserveFPMMRate: false });
 
-    _deployLiquity();
-
-    _configureCDPLiquidityStrategy({
-      cooldown: 60,
-      incentiveBps: 50,
-      stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100,
-      troveOwnerRedemptionFee: 25,
-      protocolRedemptionFee: 25
+    _configureReserveLiquidityStrategy({
+      cooldown: 0,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
     });
-    _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
 
     _checkSetup();
+  }
+
+  function test_expansion() public {
+    _mintResCollToken(reserveMultisig, 15_000_000e6);
+    _mintResDebtToken(reserveMultisig, 15_000_000e18);
+    uint256 fpmmDebt = 5_000_000e18;
+    uint256 fpmmColl = 10_000_000e6;
+    bool isDebtToken0 = $fpmm.fpmmReserve.token0() == address($tokens.usdm);
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+
+    // amountTakenFromPool: 2313624678663
+    // reserve0 = 10_000_000e6 - 2313624678663
+    // reserve1 = 5_000_000e18 + ((2313624678663 * 9950) / 10_000) * 1e12
+    uint256 fpmmDebtAfter = isDebtToken0 ? $fpmm.fpmmReserve.reserve0() : $fpmm.fpmmReserve.reserve1();
+    uint256 fpmmCollAfter = isDebtToken0 ? $fpmm.fpmmReserve.reserve1() : $fpmm.fpmmReserve.reserve0();
+    assertEq(fpmmCollAfter, 10_000_000e6 - 2313624678663);
+    assertEq(fpmmDebtAfter, 5_000_000e18 + ((2313624678663 * 9950) / 10_000) * 1e12);
+    assertEq(pricesAfter.priceDifference, 500, "Reserve price should be at the threshold away from oracle price");
+    assertEq(pricesAfter.reservePriceAboveOraclePrice, false, "Reserve price should be still below oracle price");
+  }
+
+  function test_contraction() public {
+    _mintResCollToken(address($liquidityStrategies.reserveV2), 10_000_000e6);
+    _mintResCollToken(reserveMultisig, 10_000_000e6);
+    _mintResDebtToken(reserveMultisig, 10_000_000e18);
+
+    uint256 fpmmDebt = 10_000_000e18;
+    uint256 fpmmColl = 5_000_000e6;
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+
+    // amountTakenFromPool: 2323022374373395280596649
+    // reserve0 = 5_000_000e6 + 2323022374373395280596649 * 9950 / 10000 / 1e12
+    // reserve1 = 10_000_000e18 - 2323022374373395280596649
+    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmReserve);
+    assertEq(fpmmCollAfter, 5_000_000e6 + uint256(2323022374373395280596649 * 9950) / 1e16);
+    assertEq(fpmmDebtAfter, 10_000_000e18 - 2323022374373395280596649);
+    assertEq(pricesAfter.priceDifference, 500, "Reserve price should be at the threshold away from oracle price");
+    assertEq(pricesAfter.reservePriceAboveOraclePrice, true, "Reserve price should be still above oracle price");
+  }
+
+  function test_clampedContraction() public {
+    _mintResCollToken(address($liquidityStrategies.reserveV2), 1_000_000e6);
+    _mintResCollToken(reserveMultisig, 10_000_000e6);
+    _mintResDebtToken(reserveMultisig, 10_000_000e18);
+    uint256 fpmmDebt = 10_000_000e18;
+    uint256 fpmmColl = 5_000_000e6;
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+
+    // amountGivenToPool: 1_000_000e6 (reserve0)
+    // amountTakenFromPool: 1_000_000 * 1e18 * 10000 / 9950 = 1005025125628140703517587
+    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmReserve);
+    assertEq(fpmmCollAfter, 5_000_000e6 + 1_000_000e6);
+    assertEq(fpmmDebtAfter, 10_000_000e18 - 1005025125628140703517587);
+    assertGt(
+      pricesAfter.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price due to clamping"
+    );
+    assertEq(pricesAfter.reservePriceAboveOraclePrice, true, "Reserve price should be still above oracle price");
+  }
+
+  /// forge-config: default.fuzz.runs = 10000
+  function testFuzz_expansion(uint256 fpmmDebt, uint256 fpmmColl) public {
+    fpmmDebt = bound(fpmmDebt, 1e18, 100_000_000e18);
+    fpmmColl = bound(fpmmColl, ((fpmmDebt / 1e12) * 3) / 2, 1_000_001_000e6);
+
+    _mintResCollToken(reserveMultisig, fpmmColl);
+    _mintResDebtToken(reserveMultisig, fpmmDebt);
+
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceBefore = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyBefore = $tokens.usdm.totalSupply();
+
+    assertFalse(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be below oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceAfter = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyAfter = $tokens.usdm.totalSupply();
+
+    assertGt(reserveBalanceAfter, reserveBalanceBefore, "Reserve should have more collateral");
+    assertFalse(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still below oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Expansion should always rebalance perfectly towards the threshold");
+
+    assertGt(usdmTotalSupplyAfter, usdmTotalSupplyBefore, "USD.m should be minted");
+    uint256 usdmTotalSupplyDelta = usdmTotalSupplyAfter - usdmTotalSupplyBefore;
+
+    assertLt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be less of asset0 (coll)"
+    );
+    assertGt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be more of asset1 (debt)"
+    );
+    assertEq(
+      pricesAfter.reservePriceNumerator - pricesBefore.reservePriceNumerator,
+      usdmTotalSupplyDelta,
+      "Minted amount should equal reserve delta"
+    );
+    assertFalse(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still below oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Reserve price should be back to the threshold away from oracle price");
+  }
+
+  /// forge-config: default.fuzz.runs = 10000
+  function testFuzz_contraction(uint256 fpmmDebt, uint256 fpmmColl) public {
+    fpmmColl = bound(fpmmColl, 1e6, 100_000_000e6);
+    fpmmDebt = bound(fpmmDebt, ((fpmmColl * 1e12) * 3) / 2, 1_000_000_000e18);
+
+    _mintResCollToken(reserveMultisig, fpmmColl);
+    _mintResDebtToken(reserveMultisig, fpmmDebt);
+
+    // Ensure there's enough collateral to rebalance the price
+    _mintResCollToken(address($liquidityStrategies.reserveV2), fpmmDebt / 1e12);
+
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceBefore = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyBefore = $tokens.usdm.totalSupply();
+    assertTrue(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be above oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceAfter = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyAfter = $tokens.usdm.totalSupply();
+
+    assertLt(reserveBalanceAfter, reserveBalanceBefore, "Reserve should have less collateral");
+    if (reserveBalanceAfter > 0) {
+      assertEq(
+        pricesAfter.priceDifference,
+        500,
+        "Contraction should always rebalance perfectly towards the threshold, if enough collateral"
+      );
+    } else {
+      assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference, "Contraction should reduce price difference");
+    }
+    assertLt(usdmTotalSupplyAfter, usdmTotalSupplyBefore, "USD.m should be burned");
+    uint256 usdmTotalSupplyDelta = usdmTotalSupplyBefore - usdmTotalSupplyAfter;
+
+    assertGt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be more of asset0 (coll)"
+    );
+    assertLt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be less of asset1 (debt)"
+    );
+    assertApproxEqAbs(
+      pricesBefore.reservePriceNumerator - pricesAfter.reservePriceNumerator,
+      usdmTotalSupplyDelta + ((pricesBefore.reservePriceNumerator - pricesAfter.reservePriceNumerator) * 50) / 10000,
+      1,
+      "Burned amount should equal reserve delta minus the fees"
+    );
+    assertTrue(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Reserve price should be back to the threshold away from oracle price");
   }
 
   function _checkSetup() internal {
@@ -255,19 +251,201 @@ contract ReserveFPMM_Token0Debt_Test is ReserveFPMM_BaseTest {
 
     _deployFPMM({ invertCDPFPMMRate: false, invertReserveFPMMRate: false });
 
-    _deployLiquity();
-
-    _configureCDPLiquidityStrategy({
-      cooldown: 60,
-      incentiveBps: 50,
-      stabilityPoolPercentage: 9000, // 90%
-      maxIterations: 100,
-      troveOwnerRedemptionFee: 25,
-      protocolRedemptionFee: 25
+    _configureReserveLiquidityStrategy({
+      cooldown: 0,
+      liquiditySourceIncentiveBpsContraction: 25,
+      protocolIncentiveBpsContraction: 25,
+      liquiditySourceIncentiveBpsExpansion: 25,
+      protocolIncentiveBpsExpansion: 25
     });
-    _configureReserveLiquidityStrategy({ cooldown: 0, incentiveBps: 50 });
 
     _checkSetup();
+  }
+
+  function test_expansion() public {
+    _mintResCollToken(reserveMultisig, 15_000_000e6);
+    _mintResDebtToken(reserveMultisig, 15_000_000e18);
+    uint256 fpmmDebt = 5_000_000e18;
+    uint256 fpmmColl = 10_000_000e6;
+    bool isDebtToken0 = $fpmm.fpmmReserve.token0() == address($tokens.usdm);
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    (, , , , uint256 priceDifference, bool reservePriceAboveOraclePrice) = $fpmm.fpmmReserve.getPrices();
+
+    // amountTakenFromPool: 2323022374373
+    // reserve0 = 10_000_000e6 - 2323022374373
+    // reserve1 = 5_000_000e18 + ((2323022374373 * 9950) / 10_000) * 1e12
+    uint256 fpmmDebtAfter = isDebtToken0 ? $fpmm.fpmmReserve.reserve0() : $fpmm.fpmmReserve.reserve1();
+    uint256 fpmmCollAfter = isDebtToken0 ? $fpmm.fpmmReserve.reserve1() : $fpmm.fpmmReserve.reserve0();
+    assertEq(fpmmCollAfter, 10_000_000e6 - 2323022374373);
+    assertEq(fpmmDebtAfter, 5_000_000e18 + ((2323022374373 * 9950) / 10_000) * 1e12);
+    assertEq(priceDifference, 500, "Reserve price should be at the threshold away from oracle price");
+    assertEq(reservePriceAboveOraclePrice, true, "Reserve price should be still above oracle price");
+  }
+
+  function test_contraction() public {
+    _mintResCollToken(address($liquidityStrategies.reserveV2), 10_000_000e6);
+    _mintResCollToken(reserveMultisig, 10_000_000e6);
+    _mintResDebtToken(reserveMultisig, 10_000_000e18);
+
+    uint256 fpmmDebt = 10_000_000e18;
+    uint256 fpmmColl = 5_000_000e6;
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+
+    // amountTakenFromPool: 2313624678663239074550128
+    // reserve0 = 5_000_000e6 + 2313624678663239074550128 * 9950 / 10000 / 1e12
+    // reserve1 = 10_000_000e18 - 2313624678663239074550128
+    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmReserve);
+    assertEq(fpmmCollAfter, 5_000_000e6 + uint256(2313624678663239074550128 * 9950) / 1e16);
+    assertEq(fpmmDebtAfter, 10_000_000e18 - 2313624678663239074550128);
+    assertEq(pricesAfter.priceDifference, 500, "Reserve price should be at the threshold away from oracle price");
+    assertEq(pricesAfter.reservePriceAboveOraclePrice, false, "Reserve price should be still below oracle price");
+  }
+
+  function test_clampedContraction() public {
+    _mintResCollToken(address($liquidityStrategies.reserveV2), 1_000_000e6);
+    _mintResCollToken(reserveMultisig, 10_000_000e6);
+    _mintResDebtToken(reserveMultisig, 10_000_000e18);
+    uint256 fpmmDebt = 10_000_000e18;
+    uint256 fpmmColl = 5_000_000e6;
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+
+    // amountGivenToPool: 1_000_000e6 (reserve0)
+    // amountTakenFromPool: 1_000_000 * 1e18 * 10000 / 9950 = 1005025125628140703517587
+    (uint256 fpmmDebtAfter, uint256 fpmmCollAfter) = _fpmmReserves($fpmm.fpmmReserve);
+    assertEq(fpmmCollAfter, 5_000_000e6 + 1_000_000e6);
+    assertEq(fpmmDebtAfter, 10_000_000e18 - 1005025125628140703517587);
+    assertGt(
+      pricesAfter.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price due to clamping"
+    );
+    assertEq(pricesAfter.reservePriceAboveOraclePrice, false, "Reserve price should be still below oracle price");
+  }
+
+  /// forge-config: default.fuzz.runs = 10000
+  function testFuzz_expansion(uint256 fpmmDebt, uint256 fpmmColl) public {
+    fpmmDebt = bound(fpmmDebt, 1e18, 100_000_000e18);
+    fpmmColl = bound(fpmmColl, ((fpmmDebt / 1e12) * 3) / 2, 1_000_001_000e6);
+
+    _mintResCollToken(reserveMultisig, fpmmColl);
+    _mintResDebtToken(reserveMultisig, fpmmDebt);
+
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceBefore = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyBefore = $tokens.usdm.totalSupply();
+
+    assertTrue(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be above oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceAfter = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyAfter = $tokens.usdm.totalSupply();
+
+    assertGt(reserveBalanceAfter, reserveBalanceBefore, "Reserve should have more collateral");
+    assertTrue(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Expansion should always rebalance perfectly towards the threshold");
+
+    assertGt(usdmTotalSupplyAfter, usdmTotalSupplyBefore, "USD.m should be minted");
+    uint256 usdmTotalSupplyDelta = usdmTotalSupplyAfter - usdmTotalSupplyBefore;
+
+    assertGt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be more of asset0 (debt)"
+    );
+    assertLt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be less of asset1 (coll)"
+    );
+    assertEq(
+      pricesAfter.reservePriceDenominator - pricesBefore.reservePriceDenominator,
+      usdmTotalSupplyDelta,
+      "Minted amount should equal reserve delta"
+    );
+    assertTrue(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still above oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Reserve price should be back to the threshold away from oracle price");
+  }
+
+  /// forge-config: default.fuzz.runs = 10000
+  function testFuzz_contraction(uint256 fpmmDebt, uint256 fpmmColl) public {
+    fpmmColl = bound(fpmmColl, 1e6, 100_000_000e6);
+    fpmmDebt = bound(fpmmDebt, ((fpmmColl * 1e12) * 3) / 2, 1_000_000_000e18);
+
+    _mintResCollToken(reserveMultisig, fpmmColl);
+    _mintResDebtToken(reserveMultisig, fpmmDebt);
+
+    // Ensure there's enough collateral to rebalance the price
+    _mintResCollToken(address($liquidityStrategies.reserveV2), fpmmDebt / 1e12);
+
+    _provideLiquidityToFPMM($fpmm.fpmmReserve, reserveMultisig, fpmmDebt, fpmmColl);
+
+    FPMMPrices memory pricesBefore = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceBefore = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyBefore = $tokens.usdm.totalSupply();
+    assertFalse(pricesBefore.reservePriceAboveOraclePrice, "Reserve price should be below oracle price");
+    assertGt(
+      pricesBefore.priceDifference,
+      500,
+      "Reserve price should be more then then threshold away from oracle price"
+    );
+
+    $liquidityStrategies.reserveLiquidityStrategy.rebalance(address($fpmm.fpmmReserve));
+
+    FPMMPrices memory pricesAfter = _snapshotPrices($fpmm.fpmmReserve);
+    uint256 reserveBalanceAfter = $tokens.usdc.balanceOf(address($liquidityStrategies.reserveV2));
+    uint256 usdmTotalSupplyAfter = $tokens.usdm.totalSupply();
+
+    assertLt(reserveBalanceAfter, reserveBalanceBefore, "Reserve should have less collateral");
+    if (reserveBalanceAfter > 0) {
+      assertEq(
+        pricesAfter.priceDifference,
+        500,
+        "Contraction should always rebalance perfectly towards the threshold, if enough collateral"
+      );
+    } else {
+      assertLt(pricesAfter.priceDifference, pricesBefore.priceDifference, "Contraction should reduce price difference");
+    }
+    assertLt(usdmTotalSupplyAfter, usdmTotalSupplyBefore, "USD.m should be burned");
+    uint256 usdmTotalSupplyDelta = usdmTotalSupplyBefore - usdmTotalSupplyAfter;
+
+    assertLt(
+      pricesAfter.reservePriceDenominator,
+      pricesBefore.reservePriceDenominator,
+      "There should be less of asset0 (debt)"
+    );
+    assertGt(
+      pricesAfter.reservePriceNumerator,
+      pricesBefore.reservePriceNumerator,
+      "There should be more of asset1 (coll)"
+    );
+    assertApproxEqAbs(
+      pricesBefore.reservePriceDenominator - pricesAfter.reservePriceDenominator,
+      usdmTotalSupplyDelta +
+        ((pricesBefore.reservePriceDenominator - pricesAfter.reservePriceDenominator) * 50) /
+        10000,
+      1,
+      "Burned amount should equal reserve delta minus the fees"
+    );
+
+    assertFalse(pricesAfter.reservePriceAboveOraclePrice, "Reserve price should be still below oracle price");
+    assertEq(pricesAfter.priceDifference, 500, "Reserve price should be back to the threshold away from oracle price");
   }
 
   function _checkSetup() internal {

--- a/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_ActionContraction.t.sol
+++ b/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_ActionContraction.t.sol
@@ -16,10 +16,10 @@ contract CDPLiquidityStrategy_ActionContractionTest is CDPLiquidityStrategy_Base
   /* ============== Contraction target liquidity ================ */
   /* ============================================================ */
 
-  function test_determineAction_whenToken0DebtPoolPriceBelowAndRedemptionFeeEqualToIncentive_shouldContractAndBringPriceBackToOraclePrice()
+  function test_determineAction_whenToken0DebtPoolPriceBelowRebalanceThreshold_shouldContractAndBringPriceBackToRebalanceThreshold()
     public
     fpmmToken0Debt(18, 6)
-    addFpmm(0, 50, 9000)
+    addFpmm(0, 9000, 100, 25, 25, 25, 25)
   {
     uint256 reserve0 = 7_089_031 * 1e18; // brl.m 1.3Mio in $
     uint256 reserve1 = 1_000_000 * 1e6; // usd.m 1Mio in $
@@ -30,30 +30,61 @@ contract CDPLiquidityStrategy_ActionContractionTest is CDPLiquidityStrategy_Base
       oracleNum: 1e18, // USD/BRL rate
       oracleDen: 5476912800000000000,
       poolPriceAbove: false,
-      incentiveBps: 50,
-      isToken0Debt: true
+      isToken0Debt: true,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveBpsExpansion: 25,
+        protocolIncentiveBpsExpansion: 25,
+        liquiditySourceIncentiveBpsContraction: 25,
+        protocolIncentiveBpsContraction: 25
+      })
     });
 
-    mockRedemptionRateWithDecay(0.0025 * 1e18); // 0.25%
-    uint256 totalSupply = calculateTargetSupply(0.0025 * 1e18, ctx); // 0.25% resulting in redemption fee being 0.25% + 0.25% = 0.5%
-    setDebtTokenTotalSupply(totalSupply);
+    (uint256 priceDiffBefore, bool poolPriceAboveBefore) = calculatePriceDifference(
+      ctx.prices.oracleNum,
+      ctx.prices.oracleDen,
+      ctx.reserves.reserveNum,
+      ctx.reserves.reserveDen
+    );
+    assertFalse(poolPriceAboveBefore, "Pool price should be below oracle");
+    assertGt(priceDiffBefore, 500, "Price difference should be greater than rebalance threshold");
 
     LQ.Action memory action = strategy.determineAction(ctx);
 
-    // amount out in token 0 := (ON*RD - OD*RN)/(ON*(2-i)) = 808079.298245614035087719
-    uint256 expectedAmount0Out = 808079298245614035087719;
+    // amount out in token 0 := (TN*RD - TD*RN) / (TN + TD * (1 - i) * ON/OD)
+    // = 646615.244215938303341902
+    uint256 expectedAmount0Out = 646615244215938303341902;
     uint256 expectedAmount1Out = 0;
+
+    // input amount in token 1 := (amountOut * ON * (1-i))/OD = 117471683681
+    uint256 expectedAmountOwedToPool = 117471683681;
+
+    (uint256 priceDiffAfter, bool poolPriceAboveAfter) = calculatePriceDifference(
+      ctx.prices.oracleNum,
+      ctx.prices.oracleDen,
+      ctx.reserves.reserveNum + expectedAmountOwedToPool * (1e18 / ctx.token1Dec),
+      ctx.reserves.reserveDen - expectedAmount0Out
+    );
+    assertFalse(poolPriceAboveAfter, "Pool price should be below oracle");
+    assertEq(priceDiffAfter, 500, "Price difference should be equal to rebalance threshold");
 
     assertEq(action.dir, LQ.Direction.Contract);
     assertEq(action.amount0Out, expectedAmount0Out);
     assertEq(action.amount1Out, expectedAmount1Out);
-    assertEq(action.amountOwedToPool, 0); // expected to always be 0 because can't calculate precise amount of collateral to receive from redemption
+    assertEq(action.amountOwedToPool, expectedAmountOwedToPool);
+    assertIncentive(
+      ctx.incentives.liquiditySourceIncentiveBpsContraction + ctx.incentives.protocolIncentiveBpsContraction,
+      true,
+      expectedAmount0Out,
+      expectedAmountOwedToPool * (1e18 / ctx.token1Dec),
+      ctx.prices.oracleNum,
+      ctx.prices.oracleDen
+    );
   }
 
-  function test_determineAction_whenToken1DebtPoolPriceAboveAndRedemptionFeeEqualToIncentive_shouldContractAndBringPriceBackToOraclePrice()
+  function test_determineAction_whenToken1DebtPoolPriceAboveRebalanceThreshold_shouldContractAndBringPriceBackToRebalanceThreshold()
     public
     fpmmToken1Debt(6, 18)
-    addFpmm(0, 50, 9000)
+    addFpmm(0, 9000, 100, 25, 25, 25, 25)
   {
     uint256 reserve0 = 10_000_000 * 1e18; // usd.m
     uint256 reserve1 = 14_500_000 * 1e6; // chf.m
@@ -64,202 +95,52 @@ contract CDPLiquidityStrategy_ActionContractionTest is CDPLiquidityStrategy_Base
       oracleNum: 1e18,
       oracleDen: 1242930830000000000,
       poolPriceAbove: true,
-      incentiveBps: 50,
-      isToken0Debt: false
+      isToken0Debt: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveBpsExpansion: 25,
+        protocolIncentiveBpsExpansion: 25,
+        liquiditySourceIncentiveBpsContraction: 25,
+        protocolIncentiveBpsContraction: 25
+      })
     });
 
-    mockRedemptionRateWithDecay(0.0025 * 1e18); // 0.25%
-    uint256 totalSupply = calculateTargetSupply(0.0025 * 1e18, ctx); // 0.25% resulting in redemption fee being 0.25% + 0.25% = 0.5%
-    setDebtTokenTotalSupply(totalSupply);
+    (uint256 priceDiffBefore, bool poolPriceAboveBefore) = calculatePriceDifference(
+      ctx.prices.oracleNum,
+      ctx.prices.oracleDen,
+      ctx.reserves.reserveNum,
+      ctx.reserves.reserveDen
+    );
+    assertTrue(poolPriceAboveBefore, "Pool price should be above oracle");
+    assertGt(priceDiffBefore, 500, "Price difference should be greater than rebalance threshold");
 
     LQ.Action memory action = strategy.determineAction(ctx);
 
     uint256 expectedAmount0Out = 0;
-    // amount out in token 1 := (OD*RN - ON*RD)/(OD*(2-i)) = 3_235_338.342946
-    uint256 expectedAmount1Out = 3235338342946;
+    // amount out in token 1 := (RN * TD - TN * RD) / (TD + TN * (1 - i) * OD/ON)  =
+    uint256 expectedAmount1Out = 2959885068535;
+    // input amount in token 0 := (amountOut * OD * (1-i))/ON = 2942403628118
+    uint256 expectedAmountOwedToPool = 3660537742914120361879750;
+
+    (uint256 priceDiffAfter, bool poolPriceAboveAfter) = calculatePriceDifference(
+      ctx.prices.oracleNum,
+      ctx.prices.oracleDen,
+      ctx.reserves.reserveNum - action.amount1Out * (1e18 / ctx.token1Dec),
+      ctx.reserves.reserveDen + action.amountOwedToPool
+    );
+    assertTrue(poolPriceAboveAfter, "Pool price should be above oracle");
+    assertEq(priceDiffAfter, 500, "Price difference should be equal to rebalance threshold");
 
     assertEq(action.dir, LQ.Direction.Contract);
     assertEq(action.amount0Out, expectedAmount0Out);
     assertEq(action.amount1Out, expectedAmount1Out);
-    assertEq(action.amountOwedToPool, 0); // expected to always be 0 because can't calculate precise amount of collateral to receive from redemption
-  }
-
-  /* ============================================================ */
-  /* ============== Contraction non-target liquidity ============ */
-  /* ============================================================ */
-
-  function test_determineAction_whenToken0DebtPoolPriceBelowAndRedemptionFeeLessIncentive_shouldContractAndBringPriceAboveOraclePrice()
-    public
-    fpmmToken0Debt(6, 18)
-    addFpmm(0, 50, 9000)
-  {
-    uint256 reserve0 = 10_956_675_007 * 1e6; // ngnm 7.5 mio in $
-    uint256 reserve1 = 6_000_000 * 1e18; // usdm 6 mio in $
-
-    LQ.Context memory ctx = _createContextWithTokenOrder({
-      reserveDen: reserve0 * 1e12, // reserve token 0 ngnm
-      reserveNum: reserve1, // reserve token 1 usdm
-      oracleNum: 684510000000000,
-      oracleDen: 1e18,
-      poolPriceAbove: false,
-      incentiveBps: 50,
-      isToken0Debt: true
-    });
-
-    mockRedemptionRateWithDecay(0.0025 * 1e18); // 0.25%
-    uint256 totalSupply = calculateTargetSupply(0.0015 * 1e18, ctx); // 0.15% resulting in redemption fee being 0.25% + 0.15% = 0.4%
-    setDebtTokenTotalSupply(totalSupply);
-
-    LQ.Action memory action = strategy.determineAction(ctx);
-
-    // amount out in token 0 := (ON*RD - OD*RN)/(ON*(2-i)) = 1_098_386_357.591375
-    uint256 expectedAmount0Out = 1098386357591375;
-    uint256 expectedAmount1Out = 0;
-
-    assertEq(action.dir, LQ.Direction.Contract);
-
-    assertEq(action.amount0Out, expectedAmount0Out);
-    assertEq(action.amount1Out, expectedAmount1Out);
-    assertEq(action.amountOwedToPool, 0); // expected to always be 0 because can't calculate precise amount of collateral to receive from redemption
-  }
-
-  function test_determineAction_whenToken1DebtPoolPriceAboveAndRedemptionFeeLessIncentive_shouldContractAndBringPriceBelowOraclePrice()
-    public
-    fpmmToken1Debt(18, 6)
-    addFpmm(0, 50, 9000)
-  {
-    uint256 reserve0 = 555_555 * 1e6; // 555555 usd.m
-    uint256 reserve1 = 43_629_738 * 1e18; // php.m 750k in $
-
-    LQ.Context memory ctx = _createContextWithTokenOrder({
-      reserveDen: reserve0 * 1e12, // reserve token 0 usd.m
-      reserveNum: reserve1, // reserve token 1 php.m
-      oracleNum: 1e18,
-      oracleDen: 17190990000000000,
-      poolPriceAbove: true,
-      incentiveBps: 50,
-      isToken0Debt: false
-    });
-
-    mockRedemptionRateWithDecay(0.0025 * 1e18); // 0.25%
-    uint256 totalSupply = calculateTargetSupply(0.001 * 1e18, ctx); // 0.1% resulting in redemption fee being 0.25% + 0.1% = 0.35%
-    setDebtTokenTotalSupply(totalSupply);
-
-    LQ.Action memory action = strategy.determineAction(ctx);
-
-    uint256 expectedAmount0Out = 0;
-    // amount out in token 1 := (OD*RN - ON*RD)/(OD*(2-i)) = 5_670_726.837208791926748374
-    uint256 expectedAmount1Out = 5670726837208791926748374;
-
-    assertEq(action.dir, LQ.Direction.Contract);
-    assertEq(action.amount0Out, expectedAmount0Out);
-    assertEq(action.amount1Out, expectedAmount1Out);
-    assertEq(action.amountOwedToPool, 0); // expected to always be 0 because can't calculate precise amount of collateral to receive from redemption
-  }
-
-  function test_determineAction_whenToken0DebtPoolPriceBelowAndRedemptionFeeGreaterIncentive_shouldContractAndBringPriceCloserToOraclePrice()
-    public
-    fpmmToken0Debt(6, 18)
-    addFpmm(0, 50, 9000)
-  {
-    uint256 reserve0 = 10_956_675_007 * 1e6; // ngnm 7.5 mio in $
-    uint256 reserve1 = 6_000_000 * 1e18; // usdm 6 mio in $
-
-    LQ.Context memory ctx = _createContextWithTokenOrder({
-      reserveDen: reserve0 * 1e12, // reserve token 0 ngnm
-      reserveNum: reserve1, // reserve token 1 usdm
-      oracleNum: 684510000000000,
-      oracleDen: 1e18,
-      poolPriceAbove: false,
-      incentiveBps: 50,
-      isToken0Debt: true
-    });
-
-    mockRedemptionRateWithDecay(0.0025 * 1e18); // 0.25%
-    uint256 totalSupply = calculateTargetSupply(0.0035 * 1e18, ctx); // 0.35% resulting in redemption fee being 0.25% + 0.35% = 0.6%
-    setDebtTokenTotalSupply(totalSupply);
-
-    LQ.Action memory action = strategy.determineAction(ctx);
-
-    // target amount out in token 0 := (ON*RD - OD*RN)/(ON*(2-i)) = 1_098_386_357.591375
-    // since redemption fee for target amount is greater than incentive.
-    // we will redeem an amount that results in a redemption fee equal to incentive.
-    // maximum amount that can be redeemed is: totalSupply * redemptionBeta * (incentive - decayedBaseFee) =
-    // = 313824673597535714 * 1 * (0.005 - 0.0025) =  784_561_683.993839
-    uint256 expectedAmount0Out = 784561683993839;
-    uint256 expectedAmount1Out = 0;
-
-    assertEq(action.dir, LQ.Direction.Contract);
-    assertEq(action.amount0Out, expectedAmount0Out);
-    assertEq(action.amount1Out, expectedAmount1Out);
-    assertEq(action.amountOwedToPool, 0); // expected to always be 0 because can't calculate precise amount of collateral to receive from redemption
-  }
-
-  function test_determineAction_whenToken1DebtPoolPriceAboveAndRedemptionFeeGreaterIncentive_shouldContractAndBringPriceCloserToOraclePrice()
-    public
-    fpmmToken1Debt(18, 6)
-    addFpmm(0, 50, 9000)
-  {
-    uint256 reserve0 = 555_555 * 1e6; // 555555 usd.m
-    uint256 reserve1 = 43_629_738 * 1e18; // php.m 750k in $
-
-    LQ.Context memory ctx = _createContextWithTokenOrder({
-      reserveDen: reserve0 * 1e12, // reserve token 0 usd.m
-      reserveNum: reserve1, // reserve token 1 php.m
-      oracleNum: 1e18,
-      oracleDen: 17190990000000000,
-      poolPriceAbove: true,
-      incentiveBps: 50,
-      isToken0Debt: false
-    });
-
-    mockRedemptionRateWithDecay(0.0025 * 1e18); // 0.25%
-    uint256 totalSupply = calculateTargetSupply(0.005 * 1e18, ctx); // 0.5% resulting in redemption fee being 0.25% + 0.5% = 0.75%
-    setDebtTokenTotalSupply(totalSupply);
-
-    LQ.Action memory action = strategy.determineAction(ctx);
-
-    uint256 expectedAmount0Out = 0;
-    // amount out in token 1 := (OD*RN - ON*RD)/(OD*(2-i)) = 5_670_726.837208791926748374
-    // since redemption fee for target amount is greater than incentive.
-    // we will redeem an amount that results in a redemption fee equal to incentive.
-    // maximum amount that can be redeemed is: totalSupply * redemptionBeta * (incentive - decayedBaseFee) =
-    // = 1134145367441758385349674800 * 1 * (0.005 - 0.0025) =  2_835_363.418604395963374187
-    uint256 expectedAmount1Out = 2835363418604395963374187;
-
-    assertEq(action.dir, LQ.Direction.Contract);
-    assertEq(action.amount0Out, expectedAmount0Out);
-    assertEq(action.amount1Out, expectedAmount1Out);
-    assertEq(action.amountOwedToPool, 0); // expected to always be 0 because can't calculate precise amount of collateral to receive from redemption
-  }
-
-  /* ============================================================ */
-  /* ================ Redemption Fee Edge Cases ================ */
-  /* ============================================================ */
-
-  function test_determineAction_whenRedemptionFeeExceedsIncentive_shouldRevert()
-    public
-    fpmmToken0Debt(18, 18)
-    addFpmm(0, 50, 9000)
-  {
-    // Setup: Redemption fee is higher than incentive
-    LQ.Context memory ctx = _createContext({
-      reserveDen: 1_500_000e18,
-      reserveNum: 1_000_000e18,
-      oracleNum: 1e18,
-      oracleDen: 1e18,
-      poolPriceAbove: false,
-      incentiveBps: 50 // 0.5% incentive
-    });
-
-    // Mock redemption rate at 0.6% (higher than 0.5% incentive)
-    mockRedemptionRateWithDecay(0.006 * 1e18);
-
-    setDebtTokenTotalSupply(1_000_000_000e18);
-    mockCollateralRegistryOracleRate(ctx.prices.oracleNum, ctx.prices.oracleDen);
-
-    // Should revert because redemption fee exceeds incentive
-    vm.expectRevert();
-    strategy.determineAction(ctx);
+    assertEq(action.amountOwedToPool, expectedAmountOwedToPool);
+    assertIncentive(
+      ctx.incentives.liquiditySourceIncentiveBpsContraction + ctx.incentives.protocolIncentiveBpsContraction,
+      false,
+      expectedAmount1Out * (1e18 / ctx.token1Dec),
+      expectedAmountOwedToPool,
+      ctx.prices.oracleNum,
+      ctx.prices.oracleDen
+    );
   }
 }

--- a/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_Admin.t.sol
+++ b/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_Admin.t.sol
@@ -36,7 +36,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       address(mockCollateralRegistry),
       mockSystemParams,
       9000, // stabilityPoolPercentage (90%)
-      100 // maxIterations
+      100, // maxIterations
+      25, // troveOwnerRedemptionFee
+      25 // protocolRedemptionFee
     );
 
     // Verify pool is registered
@@ -66,7 +68,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       address(mockCollateralRegistry),
       mockSystemParams,
       9000,
-      100
+      100,
+      25,
+      25
     );
   }
 
@@ -85,7 +89,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       address(mockCollateralRegistry),
       mockSystemParams,
       0, // Invalid: 0%
-      100
+      100,
+      25,
+      25
     );
   }
 
@@ -104,7 +110,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       address(mockCollateralRegistry),
       mockSystemParams,
       10000, // Invalid: 100%
-      100
+      100,
+      25,
+      25
     );
   }
 
@@ -122,7 +130,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       address(0), // Invalid
       mockSystemParams,
       9000,
-      100
+      100,
+      25,
+      25
     );
   }
 
@@ -140,7 +150,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       address(mockCollateralRegistry),
       mockSystemParams,
       9000,
-      100
+      100,
+      25,
+      25
     );
   }
 
@@ -197,7 +209,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       collateralRegistry: address(newCollateralRegistry),
       systemParams: newSystemParams,
       stabilityPoolPercentage: 8000, // 80%
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
 
     vm.prank(owner);
@@ -218,7 +232,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       collateralRegistry: address(mockCollateralRegistry),
       systemParams: mockSystemParams,
       stabilityPoolPercentage: 8000,
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
 
     vm.expectRevert("Ownable: caller is not the owner");
@@ -232,7 +248,9 @@ contract CDPLiquidityStrategy_AdminTest is CDPLiquidityStrategy_BaseTest {
       collateralRegistry: address(mockCollateralRegistry),
       systemParams: mockSystemParams,
       stabilityPoolPercentage: 8000,
-      maxIterations: 100
+      maxIterations: 100,
+      troveOwnerRedemptionFee: 25,
+      protocolRedemptionFee: 25
     });
 
     vm.expectRevert("LS_POOL_NOT_FOUND()");

--- a/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_BaseTest.sol
@@ -55,7 +55,9 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
       address(mockCollateralRegistry),
       mockSystemParams,
       stabilityPoolPercentage,
-      100 // maxIterations
+      100, // maxIterations
+      25, // troveOwnerRedemptionFee
+      25 // protocolRedemptionFee
     );
     _;
   }

--- a/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_BaseTest.sol
@@ -14,7 +14,6 @@ import { MockStabilityPool } from "test/utils/mocks/MockStabilityPool.sol";
 import { MockCollateralRegistry } from "test/utils/mocks/MockCollateralRegistry.sol";
 
 import { ISystemParams } from "bold/src/Interfaces/ISystemParams.sol";
-
 import { MockERC20 } from "test/utils/mocks/MockERC20.sol";
 
 contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
@@ -32,59 +31,48 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
 
     // Create mock SystemParams address
     mockSystemParams = makeAddr("SystemParams");
-    // Mock REDEMPTION_BETA to return 1 (default value)
-    mockRedemptionBeta(1);
     setMockSystemParamsMinBoldAfterRebalance(0);
   }
 
-  modifier addFpmm(uint64 cooldown, uint32 incentiveBps, uint256 stabilityPoolPercentage) {
+  modifier addFpmm(
+    uint64 cooldown,
+    uint16 stabilityPoolPercentage,
+    uint16 maxIterations,
+    uint16 liquiditySourceIncentiveBpsContraction,
+    uint16 protocolIncentiveBpsContraction,
+    uint16 liquiditySourceIncentiveBpsExpansion,
+    uint16 protocolIncentiveBpsExpansion
+  ) {
     // Deploy collateral registry mock
     mockCollateralRegistry = new MockCollateralRegistry(debtToken, collToken);
 
     // Deploy stability pool mock
-    mockStabilityPool = new MockStabilityPool(debtToken, collToken);
+    mockStabilityPool = new MockStabilityPool(debtToken, collToken, mockSystemParams);
+
+    ICDPLiquidityStrategy.AddPoolParams memory params = ICDPLiquidityStrategy.AddPoolParams({
+      pool: address(fpmm),
+      debtToken: debtToken,
+      cooldown: cooldown,
+      liquiditySourceIncentiveBpsExpansion: liquiditySourceIncentiveBpsExpansion,
+      protocolIncentiveBpsExpansion: protocolIncentiveBpsExpansion,
+      liquiditySourceIncentiveBpsContraction: liquiditySourceIncentiveBpsContraction,
+      protocolIncentiveBpsContraction: protocolIncentiveBpsContraction,
+      protocolFeeRecipient: protocolFeeRecipient,
+      stabilityPool: address(mockStabilityPool),
+      collateralRegistry: address(mockCollateralRegistry),
+      stabilityPoolPercentage: stabilityPoolPercentage,
+      maxIterations: maxIterations
+    });
 
     // Add pool to strategy with CDP-specific configuration
     vm.prank(owner);
-    strategy.addPool(
-      address(fpmm),
-      debtToken,
-      cooldown,
-      incentiveBps,
-      address(mockStabilityPool),
-      address(mockCollateralRegistry),
-      mockSystemParams,
-      stabilityPoolPercentage,
-      100, // maxIterations
-      25, // troveOwnerRedemptionFee
-      25 // protocolRedemptionFee
-    );
+    strategy.addPool(params);
     _;
   }
 
   /* ============================================================ */
   /* ================= Helper Functions ========================= */
   /* ============================================================ */
-
-  /**
-   * @notice Mock the collateral registry redemption rate with decay
-   * @param redemptionRate The redemption rate (base rate) in 18 decimals
-   */
-  function mockRedemptionRateWithDecay(uint256 redemptionRate) internal {
-    mockCollateralRegistry.setRedemptionRateWithDecay(redemptionRate);
-  }
-
-  /**
-   * @notice Mock the system params redemption beta
-   * @param redemptionBeta The redemption beta value
-   */
-  function mockRedemptionBeta(uint256 redemptionBeta) internal {
-    vm.mockCall(
-      mockSystemParams,
-      abi.encodeWithSelector(ISystemParams.REDEMPTION_BETA.selector),
-      abi.encode(redemptionBeta)
-    );
-  }
 
   /**
    * @notice Mock the collateral registry oracle rate
@@ -124,7 +112,7 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
    * @param oracleNum Oracle price numerator
    * @param oracleDen Oracle price denominator
    * @param poolPriceAbove Whether pool price is above oracle price
-   * @param incentiveBps Incentive in basis points
+   * @param incentives The incentives for the rebalance
    */
   function _createContext(
     uint256 reserveDen,
@@ -132,7 +120,7 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
     uint256 oracleNum,
     uint256 oracleDen,
     bool poolPriceAbove,
-    uint256 incentiveBps
+    LQ.RebalanceIncentives memory incentives
   ) internal view returns (LQ.Context memory) {
     return
       _createContextWithDecimals(
@@ -141,9 +129,9 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
         oracleNum,
         oracleDen,
         poolPriceAbove,
-        incentiveBps,
         1e18, // 18 decimals for token0
-        1e18 // 18 decimals for token1
+        1e18, // 18 decimals for token1
+        incentives
       );
   }
 
@@ -156,21 +144,26 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
     uint256 oracleNum,
     uint256 oracleDen,
     bool poolPriceAbove,
-    uint256 incentiveBps,
     uint256 token0Dec,
-    uint256 token1Dec
+    uint256 token1Dec,
+    LQ.RebalanceIncentives memory incentives
   ) internal view returns (LQ.Context memory) {
     return
       LQ.Context({
         pool: address(fpmm),
         reserves: LQ.Reserves({ reserveNum: reserveNum, reserveDen: reserveDen }),
-        prices: LQ.Prices({ oracleNum: oracleNum, oracleDen: oracleDen, poolPriceAbove: poolPriceAbove, diffBps: 0 }),
-        incentiveBps: uint128(incentiveBps),
-        token0Dec: uint64(token0Dec),
-        token1Dec: uint64(token1Dec),
+        prices: LQ.Prices({
+          oracleNum: oracleNum,
+          oracleDen: oracleDen,
+          poolPriceAbove: poolPriceAbove,
+          rebalanceThreshold: 500
+        }),
         token0: debtToken,
         token1: collToken,
-        isToken0Debt: true
+        token0Dec: uint64(token0Dec),
+        token1Dec: uint64(token1Dec),
+        isToken0Debt: true,
+        incentives: incentives
       });
   }
 
@@ -183,8 +176,8 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
     uint256 oracleNum,
     uint256 oracleDen,
     bool poolPriceAbove,
-    uint256 incentiveBps,
-    bool isToken0Debt
+    bool isToken0Debt,
+    LQ.RebalanceIncentives memory incentives
   ) internal view returns (LQ.Context memory) {
     uint256 token0Dec = 10 ** (isToken0Debt ? IERC20(debtToken).decimals() : IERC20(collToken).decimals());
     uint256 token1Dec = 10 ** (isToken0Debt ? IERC20(collToken).decimals() : IERC20(debtToken).decimals());
@@ -192,13 +185,18 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
       LQ.Context({
         pool: address(fpmm),
         reserves: LQ.Reserves({ reserveNum: reserveNum, reserveDen: reserveDen }),
-        prices: LQ.Prices({ oracleNum: oracleNum, oracleDen: oracleDen, poolPriceAbove: poolPriceAbove, diffBps: 0 }),
-        incentiveBps: uint128(incentiveBps),
-        token0Dec: uint64(token0Dec),
-        token1Dec: uint64(token1Dec),
+        prices: LQ.Prices({
+          oracleNum: oracleNum,
+          oracleDen: oracleDen,
+          poolPriceAbove: poolPriceAbove,
+          rebalanceThreshold: 500
+        }),
         token0: isToken0Debt ? debtToken : collToken,
         token1: isToken0Debt ? collToken : debtToken,
-        isToken0Debt: isToken0Debt
+        token0Dec: uint64(token0Dec),
+        token1Dec: uint64(token1Dec),
+        isToken0Debt: isToken0Debt,
+        incentives: incentives
       });
   }
 
@@ -276,8 +274,7 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
     uint256 amountOut,
     uint256 amountIn,
     uint256 oracleNum,
-    uint256 oracleDen,
-    bool isCheapContraction
+    uint256 oracleDen
   ) internal {
     uint256 amountOutInOtherToken;
     if (isToken0Out) {
@@ -286,14 +283,11 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
       amountOutInOtherToken = (amountOut * oracleDen) / oracleNum;
     }
     uint256 actualIncentive = ((amountOutInOtherToken - amountIn) * 10_000) / amountOutInOtherToken;
-
     // Allow 1bp difference due to rounding
-    // we allow 1bp difference due to rounding
-    if (isCheapContraction) {
-      assert(actualIncentive <= expectedIncentiveBps);
-    } else {
-      assertApproxEqAbs(actualIncentive, expectedIncentiveBps, 1);
-    }
+    assertTrue(
+      actualIncentive == expectedIncentiveBps || actualIncentive == expectedIncentiveBps - 1,
+      "Incentive should be equal to expected incentive or 1 bps less"
+    );
   }
 
   /**
@@ -347,14 +341,8 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
    * @param amountTakenOut Amount of the token taken out
    * @param amountAdded Amount of the token added
    * @param isToken0Out True if the token taken out is token0, false otherwise
-   * @param isCheapContraction True if the rebalance is a cheap contraction (contraction with less than 50bps)
    */
-  function assertRebalanceAmountIncentives(
-    uint256 amountTakenOut,
-    uint256 amountAdded,
-    bool isToken0Out,
-    bool isCheapContraction
-  ) public {
+  function assertRebalanceAmountIncentives(uint256 amountTakenOut, uint256 amountAdded, bool isToken0Out) public {
     (uint256 rateNumerator, uint256 rateDenominator, , , , ) = fpmm.getPrices();
 
     uint256 token0Scaler = 10 ** MockERC20(fpmm.token0()).decimals();
@@ -368,13 +356,18 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
     }
     uint256 bpsDifference = ((amountTakenOut - amountInInTokenOut) * 10_000) / amountTakenOut;
 
-    // 50 bps is the max but for contractions the amount can be less depending on the redemption rate
-    if (isCheapContraction) {
-      assertTrue(bpsDifference < 50); // 0.5%
-    } else {
-      // we allow for a difference of 1 due to rounding when token decimals differ
-      assertApproxEqAbs(bpsDifference, 50, 1); // 0.5%
-    }
+    // we allow for a difference of 1 due to rounding when token decimals differ
+    assertApproxEqAbs(bpsDifference, 50, 1); // 0.5%
+  }
+
+  function assertIncentive(
+    uint256 amountTakenOut,
+    uint256 incentiveRecipientBalanceDifference,
+    uint256 incentiveBps
+  ) public {
+    uint256 incentive = (amountTakenOut * incentiveBps) / 10_000;
+    // allowing 1000 wei difference due to rounding
+    assertApproxEqAbs(incentiveRecipientBalanceDifference, incentive, 1000);
   }
 
   function convertWithRateAndScale(
@@ -397,14 +390,22 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
   ) internal view returns (uint256 desiredStabilityPoolBalance) {
     uint256 targetStabilityPoolBalance;
 
+    uint256 totalIncentiveBps = ctx.incentives.liquiditySourceIncentiveBpsExpansion +
+      ctx.incentives.protocolIncentiveBpsExpansion;
+
     if (ctx.prices.poolPriceAbove) {
-      uint256 numerator = ctx.prices.oracleDen *
-        ctx.reserves.reserveNum -
-        ctx.prices.oracleNum *
-        ctx.reserves.reserveDen;
-      uint256 denominator = (ctx.prices.oracleDen * (2 * LQ.BASIS_POINTS_DENOMINATOR - ctx.incentiveBps)) /
+      uint256 targetNumerator = (ctx.prices.oracleNum * (LQ.BASIS_POINTS_DENOMINATOR + ctx.prices.rebalanceThreshold)) /
         LQ.BASIS_POINTS_DENOMINATOR;
-      uint256 amountOut = LQ.convertWithRateScaling(1, 1e18, ctx.token1Dec, numerator, denominator);
+      uint256 targetDenominator = ctx.prices.oracleDen;
+
+      uint256 numerator = targetDenominator * ctx.reserves.reserveNum - targetNumerator * ctx.reserves.reserveDen;
+      uint256 denominator = (ctx.prices.oracleDen *
+        (LQ.BASIS_POINTS_DENOMINATOR - totalIncentiveBps) *
+        targetNumerator) /
+        (LQ.BASIS_POINTS_DENOMINATOR * ctx.prices.oracleNum) +
+        targetDenominator;
+
+      uint256 amountOut = LQ.scaleFromTo(numerator, denominator, 1e18, ctx.token1Dec);
 
       targetStabilityPoolBalance = LQ.convertWithRateScalingAndFee(
         amountOut,
@@ -412,18 +413,22 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
         ctx.token0Dec,
         ctx.prices.oracleDen,
         ctx.prices.oracleNum,
-        LQ.BASIS_POINTS_DENOMINATOR - ctx.incentiveBps,
+        LQ.BASIS_POINTS_DENOMINATOR - totalIncentiveBps,
         LQ.BASIS_POINTS_DENOMINATOR
       );
     } else {
-      uint256 numerator = ctx.prices.oracleNum *
-        ctx.reserves.reserveDen -
-        ctx.prices.oracleDen *
-        ctx.reserves.reserveNum;
-      uint256 denominator = (ctx.prices.oracleNum * (2 * LQ.BASIS_POINTS_DENOMINATOR - ctx.incentiveBps)) /
+      uint256 targetNumerator = (ctx.prices.oracleNum * (LQ.BASIS_POINTS_DENOMINATOR - ctx.prices.rebalanceThreshold)) /
         LQ.BASIS_POINTS_DENOMINATOR;
+      uint256 targetDenominator = ctx.prices.oracleDen;
 
-      uint256 amountOut = LQ.convertWithRateScaling(1, 1e18, ctx.token0Dec, numerator, denominator);
+      uint256 numerator = targetNumerator * ctx.reserves.reserveDen - targetDenominator * ctx.reserves.reserveNum;
+      uint256 denominator = (ctx.prices.oracleNum *
+        (LQ.BASIS_POINTS_DENOMINATOR - totalIncentiveBps) *
+        targetDenominator) /
+        (LQ.BASIS_POINTS_DENOMINATOR * ctx.prices.oracleDen) +
+        targetNumerator;
+
+      uint256 amountOut = LQ.scaleFromTo(numerator, denominator, 1e18, ctx.token0Dec);
 
       targetStabilityPoolBalance = LQ.convertWithRateScalingAndFee(
         amountOut,
@@ -431,7 +436,7 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
         ctx.token1Dec,
         ctx.prices.oracleNum,
         ctx.prices.oracleDen,
-        LQ.BASIS_POINTS_DENOMINATOR - ctx.incentiveBps,
+        LQ.BASIS_POINTS_DENOMINATOR - totalIncentiveBps,
         LQ.BASIS_POINTS_DENOMINATOR
       );
     }
@@ -446,48 +451,19 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
   }
 
   /**
-   * @notice Calculate the target supply such that the redemption fraction is equal to the target fraction
-   * @param targetFraction the redemption fraction to target
-   * @return targetSupply
+   * @notice Expect an ERC20 transfer event from the strategy
+   * @param token The token address
+   * @param to The recipient address
+   * @param amount The amount to be transferred
    */
-  function calculateTargetSupply(
-    uint256 targetFraction,
-    LQ.Context memory ctx
-  ) internal view returns (uint256 targetSupply) {
-    uint256 amountOut;
-    if (ctx.prices.poolPriceAbove) {
-      uint256 numerator = ctx.prices.oracleDen *
-        ctx.reserves.reserveNum -
-        ctx.prices.oracleNum *
-        ctx.reserves.reserveDen;
-      uint256 denominator = (ctx.prices.oracleDen * (2 * LQ.BASIS_POINTS_DENOMINATOR - ctx.incentiveBps)) /
-        LQ.BASIS_POINTS_DENOMINATOR;
-      amountOut = LQ.convertWithRateScaling(1, 1e18, ctx.token1Dec, numerator, denominator);
-    } else {
-      uint256 numerator = ctx.prices.oracleNum *
-        ctx.reserves.reserveDen -
-        ctx.prices.oracleDen *
-        ctx.reserves.reserveNum;
-      uint256 denominator = (ctx.prices.oracleNum * (2 * LQ.BASIS_POINTS_DENOMINATOR - ctx.incentiveBps)) /
-        LQ.BASIS_POINTS_DENOMINATOR;
-
-      amountOut = LQ.convertWithRateScaling(1, 1e18, ctx.token0Dec, numerator, denominator);
-    }
-
-    targetSupply = (amountOut * 1e18) / targetFraction;
+  function expectERC20Transfer(address token, address to, uint256 amount) internal {
+    vm.expectEmit(true, true, false, true, token);
+    emit Transfer(address(strategy), to, amount);
   }
 
-  function calculatedExpectedCollateralReceivedFromRedemption(
-    uint256 debtAmount,
-    LQ.Context memory ctx
-  ) internal view returns (uint256 expectedCollateralReceived) {
-    address debtToken = ctx.isToken0Debt ? ctx.token0 : ctx.token1;
-    uint256 baseFee = mockCollateralRegistry.getRedemptionRateWithDecay();
+  /* ============================================================ */
+  /* ======================= Events ============================= */
+  /* ============================================================ */
 
-    uint256 redemptionFee = baseFee + ((debtAmount * 1e18) / IERC20(debtToken).totalSupply());
-
-    expectedCollateralReceived = LQ.convertToCollateralWithFee(ctx, debtAmount, 1e18 - redemptionFee, 1e18);
-
-    return expectedCollateralReceived;
-  }
+  event Transfer(address indexed from, address indexed to, uint256 value);
 }

--- a/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/CDPLiquidityStrategy/CDPLiquidityStrategy_BaseTest.sol
@@ -7,6 +7,7 @@ import { LiquidityStrategy_BaseTest } from "../LiquidityStrategy/LiquidityStrate
 import { CDPLiquidityStrategyHarness } from "test/utils/harnesses/CDPLiquidityStrategyHarness.sol";
 
 import { ICDPLiquidityStrategy } from "contracts/interfaces/ICDPLiquidityStrategy.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
 import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
 import { IERC20 } from "contracts/interfaces/IERC20.sol";
 
@@ -49,15 +50,17 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
     // Deploy stability pool mock
     mockStabilityPool = new MockStabilityPool(debtToken, collToken, mockSystemParams);
 
-    ICDPLiquidityStrategy.AddPoolParams memory params = ICDPLiquidityStrategy.AddPoolParams({
-      pool: address(fpmm),
-      debtToken: debtToken,
-      cooldown: cooldown,
-      liquiditySourceIncentiveBpsExpansion: liquiditySourceIncentiveBpsExpansion,
-      protocolIncentiveBpsExpansion: protocolIncentiveBpsExpansion,
-      liquiditySourceIncentiveBpsContraction: liquiditySourceIncentiveBpsContraction,
-      protocolIncentiveBpsContraction: protocolIncentiveBpsContraction,
-      protocolFeeRecipient: protocolFeeRecipient,
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      cooldown,
+      liquiditySourceIncentiveBpsExpansion,
+      protocolIncentiveBpsExpansion,
+      liquiditySourceIncentiveBpsContraction,
+      protocolIncentiveBpsContraction,
+      protocolFeeRecipient
+    );
+    ICDPLiquidityStrategy.CDPConfig memory config = ICDPLiquidityStrategy.CDPConfig({
       stabilityPool: address(mockStabilityPool),
       collateralRegistry: address(mockCollateralRegistry),
       stabilityPoolPercentage: stabilityPoolPercentage,
@@ -66,7 +69,7 @@ contract CDPLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
 
     // Add pool to strategy with CDP-specific configuration
     vm.prank(owner);
-    strategy.addPool(params);
+    strategy.addPool(params, config);
     _;
   }
 

--- a/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy.t.sol
+++ b/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy.t.sol
@@ -25,58 +25,128 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
   /* ============================================================ */
 
   function test_addPool_whenValidParams_shouldAddPool() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.expectEmit(true, true, true, true);
-    emit PoolAdded(address(fpmm), true, 3600);
+    emit PoolAdded(address(fpmm), params);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     assertTrue(strategy.isPoolRegistered(address(fpmm)));
   }
 
   function test_addPool_whenPoolIsZero_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(0),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_MUST_BE_SET.selector);
-    strategy.addPool(address(0), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_addPool_whenPoolAlreadyExists_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_ALREADY_EXISTS.selector);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_addPool_whenCalledByNonOwner_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(notOwner);
     vm.expectRevert();
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_addPool_whenDebtTokenNotInPool_shouldRevert() public fpmmToken0Debt(18, 18) {
     // Create a random token that's not in the pool
     address wrongToken = address(new MockERC20("WrongToken", "WT", 18));
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      wrongToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_DEBT_TOKEN_NOT_IN_POOL.selector);
-    strategy.addPool(address(fpmm), wrongToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_addPool_whenDebtTokenNotInPoolAndToken1Debt_shouldRevert() public fpmmToken1Debt(18, 18) {
     // Create a random token that's not in the pool
     address wrongToken = address(new MockERC20("WrongToken", "WT", 18));
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      wrongToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_DEBT_TOKEN_NOT_IN_POOL.selector);
-    strategy.addPool(address(fpmm), wrongToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_removePool_whenPoolExists_shouldRemovePool() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     // Add pool first
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // Remove it
     vm.expectEmit(true, false, false, false);
@@ -95,9 +165,19 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
   }
 
   function test_setRebalanceCooldown_whenPoolExists_shouldUpdateCooldown() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     // Add pool
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // Update cooldown
     vm.expectEmit(true, false, false, true);
@@ -117,8 +197,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     // Provide liquidity with pool price 10% above oracle (110:100 reserves)
     provideFPMMReserves(100e18, 110e18, true);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -136,8 +226,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     // Provide liquidity with pool price 10% below oracle (100:90 reserves)
     provideFPMMReserves(100e18, 90e18, true);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -156,8 +256,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     // Provide liquidity with pool price 10% above oracle (110:100 reserves for token0:token1)
     provideFPMMReserves(100e18, 110e18, false);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -176,8 +286,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     // Provide liquidity with pool price 10% below oracle (90:100 reserves for token0:token1)
     provideFPMMReserves(100e18, 90e18, false);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -195,8 +315,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     // Provide liquidity with pool price 10% above oracle
     provideFPMMReserves(100e6, 110e18, true); // debt has 6 decimals, collateral has 18
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     (, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -214,8 +344,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 110e18, true);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // First rebalance
     vm.prank(owner);
@@ -237,8 +377,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 105e18, true); // threshold is 5% of oracle price
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE.selector);
@@ -252,8 +402,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 95e18, true); // threshold is 5% of oracle price
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE.selector);
@@ -267,8 +427,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 10501e16, true); // price difference is 5.01% of oracle price
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     vm.expectEmit(true, true, false, false);
     emit LiquidityMoved(address(fpmm), LQ.Direction.Expand, address(0), 0, address(0), 0);
@@ -282,8 +452,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 9499e16, true); // price difference is 5.01% of oracle price
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     vm.expectEmit(true, true, false, false);
     emit LiquidityMoved(address(fpmm), LQ.Direction.Contract, address(0), 0, address(0), 0);
@@ -294,8 +474,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 110e18, true);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // First rebalance
     vm.prank(owner);
@@ -317,8 +507,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 110e18, true);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      0,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient); // 0 cooldown
+    strategy.addPool(params); // 0 cooldown
 
     // Expect LiquidityMoved event (only checking indexed fields)
     vm.expectEmit(true, true, false, false);
@@ -336,16 +536,36 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 110e18, true);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      0,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     vm.prank(owner);
     strategy.rebalance(address(fpmm));
   }
 
   function test_hook_whenCalledFromNonPool_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      0,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // Try to call hook from non-pool address
     bytes memory hookData = abi.encode(
@@ -364,8 +584,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
   }
 
   function test_hook_whenSenderIsNotStrategy_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      0,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     bytes memory hookData = abi.encode(
       LQ.CallbackData({
@@ -387,8 +617,18 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 110e18, true);
 
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      0,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // First transaction - should succeed
     vm.prank(owner);
@@ -452,9 +692,30 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     MockERC20(debtToken2).mint(address(strategy), 1000000e18);
     MockERC20(collToken2).mint(address(strategy), 1000000e18);
 
+    ILiquidityStrategy.AddPoolParams memory params1 = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      0,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
+    ILiquidityStrategy.AddPoolParams memory params2 = _buildAddPoolParams(
+      address(fpmm2),
+      debtToken2,
+      0,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
+
     vm.startPrank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
-    strategy.addPool(address(fpmm2), debtToken2, 0, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params1);
+    strategy.addPool(params2);
 
     // Should be able to rebalance both pools in the same transaction
     // Each pool tracks its own transient storage flag

--- a/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy.t.sol
+++ b/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy.t.sol
@@ -26,10 +26,10 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
 
   function test_addPool_whenValidParams_shouldAddPool() public fpmmToken0Debt(18, 18) {
     vm.expectEmit(true, true, true, true);
-    emit PoolAdded(address(fpmm), true, 3600, 50);
+    emit PoolAdded(address(fpmm), true, 3600);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     assertTrue(strategy.isPoolRegistered(address(fpmm)));
   }
@@ -37,22 +37,22 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
   function test_addPool_whenPoolIsZero_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_MUST_BE_SET.selector);
-    strategy.addPool(address(0), debtToken, 3600, 50);
+    strategy.addPool(address(0), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
   function test_addPool_whenPoolAlreadyExists_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_ALREADY_EXISTS.selector);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
   function test_addPool_whenCalledByNonOwner_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(notOwner);
     vm.expectRevert();
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
   function test_addPool_whenDebtTokenNotInPool_shouldRevert() public fpmmToken0Debt(18, 18) {
@@ -61,22 +61,22 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_DEBT_TOKEN_NOT_IN_POOL.selector);
-    strategy.addPool(address(fpmm), wrongToken, 3600, 50);
+    strategy.addPool(address(fpmm), wrongToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
-  function test_addPool_whenDebtTokenNotInPoolandToken1Debt_shouldRevert() public fpmmToken1Debt(18, 18) {
+  function test_addPool_whenDebtTokenNotInPoolAndToken1Debt_shouldRevert() public fpmmToken1Debt(18, 18) {
     // Create a random token that's not in the pool
     address wrongToken = address(new MockERC20("WrongToken", "WT", 18));
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_DEBT_TOKEN_NOT_IN_POOL.selector);
-    strategy.addPool(address(fpmm), wrongToken, 3600, 50);
+    strategy.addPool(address(fpmm), wrongToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
   function test_removePool_whenPoolExists_shouldRemovePool() public fpmmToken0Debt(18, 18) {
     // Add pool first
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     // Remove it
     vm.expectEmit(true, false, false, false);
@@ -97,7 +97,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
   function test_setRebalanceCooldown_whenPoolExists_shouldUpdateCooldown() public fpmmToken0Debt(18, 18) {
     // Add pool
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     // Update cooldown
     vm.expectEmit(true, false, false, true);
@@ -118,7 +118,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 110e18, true);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -137,7 +137,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 90e18, true);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -157,7 +157,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 110e18, false);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -177,7 +177,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 90e18, false);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     (LQ.Context memory ctx, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -196,7 +196,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e6, 110e18, true); // debt has 6 decimals, collateral has 18
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     (, LQ.Action memory action) = strategy.determineAction(address(fpmm));
 
@@ -215,7 +215,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 110e18, true);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     // First rebalance
     vm.prank(owner);
@@ -230,12 +230,72 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     strategy.rebalance(address(fpmm));
   }
 
+  function test_rebalance_whenPoolPriceAboveOraclePriceButDifferenceBelowThreshold_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+  {
+    setOracleRate(1e18, 1e18);
+    provideFPMMReserves(100e18, 105e18, true); // threshold is 5% of oracle price
+
+    vm.prank(owner);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+
+    vm.prank(owner);
+    vm.expectRevert(ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE.selector);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenPoolPriceBelowOraclePriceButDifferenceBelowThreshold_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+  {
+    setOracleRate(1e18, 1e18);
+    provideFPMMReserves(100e18, 95e18, true); // threshold is 5% of oracle price
+
+    vm.prank(owner);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+
+    vm.prank(owner);
+    vm.expectRevert(ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE.selector);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenPoolPriceAboveOraclePriceButDifferenceAboveThreshold_shouldSucceed()
+    public
+    fpmmToken0Debt(18, 18)
+  {
+    setOracleRate(1e18, 1e18);
+    provideFPMMReserves(100e18, 10501e16, true); // price difference is 5.01% of oracle price
+
+    vm.prank(owner);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Expand, address(0), 0, address(0), 0);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenPoolPriceBelowOraclePriceButDifferenceAboveThreshold_shouldSucceed()
+    public
+    fpmmToken0Debt(18, 18)
+  {
+    setOracleRate(1e18, 1e18);
+    provideFPMMReserves(100e18, 9499e16, true); // price difference is 5.01% of oracle price
+
+    vm.prank(owner);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Contract, address(0), 0, address(0), 0);
+    strategy.rebalance(address(fpmm));
+  }
+
   function test_rebalance_afterCooldown_shouldSucceed() public fpmmToken0Debt(18, 18) {
     setOracleRate(1e18, 1e18);
     provideFPMMReserves(100e18, 110e18, true);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     // First rebalance
     vm.prank(owner);
@@ -246,7 +306,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     vm.warp(block.timestamp + 3601);
 
     // Create new imbalance
-    swapIn(debtToken, 5e18);
+    swapIn(debtToken, 6e18);
 
     // Second rebalance should succeed
     vm.prank(owner);
@@ -258,7 +318,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 110e18, true);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 50); // 0 cooldown
+    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient); // 0 cooldown
 
     // Expect LiquidityMoved event (only checking indexed fields)
     vm.expectEmit(true, true, false, false);
@@ -277,7 +337,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 110e18, true);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 50);
+    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
 
     vm.prank(owner);
     strategy.rebalance(address(fpmm));
@@ -285,13 +345,12 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
 
   function test_hook_whenCalledFromNonPool_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 50);
+    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
 
     // Try to call hook from non-pool address
     bytes memory hookData = abi.encode(
       LQ.CallbackData({
         amountOwedToPool: 100e18,
-        incentiveBps: 50,
         dir: LQ.Direction.Expand,
         isToken0Debt: true,
         debtToken: debtToken,
@@ -306,12 +365,11 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
 
   function test_hook_whenSenderIsNotStrategy_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 50);
+    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
 
     bytes memory hookData = abi.encode(
       LQ.CallbackData({
         amountOwedToPool: 100e18,
-        incentiveBps: 50,
         dir: LQ.Direction.Expand,
         isToken0Debt: true,
         debtToken: debtToken,
@@ -330,7 +388,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     provideFPMMReserves(100e18, 110e18, true);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 50);
+    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
 
     // First transaction - should succeed
     vm.prank(owner);
@@ -343,7 +401,7 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     strategy.clearTransientStorage(address(fpmm));
 
     // Create a new imbalance by swapping tokens
-    swapIn(debtToken, 5e18);
+    swapIn(debtToken, 6e18);
 
     // Second transaction - transient storage should be cleared
     // So the hook check at the start should NOT revert with LS_CAN_ONLY_REBALANCE_ONCE
@@ -395,8 +453,8 @@ contract LiquidityStrategy_Test is LiquidityStrategy_BaseTest {
     MockERC20(collToken2).mint(address(strategy), 1000000e18);
 
     vm.startPrank(owner);
-    strategy.addPool(address(fpmm), debtToken, 0, 50);
-    strategy.addPool(address(fpmm2), debtToken2, 0, 50);
+    strategy.addPool(address(fpmm), debtToken, 0, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(address(fpmm2), debtToken2, 0, 25, 25, 25, 25, protocolFeeRecipient);
 
     // Should be able to rebalance both pools in the same transaction
     // Each pool tracks its own transient storage flag

--- a/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy_BaseTest.sol
@@ -12,6 +12,7 @@ import { IERC20 } from "openzeppelin-contracts-next/contracts/token/ERC20/IERC20
 
 import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
 import { IOracleAdapter } from "contracts/interfaces/IOracleAdapter.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
 
 /**
  * @title LiquidityStrategy_BaseTest
@@ -172,11 +173,34 @@ abstract contract LiquidityStrategy_BaseTest is Test {
     assertEq(uint256(expected), uint256(given));
   }
 
+  function _buildAddPoolParams(
+    address pool,
+    address _debtToken,
+    uint64 cooldown,
+    uint16 liquiditySourceIncentiveBpsExpansion,
+    uint16 protocolIncentiveBpsExpansion,
+    uint16 liquiditySourceIncentiveBpsContraction,
+    uint16 protocolIncentiveBpsContraction,
+    address _protocolFeeRecipient
+  ) internal pure returns (ILiquidityStrategy.AddPoolParams memory) {
+    return
+      ILiquidityStrategy.AddPoolParams({
+        pool: pool,
+        debtToken: _debtToken,
+        cooldown: cooldown,
+        liquiditySourceIncentiveBpsExpansion: liquiditySourceIncentiveBpsExpansion,
+        protocolIncentiveBpsExpansion: protocolIncentiveBpsExpansion,
+        liquiditySourceIncentiveBpsContraction: liquiditySourceIncentiveBpsContraction,
+        protocolIncentiveBpsContraction: protocolIncentiveBpsContraction,
+        protocolFeeRecipient: _protocolFeeRecipient
+      });
+  }
+
   /* ============================================================ */
   /* ======================= Events ============================= */
   /* ============================================================ */
 
-  event PoolAdded(address indexed pool, bool isToken0Debt, uint64 cooldown);
+  event PoolAdded(address indexed pool, ILiquidityStrategy.AddPoolParams params);
   event PoolRemoved(address indexed pool);
   event RebalanceCooldownSet(address indexed pool, uint64 cooldown);
   event LiquidityMoved(

--- a/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/LiquidityStrategy/LiquidityStrategy_BaseTest.sol
@@ -22,6 +22,8 @@ abstract contract LiquidityStrategy_BaseTest is Test {
   FPMM public fpmm;
   IFPMM.FPMMParams internal defaultFPMMParams;
 
+  uint256 public constant BPS_DENOMINATOR = 10000;
+  address public protocolFeeRecipient = makeAddr("protocolFeeRecipient");
   address public owner = makeAddr("Owner");
   address public notOwner = makeAddr("NotOwner");
   address public debtToken;
@@ -174,7 +176,7 @@ abstract contract LiquidityStrategy_BaseTest is Test {
   /* ======================= Events ============================= */
   /* ============================================================ */
 
-  event PoolAdded(address indexed pool, bool isToken0Debt, uint64 cooldown, uint32 incentiveBps);
+  event PoolAdded(address indexed pool, bool isToken0Debt, uint64 cooldown);
   event PoolRemoved(address indexed pool);
   event RebalanceCooldownSet(address indexed pool, uint64 cooldown);
   event LiquidityMoved(

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_ActionExpansion.t.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_ActionExpansion.t.sol
@@ -18,7 +18,7 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
   function test_determineAction_whenPoolPriceAboveOracle_shouldReturnExpandAction()
     public
     fpmmToken0Debt(18, 18)
-    addFpmm(0, 100)
+    addFpmm(0, 50, 50, 50, 50)
   {
     LQ.Context memory ctx = _createContext({
       reserveDen: 100e18, // token0 reserves
@@ -26,7 +26,12 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
       oracleNum: 1e18,
       oracleDen: 1e18,
       poolPriceAbove: true,
-      incentiveBps: 100 // 1% (capped at FPMM max)
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveBpsExpansion: 50,
+        protocolIncentiveBpsExpansion: 50, // 0.5% + 0.5% = 1% total expansion incentive
+        liquiditySourceIncentiveBpsContraction: 50,
+        protocolIncentiveBpsContraction: 50 // 0.5% + 0.5% = 1% total contraction incentive
+      })
     });
 
     LQ.Action memory action = strategy.determineAction(ctx);
@@ -40,7 +45,7 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
   function test_determineAction_whenPoolPriceAboveOracleWithDifferentDecimals_shouldHandleCorrectly()
     public
     fpmmToken0Debt(18, 18)
-    addFpmm(0, 100)
+    addFpmm(0, 50, 50, 50, 50)
   {
     // Test with 6 decimal token1 and 18 decimal token0
     // Reserves are normalized to 18 decimals: 200 token1 = 200e18 normalized
@@ -50,9 +55,14 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
       oracleNum: 1e18,
       oracleDen: 1e18,
       poolPriceAbove: true,
-      incentiveBps: 100,
       token0Dec: 1e18,
-      token1Dec: 1e6
+      token1Dec: 1e6,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveBpsExpansion: 50,
+        protocolIncentiveBpsExpansion: 50, // 0.5% + 0.5% = 1% total expansion incentive
+        liquiditySourceIncentiveBpsContraction: 50,
+        protocolIncentiveBpsContraction: 50 // 0.5% + 0.5% = 1% total contraction incentive
+      })
     });
 
     LQ.Action memory action = strategy.determineAction(ctx);
@@ -66,7 +76,7 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
   function test_determineAction_whenPoolPriceAboveOracleWithZeroIncentive_shouldReturnCorrectAmounts()
     public
     fpmmToken0Debt(18, 18)
-    addFpmm(0, 0)
+    addFpmm(0, 0, 0, 0, 0)
   {
     LQ.Context memory ctx = _createContext({
       reserveDen: 100e18, // token0 reserves
@@ -74,24 +84,28 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
       oracleNum: 1e18,
       oracleDen: 1e18,
       poolPriceAbove: true,
-      incentiveBps: 0
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveBpsExpansion: 0,
+        protocolIncentiveBpsExpansion: 0,
+        liquiditySourceIncentiveBpsContraction: 0,
+        protocolIncentiveBpsContraction: 0
+      })
     });
 
     LQ.Action memory action = strategy.determineAction(ctx);
 
-    // Formula: X = (OD * RN - ON * RD) / (OD * (2 - i))
-    // X = (1e18 * 200e18 - 1e18 * 100e18) / (1e18 * (20000 - 0) / 10000)
-    // X = 100e18 / 2 = 50e18
-    assertEq(action.amount1Out, 50e18, "Should calculate correct collateral out with zero incentive");
-    // Y = X * OD/ON = 50e18 * 1e18/1e18 = 50e18 (debt flows into pool)
+    // Formula: X = (RN * TD - TN * RD) / (TD + TN * (1 - i) * OD/ON)
+    // X = (200e18 * 1e18 - 1.05e18 * 100e18) / (1e18 + 1.05e18 * (1 - 0) * 1e18/1e18) = 46.341463414634146341e18
+    assertEq(action.amount1Out, 46341463414634146341, "Should calculate correct collateral out with zero incentive");
+    // Y = X * OD/ON * (1 - i) = 46341463414634146341e18 * 1e18/1e18 * (1 - 0) = 46341463414634146341e18
     // In expansion: debt flows in via inputAmount
-    assertEq(action.amountOwedToPool, 50e18, "Should calculate correct debt input amount");
+    assertEq(action.amountOwedToPool, 46341463414634146341, "Should calculate correct debt input amount");
   }
 
   function test_determineAction_whenPoolPriceAboveOracleWithMaxIncentive_shouldReturnCorrectAmounts()
     public
     fpmmToken0Debt(18, 18)
-    addFpmm(0, 100)
+    addFpmm(0, 50, 50, 50, 50)
   {
     LQ.Context memory ctx = _createContext({
       reserveDen: 100e18, // token0 reserves
@@ -99,16 +113,20 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
       oracleNum: 1e18,
       oracleDen: 1e18,
       poolPriceAbove: true,
-      incentiveBps: 10000 // 100%
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveBpsExpansion: 5000,
+        protocolIncentiveBpsExpansion: 5000, // 50% + 50% = 100% total expansion incentive
+        liquiditySourceIncentiveBpsContraction: 5000,
+        protocolIncentiveBpsContraction: 5000 // 50% + 50% = 100% total contraction incentive
+      })
     });
 
     LQ.Action memory action = strategy.determineAction(ctx);
 
-    // Formula: X = (OD * RN - ON * RD) / (OD * (2 - i))
-    // X = (1e18 * 200e18 - 1e18 * 100e18) / (1e18 * (20000 - 10000) / 10000)
-    // X = 100e18 / 1 = 100e18
-    assertEq(action.amount1Out, 100e18, "Should calculate correct collateral out with max incentive");
-    // Y = X * OD/ON * (1 - i) = 100e18 * 1e18/1e18 * (1 - 1) = 0
+    // Formula: X = (RN * TD - TN * RD) / (TD + TN * (1 - i) * OD/ON)
+    // X = (200e18 * 1e18 - 1.05e18 * 100e18) / (1e18 + 1.05e18 * 0 * 1e18/1e18) = 95e18
+    assertEq(action.amount1Out, 95e18, "Should calculate correct collateral out with max incentive");
+    // Y = X * OD/ON * (1 - i) = 95e18 * 1e18/1e18 * (1 - 1) = 0
     // With 100% incentive, all goes to incentive, nothing flows to pool
     assertEq(action.amountOwedToPool, 0, "Should be zero with 100% incentive");
   }
@@ -120,44 +138,56 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
   function test_formulaValidation_whenPPGreaterThanOP_shouldFollowExactFormula()
     public
     fpmmToken0Debt(18, 18)
-    addFpmm(0, 0)
+    addFpmm(0, 0, 0, 0, 0)
   {
-    // PP > OP: X = (OD * RN - ON * RD) / (OD * (2 - i))
-    // Test with specific values that give clean division: RN=400, RD=100, ON=2, OD=1, i=0
+    // PP > OP: X = (RN*TD - TN*RD) / (TD + TN * (1 - i) * OD/ON)
+    // Test with specific values that give clean division: RN=400, RD=100, ON=2, OD=1, i=0, TD=1e18, TN=2.1e18
     LQ.Context memory ctx = _createContext({
       reserveDen: 100e18, // RD (token0)
       reserveNum: 400e18, // RN (token1)
       oracleNum: 2e18, // ON
       oracleDen: 1e18, // OD
       poolPriceAbove: true,
-      incentiveBps: 0 // 0% for clean calculation
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveBpsExpansion: 0,
+        protocolIncentiveBpsExpansion: 0, // 0% total expansion incentive
+        liquiditySourceIncentiveBpsContraction: 0,
+        protocolIncentiveBpsContraction: 0 // 0% total contraction incentive
+      })
     });
 
     LQ.Action memory action = strategy.determineAction(ctx);
 
     // Manual calculation:
-    // X = (1e18 * 400e18 - 2e18 * 100e18) / (1e18 * 2)
-    // X = (400e18 - 200e18) / 2 = 200e18 / 2 = 100e18
-    uint256 expectedX = 100e18;
+    // PP > OP: X = (RN*TD - TN*RD) / (TD + TN * (1 - i) * OD/ON)
+    // X = (400e18 * 1e18 - 2.1e18 * 100e18) / (1e18 + 2.1e18 * 1 * 1e18/2e18) = 92.682926829268292682e18
+    uint256 expectedX = 92682926829268292682;
     assertEq(action.amount1Out, expectedX, "X calculation should match formula");
 
-    // Y = X * OD/ON = 100e18 * 1e18/2e18 = 50e18
-    uint256 expectedY = 50e18;
+    // Y = X * OD/ON = 92682926829268292682 * 1e18/2e18 = 46.341463414634146341e18
+    uint256 expectedY = 46341463414634146341;
     assertEq(action.amountOwedToPool, expectedY, "Y should equal X * OD/ON");
   }
 
-  function test_YRelationship_shouldAlwaysHoldForExpansion() public fpmmToken0Debt(18, 18) addFpmm(0, 100) {
+  function test_YRelationship_shouldAlwaysHoldForExpansion() public fpmmToken0Debt(18, 18) addFpmm(0, 50, 50, 50, 50) {
     // Test Y = X * OD/ON * (1 - i) relationship for expansion (PP > OP)
-    uint256[3] memory incentives = [uint256(0), 100, 100]; // Capped at 1%
+    // total incentives are 0%, 1%, 1%
+    uint16[3] memory liquiditySourceIncentiveBps = [uint16(0), 50, 50]; // 0%, 0.5%, 0.5% liquidity source incentive
+    uint16[3] memory protocolIncentiveBps = [uint16(0), 50, 50]; // 0%, 0.5%, 0.5% protocol incentive
 
-    for (uint256 i = 0; i < incentives.length; i++) {
+    for (uint256 i = 0; i < liquiditySourceIncentiveBps.length; i++) {
       LQ.Context memory ctx = _createContext({
         reserveDen: 150e18, // token0 reserves
         reserveNum: 450e18, // token1 reserves
         oracleNum: 3e18,
         oracleDen: 2e18,
         poolPriceAbove: true,
-        incentiveBps: incentives[i]
+        incentives: LQ.RebalanceIncentives({
+          liquiditySourceIncentiveBpsExpansion: liquiditySourceIncentiveBps[i],
+          protocolIncentiveBpsExpansion: protocolIncentiveBps[i],
+          liquiditySourceIncentiveBpsContraction: liquiditySourceIncentiveBps[i],
+          protocolIncentiveBpsContraction: protocolIncentiveBps[i]
+        })
       });
 
       LQ.Action memory action = strategy.determineAction(ctx);
@@ -166,7 +196,8 @@ contract ReserveLiquidityStrategy_ActionExpansionTest is ReserveLiquidityStrateg
         // Y/X should equal OD/ON * (1 - i) (Y is amountOwedToPool, X is amount1Out) within precision limits
         uint256 calculatedRatio = (action.amountOwedToPool * ctx.prices.oracleNum) / action.amount1Out;
         // Apply incentive multiplier to expected ratio
-        uint256 expectedRatio = (ctx.prices.oracleDen * (10000 - ctx.incentiveBps)) / 10000;
+        uint256 expectedRatio = (ctx.prices.oracleDen *
+          (10000 - (liquiditySourceIncentiveBps[i] + protocolIncentiveBps[i]))) / 10000;
         // Allow for rounding errors (1 wei difference)
         assertApproxEqAbs(calculatedRatio, expectedRatio, 1, "Y/X ratio should approximately equal OD/ON * (1 - i)");
       }

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_Admin.t.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_Admin.t.sol
@@ -83,40 +83,90 @@ contract ReserveLiquidityStrategy_AdminTest is ReserveLiquidityStrategy_BaseTest
   /* ============================================================ */
 
   function test_addPool_whenValidParams_shouldAddPool() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.expectEmit(true, true, true, true);
-    emit PoolAdded(address(fpmm), true, 3600);
+    emit PoolAdded(address(fpmm), params);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     assertTrue(strategy.isPoolRegistered(address(fpmm)));
   }
 
   function test_addPool_whenPoolIsZero_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(0),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_MUST_BE_SET.selector);
-    strategy.addPool(address(0), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_addPool_whenPoolAlreadyExists_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_ALREADY_EXISTS.selector);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_addPool_whenCalledByNonOwner_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     vm.prank(notOwner);
     vm.expectRevert();
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
   }
 
   function test_removePool_whenPoolExists_shouldRemovePool() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     // Add pool first
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // Remove it
     vm.expectEmit(true, false, false, false);
@@ -135,9 +185,19 @@ contract ReserveLiquidityStrategy_AdminTest is ReserveLiquidityStrategy_BaseTest
   }
 
   function test_setRebalanceCooldown_whenPoolExists_shouldUpdateCooldown() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      25,
+      25,
+      25,
+      25,
+      protocolFeeRecipient
+    );
     // Add pool
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
+    strategy.addPool(params);
 
     // Update cooldown
     vm.expectEmit(true, false, false, true);

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_Admin.t.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_Admin.t.sol
@@ -84,10 +84,10 @@ contract ReserveLiquidityStrategy_AdminTest is ReserveLiquidityStrategy_BaseTest
 
   function test_addPool_whenValidParams_shouldAddPool() public fpmmToken0Debt(18, 18) {
     vm.expectEmit(true, true, true, true);
-    emit PoolAdded(address(fpmm), true, 3600, 50);
+    emit PoolAdded(address(fpmm), true, 3600);
 
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     assertTrue(strategy.isPoolRegistered(address(fpmm)));
   }
@@ -95,28 +95,28 @@ contract ReserveLiquidityStrategy_AdminTest is ReserveLiquidityStrategy_BaseTest
   function test_addPool_whenPoolIsZero_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_MUST_BE_SET.selector);
-    strategy.addPool(address(0), debtToken, 3600, 50);
+    strategy.addPool(address(0), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
   function test_addPool_whenPoolAlreadyExists_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     vm.prank(owner);
     vm.expectRevert(ILiquidityStrategy.LS_POOL_ALREADY_EXISTS.selector);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
   function test_addPool_whenCalledByNonOwner_shouldRevert() public fpmmToken0Debt(18, 18) {
     vm.prank(notOwner);
     vm.expectRevert();
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
   }
 
   function test_removePool_whenPoolExists_shouldRemovePool() public fpmmToken0Debt(18, 18) {
     // Add pool first
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     // Remove it
     vm.expectEmit(true, false, false, false);
@@ -137,7 +137,7 @@ contract ReserveLiquidityStrategy_AdminTest is ReserveLiquidityStrategy_BaseTest
   function test_setRebalanceCooldown_whenPoolExists_shouldUpdateCooldown() public fpmmToken0Debt(18, 18) {
     // Add pool
     vm.prank(owner);
-    strategy.addPool(address(fpmm), debtToken, 3600, 50);
+    strategy.addPool(address(fpmm), debtToken, 3600, 25, 25, 25, 25, protocolFeeRecipient);
 
     // Update cooldown
     vm.expectEmit(true, false, false, true);

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_BaseTest.sol
@@ -9,6 +9,7 @@ import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrat
 import { IReserveV2 } from "contracts/interfaces/IReserveV2.sol";
 import { ReserveV2 } from "contracts/swap/ReserveV2.sol";
 import { MockERC20 } from "test/utils/mocks/MockERC20.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
 
 contract ReserveLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
   ReserveLiquidityStrategyHarness public strategy;
@@ -56,8 +57,7 @@ contract ReserveLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
 
     fpmm.setRebalanceIncentive(fpmmIncentive);
 
-    vm.startPrank(owner);
-    strategy.addPool(
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
       address(fpmm),
       debtToken,
       cooldown,
@@ -67,6 +67,9 @@ contract ReserveLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
       protocolIncentiveBpsContraction,
       protocolFeeRecipient
     );
+
+    vm.startPrank(owner);
+    strategy.addPool(params);
     reserve.registerCollateralAsset(collToken);
     reserve.registerStableAsset(debtToken);
     MockERC20(collToken).mint(address(reserve), 1000000e18);

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_Integration.t.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_Integration.t.sol
@@ -9,6 +9,7 @@ import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrat
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { MockERC20 } from "../../../utils/mocks/MockERC20.sol";
 import { FPMM } from "contracts/swap/FPMM.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
 
 contract ReserveLiquidityStrategy_IntegrationTest is ReserveLiquidityStrategy_BaseTest {
   // Test variations for multiple scenarios test
@@ -263,8 +264,18 @@ contract ReserveLiquidityStrategy_IntegrationTest is ReserveLiquidityStrategy_Ba
       vm.stopPrank();
 
       // 4. Add this pool to the strategy
+      ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+        address(testFpmm),
+        _debtToken,
+        100,
+        0,
+        0,
+        0,
+        0,
+        protocolFeeRecipient
+      );
       vm.prank(owner);
-      strategy.addPool(address(testFpmm), _debtToken, 100, 0, 0, 0, 0, protocolFeeRecipient);
+      strategy.addPool(params);
 
       // 5. Mock reserve balance for contraction scenarios
       vm.mockCall(_collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(1000e18));

--- a/test/unit/swap/FPMM/FPMMGetters.t.sol
+++ b/test/unit/swap/FPMM/FPMMGetters.t.sol
@@ -118,4 +118,28 @@ contract FPMMGettersTest is FPMMBaseTest {
     assertEq(priceDifference, 0);
     assertEq(reservePriceAboveOraclePrice, false);
   }
+
+  function test_getPrices2_whenReferenceRateSet_shouldReturnCorrectData()
+    public
+    initializeFPMM_withDecimalTokens(18, 18)
+    mintInitialLiquidity(18, 18)
+    withOracleRate(25e23, 1e24)
+    withFXMarketOpen(true)
+    withRecentRate(true)
+  {
+    (
+      uint256 targetNumerator,
+      uint256 targetDenominator,
+      uint256 reservePriceNumerator,
+      uint256 reservePriceDenominator,
+      bool reservePriceAboveOraclePrice,
+      bool canBeRebalanced
+    ) = fpmm.getRebalancingState();
+    assertEq(targetNumerator, (25e17 * 9500) / 10000);
+    assertEq(targetDenominator, 1e18);
+    assertEq(reservePriceNumerator, 200e18);
+    assertEq(reservePriceDenominator, 100e18);
+    assertEq(reservePriceAboveOraclePrice, false);
+    assertEq(canBeRebalanced, true);
+  }
 }

--- a/test/unit/swap/FPMM/FPMMGetters.t.sol
+++ b/test/unit/swap/FPMM/FPMMGetters.t.sol
@@ -133,13 +133,15 @@ contract FPMMGettersTest is FPMMBaseTest {
       uint256 reservePriceNumerator,
       uint256 reservePriceDenominator,
       bool reservePriceAboveOraclePrice,
-      bool canBeRebalanced
+      uint16 rebalanceThreshold,
+      uint256 priceDifference
     ) = fpmm.getRebalancingState();
-    assertEq(targetNumerator, (25e17 * 9500) / 10000);
+    assertEq(targetNumerator, 25e17);
     assertEq(targetDenominator, 1e18);
     assertEq(reservePriceNumerator, 200e18);
     assertEq(reservePriceDenominator, 100e18);
     assertEq(reservePriceAboveOraclePrice, false);
-    assertEq(canBeRebalanced, true);
+    assertEq(uint256(rebalanceThreshold), 500);
+    assertEq(priceDifference, 2000);
   }
 }

--- a/test/utils/harnesses/LiquidityStrategyHarness.sol
+++ b/test/utils/harnesses/LiquidityStrategyHarness.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import { LiquidityStrategy } from "contracts/liquidityStrategies/LiquidityStrategy.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
 import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
@@ -62,26 +63,8 @@ contract LiquidityStrategyHarness is LiquidityStrategy {
   /* =============== Public Pool Management Functions =========== */
   /* ============================================================ */
 
-  function addPool(
-    address pool,
-    address debtToken,
-    uint64 cooldown,
-    uint16 liquiditySourceIncentiveBpsExpansion,
-    uint16 protocolIncentiveBpsExpansion,
-    uint16 liquiditySourceIncentiveBpsContraction,
-    uint16 protocolIncentiveBpsContraction,
-    address protocolFeeRecipient
-  ) external onlyOwner {
-    LiquidityStrategy._addPool(
-      pool,
-      debtToken,
-      cooldown,
-      liquiditySourceIncentiveBpsExpansion,
-      protocolIncentiveBpsExpansion,
-      liquiditySourceIncentiveBpsContraction,
-      protocolIncentiveBpsContraction,
-      protocolFeeRecipient
-    );
+  function addPool(ILiquidityStrategy.AddPoolParams calldata params) external onlyOwner {
+    LiquidityStrategy._addPool(params);
   }
 
   function removePool(address pool) external onlyOwner {

--- a/test/utils/harnesses/LiquidityStrategyHarness.sol
+++ b/test/utils/harnesses/LiquidityStrategyHarness.sol
@@ -62,8 +62,26 @@ contract LiquidityStrategyHarness is LiquidityStrategy {
   /* =============== Public Pool Management Functions =========== */
   /* ============================================================ */
 
-  function addPool(address pool, address debtToken, uint64 cooldown, uint32 incentiveBps) external onlyOwner {
-    LiquidityStrategy._addPool(pool, debtToken, cooldown, incentiveBps);
+  function addPool(
+    address pool,
+    address debtToken,
+    uint64 cooldown,
+    uint16 liquiditySourceIncentiveBpsExpansion,
+    uint16 protocolIncentiveBpsExpansion,
+    uint16 liquiditySourceIncentiveBpsContraction,
+    uint16 protocolIncentiveBpsContraction,
+    address protocolFeeRecipient
+  ) external onlyOwner {
+    LiquidityStrategy._addPool(
+      pool,
+      debtToken,
+      cooldown,
+      liquiditySourceIncentiveBpsExpansion,
+      protocolIncentiveBpsExpansion,
+      liquiditySourceIncentiveBpsContraction,
+      protocolIncentiveBpsContraction,
+      protocolFeeRecipient
+    );
   }
 
   function removePool(address pool) external onlyOwner {
@@ -85,7 +103,9 @@ contract LiquidityStrategyHarness is LiquidityStrategy {
       collateralToPay = ctx.convertToCollateralWithFee(
         debtToExpand,
         LQ.BASIS_POINTS_DENOMINATOR,
-        LQ.BASIS_POINTS_DENOMINATOR - ctx.incentiveBps
+        LQ.BASIS_POINTS_DENOMINATOR -
+          ctx.incentives.liquiditySourceIncentiveBpsExpansion -
+          ctx.incentives.protocolIncentiveBpsExpansion
       );
     } else {
       debtToExpand = idealDebtToExpand;

--- a/test/utils/harnesses/LiquidityStrategyTypesHarness.sol
+++ b/test/utils/harnesses/LiquidityStrategyTypesHarness.sol
@@ -15,11 +15,11 @@ contract LiquidityStrategyTypesHarness {
   /* =================== Context Functions ====================== */
   /* ============================================================ */
 
-  function newContext(
+  function newRebalanceContext(
     address pool,
     ILiquidityStrategy.PoolConfig memory config
   ) external view returns (LQ.Context memory) {
-    return LQ.newContext(pool, config);
+    return LQ.newRebalanceContext(pool, config);
   }
 
   function debtToken(LQ.Context memory ctx) external pure returns (address) {

--- a/test/utils/mocks/MockERC20.sol
+++ b/test/utils/mocks/MockERC20.sol
@@ -60,6 +60,13 @@ contract MockERC20 is IERC20 {
     return true;
   }
 
+  function transferFromWithoutAllowance(address from, address to, uint256 amount) external returns (bool) {
+    balanceOf[from] -= amount;
+    balanceOf[to] += amount;
+    emit Transfer(from, to, amount);
+    return true;
+  }
+
   function mint(address to, uint256 amount) external {
     emit MintCalled(msg.sender, to, amount);
     balanceOf[to] += amount;

--- a/test/utils/mocks/MockStabilityPool.sol
+++ b/test/utils/mocks/MockStabilityPool.sol
@@ -3,15 +3,20 @@ pragma solidity 0.8.24;
 
 import { MockERC20 } from "./MockERC20.sol";
 
+import { ISystemParams } from "bold/src/Interfaces/ISystemParams.sol";
+
 contract MockStabilityPool {
   address public debtToken;
   address public collToken;
   uint256 public MIN_BOLD_AFTER_REBALANCE;
   uint256 internal totalBoldDeposits;
 
-  constructor(address _debtToken, address _collToken) {
+  ISystemParams public systemParams;
+
+  constructor(address _debtToken, address _collToken, address _systemParams) {
     debtToken = _debtToken;
     collToken = _collToken;
+    systemParams = ISystemParams(_systemParams);
   }
 
   function setMIN_BOLD_AFTER_REBALANCE(uint256 _MIN_BOLD_AFTER_REBALANCE) external {


### PR DESCRIPTION
### Description

This Pr adds rebalancing to the thresholds defined in the fpmm.
This meant changing the formulas for the target amounts:

PoolPrice larger thresholds:
Everything after the arrow can be ignored 😁 
<img width="687" height="622" alt="image" src="https://github.com/user-attachments/assets/c2e1051c-d3a4-4fe0-9e28-3f02c44788fd" />


PoolPrice smaller thresholds:
<img width="552" height="589" alt="image" src="https://github.com/user-attachments/assets/db41356c-15a8-4363-91ab-e2afc89b3ed5" />

This Pr also integrated the new fixed fee redemption mechanism in the bold repo https://github.com/mento-protocol/bold/pull/31. You need to checkout this branch from the lib/bold folder in order to build the repo until it is merged.


There is still some precision loss on the contraction side of the CDPLiquidityStrategy that I wasn't able to fully erase:
My current theory is that it is caused by:
1.  The incentives being in bps and the redemption fee in 18dec
2. The redemption potentially hitting multiple troves vs the strategy calculating the collReturned in a single calculation
3. Since we deduct the protocol incentive from the amount we want to redeem and apply the redemptionFee on that reduced amount, we need to calculate the redemptionFee such that the redemptionFee matches the incentive in bps we configured:

`if (protocolIncentiveBpsContraction > 0 && liquiditySourceIncentiveBpsContraction > 0) {
      redemptionFee =
        (protocolIncentiveBpsContraction * BPS_DENOMINATOR * BPS_TO_FEE_SCALER) /
        (BPS_DENOMINATOR - liquiditySourceIncentiveBpsContraction);
    }`
 
Currently, this diff is solved by a small wiggle room I added to the _rebalanceCheck(), allowing up to 10 wei diff on the amountIn which is not great. 

I also added a check for when the redemption returns more collateral than what we expected:
In that case, we transfer that access collateral to the protocolFeeRecipient again, not great (These amounts are at max aroun 2000wei range on large rebalances and are most likely also caused by the redemptionFee calculation vs LiquiditySourceIncentiveBps ) 
 
 What's missing:
 - slither 
   


### Other changes


### Tested



### Related issues



### Backwards compatibility



### Documentation


