### PR TITLE
fix: add missing fallbackPoolFactory getter in factory registry interface

### DIFF
--- a/contracts/interfaces/IFactoryRegistry.sol
+++ b/contracts/interfaces/IFactoryRegistry.sol
@@ -31,6 +31,9 @@ interface IFactoryRegistry {
   /// @param poolFactory .
   function unapprove(address poolFactory) external;
 
+  /// @dev The protocol will always have a usable poolFactory.
+  function fallbackPoolFactory() external view returns (address);
+
   /// @notice Get all PoolFactories approved by the registry
   /// @dev The same PoolFactory address cannot be used twice
   /// @return Array of PoolFactory addresses

--- a/contracts/swap/FactoryRegistry.sol
+++ b/contracts/swap/FactoryRegistry.sol
@@ -13,7 +13,7 @@ import { EnumerableSetUpgradeable } from "openzeppelin-contracts-upgradeable/con
 contract FactoryRegistry is IFactoryRegistry, OwnableUpgradeable {
   using EnumerableSetUpgradeable for EnumerableSetUpgradeable.AddressSet;
 
-  /// @dev The protocol will always have a usable poolFactory.
+  /// @inheritdoc IFactoryRegistry
   address public fallbackPoolFactory;
 
   /// @dev Array of poolFactories used to create a gauge and votingRewards


### PR DESCRIPTION
### Description

Add missing fallbackPoolFactory getter in factory registry interface
