### PR TITLE
fix: add _initialOwner parameter to StableTokenSpoke.initialize

### DIFF
--- a/contracts/interfaces/IStableTokenSpoke.sol
+++ b/contracts/interfaces/IStableTokenSpoke.sol
@@ -28,6 +28,21 @@ interface IStableTokenSpoke is IERC20PermitUpgradeable {
     address[] calldata _minters,
     address[] calldata _burners
   ) external;
+
+  /**
+   * @notice Checks if an address is a minter.
+   * @param account The address to check.
+   * @return bool True if the address is a minter, false otherwise.
+   */
+  function isMinter(address account) external view returns (bool);
+
+  /**
+   * @notice Checks if an address is a burner.
+   * @param account The address to check.
+   * @return bool True if the address is a burner, false otherwise.
+   */
+  function isBurner(address account) external view returns (bool);
+
   /**
    * @notice Sets the minter role for an address.
    * @param _minter The address of the minter.

--- a/contracts/interfaces/IStableTokenSpoke.sol
+++ b/contracts/interfaces/IStableTokenSpoke.sol
@@ -13,6 +13,7 @@ interface IStableTokenSpoke is IERC20PermitUpgradeable {
    * @notice Initializes a StableTokenSpoke.
    * @param _name The name of the stable token (English)
    * @param _symbol A short symbol identifying the token (e.g. "cUSD")
+   * @param _initialOwner The address that will own the contract.
    * @param initialBalanceAddresses Array of addresses with an initial balance.
    * @param initialBalanceValues Array of balance values corresponding to initialBalanceAddresses.
    * @param _minters The addresses that are allowed to mint.
@@ -21,6 +22,7 @@ interface IStableTokenSpoke is IERC20PermitUpgradeable {
   function initialize(
     string calldata _name,
     string calldata _symbol,
+    address _initialOwner,
     address[] calldata initialBalanceAddresses,
     uint256[] calldata initialBalanceValues,
     address[] calldata _minters,

--- a/contracts/interfaces/IStableTokenSpoke.sol
+++ b/contracts/interfaces/IStableTokenSpoke.sol
@@ -13,7 +13,7 @@ interface IStableTokenSpoke is IERC20PermitUpgradeable {
    * @notice Initializes a StableTokenSpoke.
    * @param _name The name of the stable token (English)
    * @param _symbol A short symbol identifying the token (e.g. "cUSD")
-   * @param _initialOwner The address that will own the contract.
+   * @param _initialOwner The address that will be the owner of the contract.
    * @param initialBalanceAddresses Array of addresses with an initial balance.
    * @param initialBalanceValues Array of balance values corresponding to initialBalanceAddresses.
    * @param _minters The addresses that are allowed to mint.

--- a/contracts/tokens/StableTokenSpoke.sol
+++ b/contracts/tokens/StableTokenSpoke.sol
@@ -66,6 +66,7 @@ contract StableTokenSpoke is ERC20PermitUpgradeable, OwnableUpgradeable, IStable
   function initialize(
     string memory name,
     string memory symbol,
+    address _initialOwner,
     address[] memory initialBalanceAddresses,
     uint256[] memory initialBalanceValues,
     address[] memory _minters,
@@ -73,7 +74,7 @@ contract StableTokenSpoke is ERC20PermitUpgradeable, OwnableUpgradeable, IStable
   ) public initializer {
     __ERC20_init(name, symbol);
     __EIP712_init_unchained(name, "3");
-    _transferOwnership(_msgSender());
+    _transferOwnership(_initialOwner);
 
     require(initialBalanceAddresses.length == initialBalanceValues.length, "Array length mismatch");
     for (uint256 i = 0; i < initialBalanceAddresses.length; i += 1) {


### PR DESCRIPTION
### Summary

This PR fixes the `StableTokenSpoke.initialize()` function to accept an `_initialOwner` parameter instead of transferring ownership to `msg.sender()`, to be compatible with CreateX, which should have been done as part of https://github.com/mento-protocol/mento-core/pull/624 but we only realized it now while writing deployment scripts for it.

### Other Changes
- **Interface** (`IStableTokenSpoke.sol`): Added `isMinter` and `isBurner` view functions that were missing
