### PR TITLE
Add fallback factory getter to interface

### DIFF
--- a/contracts/interfaces/IFactoryRegistry.sol
+++ b/contracts/interfaces/IFactoryRegistry.sol
@@ -44,4 +44,7 @@ interface IFactoryRegistry {
 
   /// @notice Get the length of the poolFactories array
   function poolFactoriesLength() external view returns (uint256);
+
+  /// @dev The protocol will always have a usable poolFactory.
+  function fallbackPoolFactory() external view returns (address);
 }


### PR DESCRIPTION
### Description

Added the getter for the fallback pool registry in IFactoryRegistry. The getter already exists in the implementation but was missing from the interface.