### PR TITLE
feat: virtual pool deprecation (Moved from `mento-core-private`)

### DIFF
--- a/contracts/interfaces/IVirtualPoolFactory.sol
+++ b/contracts/interfaces/IVirtualPoolFactory.sol
@@ -20,6 +20,12 @@ interface IVirtualPoolFactory is IRPoolFactory {
   /// @dev Used when the CREATEX bytecode hash doesn't match the expected value.
   error InvalidCreateXBytecode();
 
+  /// @dev Used when trying to deprecate a pool that doesn't exist.
+  error PoolNotFound();
+
+  /// @dev Used when trying to deprecate a pool that is already deprecated.
+  error PoolAlreadyDeprecated();
+
   /* ========================================== */
   /* ================= Events ================= */
   /* ========================================== */
@@ -32,6 +38,12 @@ interface IVirtualPoolFactory is IRPoolFactory {
    */
   event VirtualPoolDeployed(address indexed pool, address indexed token0, address indexed token1);
 
+  /**
+   * @notice Emitted when a pool is deprecated.
+   * @param pool The address of the deprecated pool
+   */
+  event PoolDeprecated(address indexed pool);
+
   /* ============================================================ */
   /* ==================== Mutative Functions ==================== */
   /* ============================================================ */
@@ -43,4 +55,27 @@ interface IVirtualPoolFactory is IRPoolFactory {
    * @return pool Address of the deployed pool.
    */
   function deployVirtualPool(address exchangeProvider, bytes32 exchangeId) external returns (address pool);
+
+  /**
+   * @notice Deprecates a VirtualPool.
+   * @param pool The address of the pool to deprecate.
+   */
+  function deprecatePool(address pool) external;
+
+  /* ============================================================ */
+  /* ===================== View Functions ======================= */
+  /* ============================================================ */
+
+  /**
+   * @notice Returns all non-deprecated pools that have been deployed.
+   * @return An array of all active pool addresses.
+   */
+  function getAllPools() external view returns (address[] memory);
+
+  /**
+   * @notice Checks if a pool is deprecated.
+   * @param pool The address of the pool to check.
+   * @return True if the pool is deprecated, false otherwise.
+   */
+  function isPoolDeprecated(address pool) external view returns (bool);
 }

--- a/test/unit/swap/VirtualPoolFactory.t.sol
+++ b/test/unit/swap/VirtualPoolFactory.t.sol
@@ -12,6 +12,7 @@ import { CreateXHelper } from "test/utils/CreateXHelper.sol";
 
 contract VirtualPoolFactoryTest is Test, CreateXHelper {
   event VirtualPoolDeployed(address indexed pool, address indexed token0, address indexed token1);
+  event PoolDeprecated(address indexed pool);
 
   VirtualPoolFactory public factory;
   address public tokenA;
@@ -135,5 +136,128 @@ contract VirtualPoolFactoryTest is Test, CreateXHelper {
           stablePoolResetSize: 1
         })
       });
+  }
+
+  function test_getAllPools_whenNoPools_shouldReturnEmptyArray() public view {
+    address[] memory pools = factory.getAllPools();
+    assertEq(pools.length, 0);
+  }
+
+  function test_getAllPools_afterDeployment_shouldReturnPool() public {
+    vm.prank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    address[] memory pools = factory.getAllPools();
+    assertEq(pools.length, 1);
+    assertEq(pools[0], pool);
+  }
+
+  function test_getAllPools_afterMultipleDeployments_shouldReturnAllPools() public {
+    address tokenC = address(new MockERC20("Token C", "TOKC", 18));
+    address tokenD = address(new MockERC20("Token D", "TOKD", 18));
+
+    vm.prank(governance);
+    address pool1 = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    vm.mockCall(
+      exchangeProvider,
+      abi.encodeWithSelector(IBiPoolManager.exchanges.selector, bytes32(uint256(1))),
+      abi.encode(_makeQuickExchange(tokenC, tokenD))
+    );
+
+    vm.prank(governance);
+    address pool2 = factory.deployVirtualPool(exchangeProvider, bytes32(uint256(1)));
+
+    address[] memory pools = factory.getAllPools();
+    assertEq(pools.length, 2);
+    assertTrue(pools[0] == pool1 || pools[1] == pool1);
+    assertTrue(pools[0] == pool2 || pools[1] == pool2);
+  }
+
+  /* ============================================================ */
+  /* ==================== Deprecation Tests ===================== */
+  /* ============================================================ */
+
+  function test_deprecatePool_whenNotOwner_shouldRevert() public {
+    vm.prank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    vm.prank(makeAddr("literallyAnyone"));
+    vm.expectRevert("Ownable: caller is not the owner");
+    factory.deprecatePool(pool);
+  }
+
+  function test_deprecatePool_whenPoolNotFound_shouldRevert() public {
+    address fakePool = makeAddr("fakePool");
+
+    vm.prank(governance);
+    vm.expectRevert(IVirtualPoolFactory.PoolNotFound.selector);
+    factory.deprecatePool(fakePool);
+  }
+
+  function test_deprecatePool_whenAlreadyDeprecated_shouldRevert() public {
+    vm.startPrank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+    factory.deprecatePool(pool);
+
+    vm.expectRevert(IVirtualPoolFactory.PoolAlreadyDeprecated.selector);
+    factory.deprecatePool(pool);
+    vm.stopPrank();
+  }
+
+  function test_deprecatePool_shouldEmitEvent() public {
+    vm.prank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    vm.prank(governance);
+    vm.expectEmit();
+    emit PoolDeprecated(pool);
+    factory.deprecatePool(pool);
+  }
+
+  function test_deprecatePool_shouldExcludeFromGetAllPools() public {
+    vm.prank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    assertEq(factory.getAllPools().length, 1);
+
+    vm.prank(governance);
+    factory.deprecatePool(pool);
+
+    assertEq(factory.getAllPools().length, 0);
+  }
+
+  function test_isPool_whenDeprecated_shouldReturnFalse() public {
+    vm.prank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    assertEq(factory.isPool(pool), true);
+
+    vm.prank(governance);
+    factory.deprecatePool(pool);
+
+    assertEq(factory.isPool(pool), false);
+  }
+
+  function test_isPoolDeprecated_whenDeprecated_shouldReturnTrue() public {
+    vm.prank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    vm.prank(governance);
+    factory.deprecatePool(pool);
+
+    assertEq(factory.isPoolDeprecated(pool), true);
+  }
+
+  function test_deprecatedPool_shouldStillBeAccessibleViaGetPool() public {
+    vm.prank(governance);
+    address pool = factory.deployVirtualPool(exchangeProvider, bytes32(0));
+
+    vm.prank(governance);
+    factory.deprecatePool(pool);
+
+    // getPool should still return the pool address
+    assertEq(factory.getPool(tokenA, tokenB), pool);
+    assertEq(factory.getPool(tokenB, tokenA), pool);
   }
 }


### PR DESCRIPTION
### Description

Updates to the VirtualPoolFactory:
- Allows the owner to mark a pool as deprecated
- Excludes deprecated pools from the `isPool()` check
- Adds a function to return all active pools
- Removes redundant isPool mapping