### PR TITLE
chore: change SatbletokenV3 pragma to allow evm paris comilation in d…

### DIFF
--- a/contracts/interfaces/IFeeCurrency.sol
+++ b/contracts/interfaces/IFeeCurrency.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.13;
+pragma solidity ^0.8;
 
 /**
  * @notice This interface should be implemented for tokens which are supposed to

--- a/contracts/interfaces/IStableTokenV3.sol
+++ b/contracts/interfaces/IStableTokenV3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.24;
+pragma solidity ^0.8;
 
 /**
  * @title IStableTokenV3

--- a/contracts/tokens/StableTokenV3.sol
+++ b/contracts/tokens/StableTokenV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // solhint-disable gas-custom-errors
-pragma solidity 0.8.24;
+pragma solidity ^0.8;
 
 import { ERC20PermitUpgradeable } from "./patched/ERC20PermitUpgradeable.sol";
 import { ERC20Upgradeable } from "./patched/ERC20Upgradeable.sol";


### PR DESCRIPTION
### Description

Making the StableTokenV3 pragma more permissive so we can compile it with the specific evmVersion=paris in the deployments repo  

### Other changes

### Tested

### Related issues

### Backwards compatibility

### Documentation