### PR TITLE
fix: optimize for contract size

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -24,7 +24,7 @@ verbosity = 3
 
 [profile.optimized]
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 1
 
 [profile.fork-tests]
 no_match_contract = "_random" # in order to reset the no_match_contract


### PR DESCRIPTION
### Description

Change optimizer settings in `optimized` profile to make contracts fit the contract size limit (notably `TroveManager`)

### Doubts

Should this be the default settings? And we would leave `optimized` at 200 runs?