### PR TITLE
feat: remove swapFee from TradingLimit accounting

### DIFF
--- a/contracts/swap/FPMM.sol
+++ b/contracts/swap/FPMM.sol
@@ -907,6 +907,7 @@ contract FPMM is IRPool, IFPMM, ReentrancyGuardUpgradeable, ERC20Upgradeable, Ow
    */
   function _applyTradingLimits(address token, uint256 amountIn, uint256 amountOut) internal {
     FPMMStorage storage $ = _getFPMMStorage();
-    $.tradingLimits[token].state = $.tradingLimits[token].applyTradingLimits(amountIn, amountOut);
+    uint256 totalFee = $.lpFee + $.protocolFee;
+    $.tradingLimits[token].state = $.tradingLimits[token].applyTradingLimits(amountIn, amountOut, totalFee);
   }
 }

--- a/test/unit/libraries/TradingLimitsV2.t.sol
+++ b/test/unit/libraries/TradingLimitsV2.t.sol
@@ -170,7 +170,7 @@ contract TradingLimitsV2Test is Test {
   /* ==================== State#update ==================== */
 
   function test_update_withNoLimit_doesNotUpdate() public {
-    state = harness.update(state, configEmpty(18), 100 * 1e15);
+    state = harness.update(state, configEmpty(18), int96(100 * 1e15));
     assertEq(state.netflow0, 0);
     assertEq(state.netflow1, 0);
   }
@@ -182,60 +182,32 @@ contract TradingLimitsV2Test is Test {
   }
 
   function test_update_withL0_updatesActive() public {
-    state = harness.update(state, configL0(1000 * 1e15, 18), 100 * 1e18);
-    assertEq(state.netflow0, 100 * 1e15); // Scaled to 15 decimals
+    state = harness.update(state, configL0(1000 * 1e15, 18), 100e15);
+    assertEq(state.netflow0, 100e15);
     assertEq(state.netflow1, 0);
   }
 
   function test_update_withL0L1_updatesActive() public {
-    state = harness.update(state, configL0L1(1000 * 1e15, 10000 * 1e15, 18), 100 * 1e18);
-    assertEq(state.netflow0, 100 * 1e15); // Scaled to 15 decimals
-    assertEq(state.netflow1, 100 * 1e15); // Scaled to 15 decimals
+    state = harness.update(state, configL0L1(1000 * 1e15, 10000 * 1e15, 18), 100e15);
+    assertEq(state.netflow0, 100e15);
+    assertEq(state.netflow1, 100e15);
   }
 
   function test_update_withL1Only_updatesL1() public {
-    state = harness.update(state, configL1(10000 * 1e15, 18), 100 * 1e18);
-    assertEq(state.netflow0, 0); // L0 not active
-    assertEq(state.netflow1, 100 * 1e15); // L1 should be updated
-  }
-
-  function test_update_withSmallAmount_doesNotRoundUp() public {
-    // In V2, small amounts that scale to 0 are rounded to ±1 based on direction
-    state = harness.update(state, configL0(1000 * 1e15, 18), 1e18 + 999);
-    assertEq(state.netflow0, 1e15); // should be 1e15, 999 wei are rounded to 0
-
-    state = ITradingLimitsV2.State(0, 0, 0, 0); // reset
-    state = harness.update(state, configL0(1000 * 1e15, 18), -1e18 - 999);
-    assertEq(state.netflow0, -1e15); // should be -1e15, 999 wei are rounded to 0
-  }
-
-  function test_update_withSmallAmount_nonZero_updates() public {
-    state = harness.update(state, configL0(1000 * 1e15, 18), 1e4); // 0.0001 tokens = 1e14 scaled
-    assertEq(state.netflow0, 10); // 1e4 / 1e3 = 10 when scaled from 18 to 15 decimals
-
-    state = ITradingLimitsV2.State(0, 0, 0, 0); // reset
-    state = harness.update(state, configL0(1000 * 1e15, 18), -1e4); // 0.0001 tokens = 1e14 scaled
-    assertEq(state.netflow0, -10); // 1e4 / 1e3 = 10 when scaled from 18 to 15 decimals
-  }
-
-  function test_update_WithSmallAmountAnd6Decimals_scalesUpCorrectly() public {
-    state = harness.update(state, configL0(1000 * 1e15, 6), 1e6 + 999);
-    assertEq(state.netflow0, 1e15 + 999e9); // scaled to 15 decimals 1e6 -> 1e15, 999 -> 999e9
-
-    state = ITradingLimitsV2.State(0, 0, 0, 0); // reset
-    state = harness.update(state, configL0(1000 * 1e15, 6), -1e6 - 999);
-    assertEq(state.netflow0, -1e15 - 999e9); // scaled to 15 decimals -1e6 -> -1e15, -999 -> -999e9
+    state = harness.update(state, configL1(10000 * 1e15, 18), 100e15);
+    assertEq(state.netflow0, 0);
+    assertEq(state.netflow1, 100e15);
   }
 
   function test_update_resetsL0_after5Minutes() public {
     vm.warp(1000);
-    state = harness.update(state, configL0(1000 * 1e15, 18), 100 * 1e18);
-    assertEq(state.netflow0, 100 * 1e15);
+    state = harness.update(state, configL0(1000 * 1e15, 18), -100e15);
+    assertEq(state.netflow0, -100e15);
     assertEq(state.lastUpdated0, 1000);
 
     // Move forward 5 minutes + 1 second
     vm.warp(1000 + 5 * 60 + 1);
-    state = harness.update(state, configL0(1000 * 1e15, 18), 50 * 1e18);
+    state = harness.update(state, configL0(1000 * 1e15, 18), 50e15);
 
     assertEq(state.netflow0, 50 * 1e15); // Should be reset to just new amount
     assertEq(state.lastUpdated0, 1000 + 5 * 60 + 1);
@@ -244,133 +216,208 @@ contract TradingLimitsV2Test is Test {
   function test_update_resetsL1_after1Day() public {
     // Start with a time that allows initial L1 timestamp to be set
     vm.warp(1 days + 1000);
-    state = harness.update(state, configL0L1(1000 * 1e15, 10000 * 1e15, 18), 100 * 1e18);
-    assertEq(state.netflow1, 100 * 1e15);
+    state = harness.update(state, configL0L1(1000 * 1e15, 10000 * 1e15, 18), -100e15);
+    assertEq(state.netflow1, -100e15);
     assertEq(state.lastUpdated1, 1 days + 1000);
 
     // Move forward 1 day + 1 second
     vm.warp(1 days + 1000 + 1 days + 1);
-    state = harness.update(state, configL0L1(1000 * 1e15, 10000 * 1e15, 18), 50 * 1e18);
+    state = harness.update(state, configL0L1(1000 * 1e15, 10000 * 1e15, 18), 50e15);
 
     // Both L0 and L1 should be reset since both timeframes elapsed
-    assertEq(state.netflow0, 50 * 1e15); // Should be reset to just new amount
-    assertEq(state.netflow1, 50 * 1e15); // Should be reset to just new amount
+    assertEq(state.netflow0, 50e15); // Should be reset to just new amount
+    assertEq(state.netflow1, 50e15); // Should be reset to just new amount
     assertEq(state.lastUpdated0, 1 days + 1000 + 1 days + 1);
     assertEq(state.lastUpdated1, 1 days + 1000 + 1 days + 1);
   }
 
   function test_update_accumulatesWithinTimeWindow() public {
     vm.warp(1000);
-    state = harness.update(state, configL0(1000 * 1e15, 18), 100 * 1e18);
+    state = harness.update(state, configL0(1000 * 1e15, 18), -100e15);
 
     // Move forward less than 5 minutes
     vm.warp(1000 + 4 * 60);
-    state = harness.update(state, configL0(1000 * 1e15, 18), 50 * 1e18);
+    state = harness.update(state, configL0(1000 * 1e15, 18), 50e15);
 
-    assertEq(state.netflow0, 150 * 1e15); // Should accumulate
+    assertEq(state.netflow0, -50e15); // Should accumulate
   }
 
   function test_update_L1Only_resetsAfter1Day() public {
     // Test that L1 resets after 1 day when used without L0
     vm.warp(1 days + 1000);
-    state = harness.update(state, configL1(10000 * 1e15, 18), 100 * 1e18);
-    assertEq(state.netflow1, 100 * 1e15);
+    state = harness.update(state, configL1(10000 * 1e15, 18), -100e15);
+    assertEq(state.netflow1, -100e15);
     assertEq(state.lastUpdated1, 1 days + 1000);
+    assertEq(state.netflow0, 0); // L0 should remain 0
 
     // Move forward 1 day + 1 second
     vm.warp(1 days + 1000 + 1 days + 1);
-    state = harness.update(state, configL1(10000 * 1e15, 18), 50 * 1e18);
+    state = harness.update(state, configL1(10000 * 1e15, 18), 50e15);
 
     // L1 should be reset
-    assertEq(state.netflow1, 50 * 1e15); // Should be reset to just new amount
+    assertEq(state.netflow1, 50e15); // Should be reset to just new amount
     assertEq(state.lastUpdated1, 1 days + 1000 + 1 days + 1);
     assertEq(state.netflow0, 0); // L0 should remain 0
   }
 
   function test_update_L1Only_accumulatesWithinTimeWindow() public {
     vm.warp(1000);
-    state = harness.update(state, configL1(10000 * 1e15, 18), 100 * 1e18);
+    state = harness.update(state, configL1(10000 * 1e15, 18), 100e15);
 
     // Move forward less than 1 day
     vm.warp(1000 + 12 hours);
-    state = harness.update(state, configL1(10000 * 1e15, 18), 50 * 1e18);
+    state = harness.update(state, configL1(10000 * 1e15, 18), 50e15);
 
     assertEq(state.netflow1, 150 * 1e15); // Should accumulate
     assertEq(state.netflow0, 0); // L0 should remain 0
   }
 
+  /* ==================== applyTradingLimits ==================== */
+
+  function test_applyTradingLimits_withSmallAmount_doesNotRoundUp() public {
+    uint256 amountIn = 1e18 + 999;
+    uint256 amountOut = 0;
+    uint256 feeBps = 0;
+    // In V2, small amounts that scale to 0 are rounded to ±1 based on direction
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(1000 * 1e15, 18)
+    });
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+    assertEq(state.netflow0, 1e15); // should be 1e15, 999 wei are rounded to 0
+  }
+
+  function test_applyTradingLimits_withSmallAmount_nonZero_updates() public {
+    uint256 amountIn = 1e4;
+    uint256 amountOut = 0;
+    uint256 feeBps = 0;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(1000 * 1e15, 18)
+    });
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+    assertEq(state.netflow0, 10); // 1e4 / 1e3 = 10 when scaled from 18 to 15 decimals
+  }
+
+  function test_applyTradingLimits_WithSmallAmountAnd6Decimals_scalesUpCorrectly() public {
+    uint256 amountIn = 1e6 + 999;
+    uint256 amountOut = 0;
+    uint256 feeBps = 0;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(1000 * 1e15, 6)
+    });
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+    assertEq(state.netflow0, 1e15 + 999e9); // scaled to 15 decimals 1e6 -> 1e15, 999 -> 999e9
+  }
+
+  function test_applyTradingLimits_withDeltaFlowExceedingMaxInt96_reverts() public {
+    uint256 amountIn = uint256(int256(type(int96).max)) + 1;
+    uint256 amountOut = 0;
+    uint256 feeBps = 0;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(1000 * 1e15, 15) // 15 decimals so the amount is not scaled
+    });
+    vm.expectRevert(ITradingLimitsV2.ValueExceedsInt96Bounds.selector);
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+  }
+
+  function test_applyTradingLimits_withDeltaFlowExceedingMinInt96_reverts() public {
+    uint256 amountIn = 0;
+    uint256 amountOut = uint256(int256(type(int96).min) * -1) + 1;
+    uint256 feeBps = 0;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(1000 * 1e15, 15) // 15 decimals so the amount is not scaled
+    });
+    vm.expectRevert(ITradingLimitsV2.ValueExceedsInt96Bounds.selector);
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+  }
+
+  function test_applyTradingLimits_withDeltaFlowWithiMaxInt96Bounds_updatesState() public {
+    uint256 amountIn = uint256(int256(type(int96).max));
+    uint256 amountOut = 0;
+    uint256 feeBps = 0;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(type(int120).max, 15) // 15 decimals so the amount is not scaled
+    });
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+    assertEq(state.netflow0, int256(type(int96).max));
+  }
+
+  function test_applyTradingLimits_withDeltaFlowWithinMinInt96Bounds_updatesState() public {
+    uint256 amountIn = 0;
+    uint256 amountOut = uint256(int256(type(int96).min) * -1);
+    uint256 feeBps = 0;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(type(int120).max, 15) // 15 decimals so the amount is not scaled
+    });
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+    assertEq(state.netflow0, int256(type(int96).min));
+  }
+
+  function test_applyTradingLimits_withDeltaFlowWithZeroFee_updatesState() public {
+    uint256 amountIn = 1000e18;
+    uint256 amountOut = 0;
+    uint256 feeBps = 0;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(1000 * 1e15, 18) // 15 decimals so the amount is not scaled
+    });
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+    assertEq(state.netflow0, 1000e15);
+  }
+
+  function test_applyTradingLimits_withDeltaFlowWithNonZeroFee_updatesState() public {
+    uint256 amountIn = 1000e18;
+    uint256 amountOut = 100e18;
+    uint256 feeBps = 100;
+    ITradingLimitsV2.TradingLimits memory tradingLimits = ITradingLimitsV2.TradingLimits({
+      state: state,
+      config: configL0(1000 * 1e15, 18) // 15 decimals so the amount is not scaled
+    });
+    state = harness.applyTradingLimits(tradingLimits, amountIn, amountOut, feeBps);
+    assertEq(state.netflow0, (1000e15 * 9900) / 10000 - 100e15); // delta flow is amountIn * (1-fee) - amountOut
+  }
+
   /* ==================== Scaling Functions ==================== */
 
   function test_scaleValue_with18Decimals_scalesDown() public view {
-    int96 scaled = harness.scaleValue(100 * 1e18, 18);
+    uint256 scaled = harness.scaleValue(100 * 1e18, 18);
     assertEq(scaled, 100 * 1e15);
   }
 
   function test_scaleValue_with15Decimals_noScaling() public view {
-    int96 scaled = harness.scaleValue(100 * 1e15, 15);
+    uint256 scaled = harness.scaleValue(100 * 1e15, 15);
     assertEq(scaled, 100 * 1e15);
   }
 
   function test_scaleValue_with6Decimals_scalesUp() public view {
-    int96 scaled = harness.scaleValue(100 * 1e6, 6);
+    uint256 scaled = harness.scaleValue(100 * 1e6, 6);
     assertEq(scaled, 100 * 1e15);
   }
 
   function test_scaleValue_withZero_returnsZero() public view {
-    int96 scaled = harness.scaleValue(0, 18);
+    uint256 scaled = harness.scaleValue(0, 18);
     assertEq(scaled, 0);
   }
 
-  function test_scaleValue_withNegative18Decimals_scalesCorrectly() public view {
-    int96 scaled = harness.scaleValue(-100 * 1e18, 18);
-    assertEq(scaled, -100 * 1e15);
-  }
-
-  function test_scaleValue_withNegative6Decimals_scalesCorrectly() public view {
-    int96 scaled = harness.scaleValue(-100 * 1e6, 6);
-    assertEq(scaled, -100 * 1e15);
-  }
-
-  function test_scaleValue_withMaxInt96_reverts() public {
-    int256 tooLarge = int256(type(int96).max) + 1;
-    vm.expectRevert(ITradingLimitsV2.ValueExceedsInt96Bounds.selector);
-    harness.scaleValue(tooLarge, 15);
-  }
-
-  function test_scaleValue_withMinInt96_reverts() public {
-    int256 tooSmall = int256(type(int96).min) - 1;
-    vm.expectRevert(ITradingLimitsV2.ValueExceedsInt96Bounds.selector);
-    harness.scaleValue(tooSmall, 15);
-  }
-
-  function test_scaleValue_asLimit_with18Decimals_scalesDown() public view {
-    int96 scaled = harness.scaleValue(100 * 1e18, 18);
-    assertEq(scaled, 100 * 1e15);
-  }
-
   function test_scaleValue_asLimit_with15Decimals_noScaling() public view {
-    int96 scaled = harness.scaleValue(100 * 1e15, 15);
+    uint256 scaled = harness.scaleValue(100 * 1e15, 15);
     assertEq(scaled, 100 * 1e15);
   }
 
   function test_scaleValue_asLimit_with6Decimals_scalesUp() public view {
-    int96 scaled = harness.scaleValue(100 * 1e6, 6);
+    uint256 scaled = harness.scaleValue(100 * 1e6, 6);
     assertEq(scaled, 100 * 1e15);
   }
 
   function test_scaleValue_asLimit_withZero_returnsZero() public view {
-    int96 scaled = harness.scaleValue(0, 18);
+    uint256 scaled = harness.scaleValue(0, 18);
     assertEq(scaled, 0);
-  }
-
-  function test_scaleValue_asLimit_withMaxInt96_reverts() public {
-    int256 tooLarge = int256(type(int96).max) + 1;
-    vm.expectRevert(ITradingLimitsV2.ValueExceedsInt96Bounds.selector);
-    harness.scaleValue(tooLarge, 15);
-
-    int256 tooSmall = int256(type(int96).min) - 1;
-    vm.expectRevert(ITradingLimitsV2.ValueExceedsInt96Bounds.selector);
-    harness.scaleValue(tooSmall, 15);
   }
 
   /* ==================== SafeAdd ==================== */
@@ -402,7 +449,7 @@ contract TradingLimitsV2Test is Test {
 
   /* ==================== Integration Tests ==================== */
 
-  function test_integration_fullWorkflow_18decimals() public {
+  function test_integration_fullWorkflow() public {
     ITradingLimitsV2.Config memory config = configL0L1(1000 * 1e15, 10000 * 1e15, 18);
 
     // Validate config
@@ -410,43 +457,25 @@ contract TradingLimitsV2Test is Test {
 
     // Update with some flow
     vm.warp(1000);
-    state = harness.update(state, config, 500 * 1e18);
+    state = harness.update(state, config, 500e15);
 
     // Verify within limits
     harness.verify(state, config);
 
-    assertEq(state.netflow0, 500 * 1e15); // scaled to 15 decimals
-    assertEq(state.netflow1, 500 * 1e15); // scaled to 15 decimals
+    assertEq(state.netflow0, 500 * 1e15);
+    assertEq(state.netflow1, 500 * 1e15);
 
     // Update more and verify still within limits
-    state = harness.update(state, config, 400 * 1e18);
+    state = harness.update(state, config, -400e15);
     harness.verify(state, config);
 
-    assertEq(state.netflow0, (500 + 400) * 1e15); // scaled to 15 decimals
-    assertEq(state.netflow1, (500 + 400) * 1e15); // scaled to 15 decimals
+    assertEq(state.netflow0, 100e15);
+    assertEq(state.netflow1, 100e15);
 
     // Update to exceed L0 limit
-    state = harness.update(state, config, 200 * 1e18);
+    state = harness.update(state, config, 900e15 + 1);
     vm.expectRevert(ITradingLimitsV2.L0LimitExceeded.selector);
     harness.verify(state, config);
-  }
-
-  function test_integration_fullWorkflow_6decimals() public {
-    ITradingLimitsV2.Config memory config = configL0L1(1000 * 1e15, 10000 * 1e15, 6);
-
-    // Validate config
-    harness.validate(config);
-
-    // Update with some flow
-    vm.warp(1000);
-    state = harness.update(state, config, 500 * 1e6);
-
-    // Verify within limits
-    harness.verify(state, config);
-
-    // Check scaled values are correct
-    assertEq(state.netflow0, 500 * 1e15); // Should be scaled to 15 decimals
-    assertEq(state.netflow1, 500 * 1e15); // Should be scaled to 15 decimals
   }
 
   function test_integration_timeWindowReset_L0and_L1() public {
@@ -455,14 +484,14 @@ contract TradingLimitsV2Test is Test {
     vm.warp(1000);
 
     // Fill L0 limit
-    state = harness.update(state, config, 1000 * 1e18);
+    state = harness.update(state, config, 1000e15);
     harness.verify(state, config);
 
     // Move forward 5 minutes to reset L0 but not L1
     vm.warp(1000 + 5 * 60 + 1);
 
     // Should be able to add more to L0 (reset) but L1 accumulates
-    state = harness.update(state, config, 1000 * 1e18);
+    state = harness.update(state, config, 1000e15);
     harness.verify(state, config);
 
     // Now L1 should have 2000, L0 should have 1000
@@ -472,7 +501,7 @@ contract TradingLimitsV2Test is Test {
     // Move forward 1 day to reset L1
     vm.warp(1000 + 1 days + 1);
 
-    state = harness.update(state, config, 1000 * 1e18);
+    state = harness.update(state, config, 1000e15);
 
     // Both should be reset to just the new amount
     assertEq(state.netflow0, 1000 * 1e15);

--- a/test/utils/harnesses/ITradingLimitsV2Harness.sol
+++ b/test/utils/harnesses/ITradingLimitsV2Harness.sol
@@ -8,6 +8,13 @@ interface ITradingLimitsV2Harness {
 
   function verify(ITradingLimitsV2.State memory state, ITradingLimitsV2.Config memory config) external pure;
 
+  function applyTradingLimits(
+    ITradingLimitsV2.TradingLimits memory self,
+    uint256 amountIn,
+    uint256 amountOut,
+    uint256 feeBps
+  ) external view returns (ITradingLimitsV2.State memory);
+
   function reset(
     ITradingLimitsV2.State memory state,
     ITradingLimitsV2.Config memory config
@@ -16,10 +23,10 @@ interface ITradingLimitsV2Harness {
   function update(
     ITradingLimitsV2.State memory state,
     ITradingLimitsV2.Config memory config,
-    int256 deltaFlow
+    int96 deltaFlow
   ) external view returns (ITradingLimitsV2.State memory);
 
-  function scaleValue(int256 value, uint8 decimals) external pure returns (int96);
+  function scaleValue(uint256 value, uint8 decimals) external pure returns (uint256);
 
   function safeAdd(int96 a, int96 b) external pure returns (int96);
 }

--- a/test/utils/harnesses/TradingLimitsV2Harness.sol
+++ b/test/utils/harnesses/TradingLimitsV2Harness.sol
@@ -9,6 +9,7 @@ import { ITradingLimitsV2Harness } from "./ITradingLimitsV2Harness.sol";
 contract TradingLimitsV2Harness is ITradingLimitsV2Harness {
   using TradingLimitsV2 for ITradingLimitsV2.State;
   using TradingLimitsV2 for ITradingLimitsV2.Config;
+  using TradingLimitsV2 for ITradingLimitsV2.TradingLimits;
 
   function validate(ITradingLimitsV2.Config memory config) public pure {
     return config.validate();
@@ -16,6 +17,15 @@ contract TradingLimitsV2Harness is ITradingLimitsV2Harness {
 
   function verify(ITradingLimitsV2.State memory state, ITradingLimitsV2.Config memory config) public pure {
     return state.verify(config);
+  }
+
+  function applyTradingLimits(
+    ITradingLimitsV2.TradingLimits memory self,
+    uint256 amountIn,
+    uint256 amountOut,
+    uint256 feeBps
+  ) public view returns (ITradingLimitsV2.State memory) {
+    return self.applyTradingLimits(amountIn, amountOut, feeBps);
   }
 
   function reset(
@@ -28,12 +38,12 @@ contract TradingLimitsV2Harness is ITradingLimitsV2Harness {
   function update(
     ITradingLimitsV2.State memory state,
     ITradingLimitsV2.Config memory config,
-    int256 deltaFlow
+    int96 deltaFlow
   ) public view returns (ITradingLimitsV2.State memory) {
     return state.update(config, deltaFlow);
   }
 
-  function scaleValue(int256 value, uint8 decimals) public pure returns (int96) {
+  function scaleValue(uint256 value, uint8 decimals) public pure returns (uint256) {
     return TradingLimitsV2.scaleValue(value, decimals);
   }
 


### PR DESCRIPTION
### Description

This PR removes the FPMM swap fee from the tradingLimit netflow accounting. 
This is done within the TradingLimits Library because we need to perform this operation after scaling to the internal 15 decimal precision. Otherwise, 1 wei of USDC would become 0 if we deduct the fee of the amountIn in the FPPM. 

Due to this, I had to move some things around within the library:
- applyTradingLimits() takes the feeBps as an additional parameter
- scaling happens on the amountIn and amountOut instead of the delatFlow in order to deduct the fee on the internal precision instead of the token decimals. 
- Therefore, the int96 min/max checks are also moved into the applyTradingLimits function. before casting the deltaflow to int96      

### Other changes

### Tested

- added tests for fee deduction and flashloan. 

### Related issues


### Backwards compatibility


### Documentation

