### PR TITLE
feat: add OpenLiquidityStrategy for direct rebalancing

### DIFF
--- a/contracts/interfaces/IOpenLiquidityStrategy.sol
+++ b/contracts/interfaces/IOpenLiquidityStrategy.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import { ILiquidityStrategy } from "./ILiquidityStrategy.sol";
+
+/**
+ * @title IOpenLiquidityStrategy
+ * @notice Interface for liquidity strategy where the rebalancer (caller) provides liquidity directly
+ */
+interface IOpenLiquidityStrategy is ILiquidityStrategy {
+  /* ============================================================ */
+  /* ======================== Errors ============================ */
+  /* ============================================================ */
+
+  /// @notice Thrown when the rebalancer has no collateral available for contraction
+  error OLS_OUT_OF_COLLATERAL();
+  /// @notice Thrown when the rebalancer has no debt tokens available for expansion
+  error OLS_OUT_OF_DEBT();
+
+  /* ============================================================ */
+  /* ==================== Mutative Functions ==================== */
+  /* ============================================================ */
+
+  /**
+   * @notice Initializes the OpenLiquidityStrategy contract
+   * @param _initialOwner The initial owner of the contract
+   */
+  function initialize(address _initialOwner) external;
+
+  /**
+   * @notice Adds a new liquidity pool to be managed by the strategy
+   * @param params The parameters for adding a pool
+   */
+  function addPool(AddPoolParams calldata params) external;
+
+  /**
+   * @notice Removes a pool from the strategy
+   * @param pool The address of the pool to remove
+   */
+  function removePool(address pool) external;
+}

--- a/contracts/liquidityStrategies/LiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/LiquidityStrategy.sol
@@ -78,6 +78,7 @@ abstract contract LiquidityStrategy is
 
   /// @inheritdoc ILiquidityStrategy
   function rebalance(address pool) external virtual nonReentrant {
+    _beforeRebalance(pool);
     _ensurePool(pool);
     if (_getHookCalled(pool)) {
       revert LS_CAN_ONLY_REBALANCE_ONCE(pool);
@@ -172,6 +173,14 @@ abstract contract LiquidityStrategy is
   /* =========================================================== */
   /* ==================== Virtual Functions ==================== */
   /* =========================================================== */
+  /**
+   * @notice Hook called at the start of rebalance() before any logic executes
+   * @dev Override to perform setup when rebalance is called (e.g. storing msg.sender)
+   * @param pool The address of the pool being rebalanced
+   */
+  // solhint-disable-next-line no-empty-blocks
+  function _beforeRebalance(address pool) internal virtual {}
+
   /**
    * @notice Handles the rebalance callback from the FPMM pool
    * @dev Must be implemented by concrete strategies to source liquidity
@@ -473,7 +482,7 @@ abstract contract LiquidityStrategy is
    * @param pool The address of the pool being checked
    * @return hookCalled True if the hook was called for this pool in the current transaction
    */
-  function _getHookCalled(address pool) private view returns (bool hookCalled) {
+  function _getHookCalled(address pool) internal view returns (bool hookCalled) {
     bytes32 key = bytes32(uint256(uint160(pool)));
     // solhint-disable-next-line no-inline-assembly
     assembly {

--- a/contracts/liquidityStrategies/LiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/LiquidityStrategy.sol
@@ -78,8 +78,8 @@ abstract contract LiquidityStrategy is
 
   /// @inheritdoc ILiquidityStrategy
   function rebalance(address pool) external virtual nonReentrant {
-    _beforeRebalance(pool);
     _ensurePool(pool);
+    _beforeRebalance(pool);
     if (_getHookCalled(pool)) {
       revert LS_CAN_ONLY_REBALANCE_ONCE(pool);
     }
@@ -174,7 +174,7 @@ abstract contract LiquidityStrategy is
   /* ==================== Virtual Functions ==================== */
   /* =========================================================== */
   /**
-   * @notice Hook called at the start of rebalance() before any logic executes
+   * @notice Hook called during rebalance() after pool validation and before rebalance logic
    * @dev Override to perform setup when rebalance is called (e.g. storing msg.sender)
    * @param pool The address of the pool being rebalanced
    */
@@ -482,7 +482,7 @@ abstract contract LiquidityStrategy is
    * @param pool The address of the pool being checked
    * @return hookCalled True if the hook was called for this pool in the current transaction
    */
-  function _getHookCalled(address pool) internal view returns (bool hookCalled) {
+  function _getHookCalled(address pool) private view returns (bool hookCalled) {
     bytes32 key = bytes32(uint256(uint160(pool)));
     // solhint-disable-next-line no-inline-assembly
     assembly {

--- a/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
@@ -209,6 +209,7 @@ contract OpenLiquidityStrategy is IOpenLiquidityStrategy, LiquidityStrategy {
     // Transfer remaining tokens to rebalancer (includes liquidity source incentive)
     IERC20(tokenFromPool).safeTransfer(rebalancer, amountFromPool - protocolIncentiveAmount);
     // Pull tokens from rebalancer and send to pool
+    // slither-disable-next-line arbitrary-send-erc20
     IERC20(tokenToPool).safeTransferFrom(rebalancer, pool, cb.amountOwedToPool);
   }
 

--- a/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
@@ -6,9 +6,7 @@ import { IERC20Upgradeable as IERC20 } from "openzeppelin-contracts-upgradeable/
 import { SafeERC20Upgradeable as SafeERC20 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
 import { LiquidityStrategy } from "./LiquidityStrategy.sol";
-import { ILiquidityStrategy } from "../interfaces/ILiquidityStrategy.sol";
 import { IOpenLiquidityStrategy } from "../interfaces/IOpenLiquidityStrategy.sol";
-import { IFPMM } from "../interfaces/IFPMM.sol";
 import { LiquidityStrategyTypes as LQ } from "../libraries/LiquidityStrategyTypes.sol";
 
 /**
@@ -54,56 +52,18 @@ contract OpenLiquidityStrategy is IOpenLiquidityStrategy, LiquidityStrategy {
     LiquidityStrategy._removePool(pool);
   }
 
-  function rebalance(address pool) external override(ILiquidityStrategy, LiquidityStrategy) nonReentrant {
-    _setRebalancer(_msgSender());
-
-    _ensurePool(pool);
-    if (_isHookCalled(pool)) {
-      revert LS_CAN_ONLY_REBALANCE_ONCE(pool);
-    }
-
-    PoolConfig memory config = poolConfigs[pool];
-    // Skip cooldown check for first rebalance (lastRebalance == 0)
-    if (config.lastRebalance > 0 && block.timestamp < config.lastRebalance + config.rebalanceCooldown) {
-      revert LS_COOLDOWN_ACTIVE();
-    }
-
-    LQ.Context memory ctx = LQ.newRebalanceContext(pool, config);
-    LQ.Action memory action = _determineAction(ctx);
-
-    (address debtToken, address collToken) = ctx.tokens();
-
-    bytes memory hookData = abi.encode(
-      LQ.CallbackData({
-        amountOwedToPool: action.amountOwedToPool,
-        dir: action.dir,
-        isToken0Debt: ctx.isToken0Debt,
-        debtToken: debtToken,
-        collToken: collToken
-      })
-    );
-
-    poolConfigs[pool].lastRebalance = uint32(block.timestamp);
-    IFPMM(pool).rebalance(action.amount0Out, action.amount1Out, hookData);
-    if (!_isHookCalled(pool)) {
-      revert LS_HOOK_NOT_CALLED();
-    }
-
-    // slither-disable-start incorrect-equality
-    emit LiquidityMoved({
-      pool: pool,
-      direction: action.dir,
-      tokenGivenToPool: action.dir == LQ.Direction.Expand ? debtToken : collToken,
-      amountGivenToPool: action.amountOwedToPool,
-      tokenTakenFromPool: action.dir == LQ.Direction.Expand ? collToken : debtToken,
-      amountTakenFromPool: action.amount0Out + action.amount1Out // only one is positive
-    });
-    // slither-disable-end incorrect-equality
-  }
-
   /* =========================================================== */
   /* ==================== Virtual Functions ==================== */
   /* =========================================================== */
+
+  /**
+   * @notice Stores the caller as the rebalancer before rebalance logic executes
+   * @param pool The address of the pool being rebalanced (unused)
+   */
+  function _beforeRebalance(address pool) internal override {
+    (pool); // silence unused parameter warning
+    _setRebalancer(_msgSender());
+  }
 
   /**
    * @notice Clamps expansion amounts based on the rebalancer's debt token balance
@@ -238,20 +198,6 @@ contract OpenLiquidityStrategy is IOpenLiquidityStrategy, LiquidityStrategy {
     // solhint-disable-next-line no-inline-assembly
     assembly {
       rebalancer := tload(slot)
-    }
-  }
-
-  /**
-   * @notice Checks if the hook was called for a pool in the current transaction
-   * @dev Mirrors LiquidityStrategy._getHookCalled (which is private) using the same key derivation
-   * @param pool The address of the pool being checked
-   * @return called True if the hook was called for this pool
-   */
-  function _isHookCalled(address pool) private view returns (bool called) {
-    bytes32 key = bytes32(uint256(uint160(pool)));
-    // solhint-disable-next-line no-inline-assembly
-    assembly {
-      called := tload(key)
     }
   }
 }

--- a/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
@@ -58,10 +58,8 @@ contract OpenLiquidityStrategy is IOpenLiquidityStrategy, LiquidityStrategy {
 
   /**
    * @notice Stores the caller as the rebalancer before rebalance logic executes
-   * @param pool The address of the pool being rebalanced (unused)
    */
-  function _beforeRebalance(address pool) internal override {
-    (pool); // silence unused parameter warning
+  function _beforeRebalance(address /* pool */) internal override {
     _setRebalancer(_msgSender());
   }
 

--- a/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/OpenLiquidityStrategy.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.24;
+
+import { IERC20Upgradeable as IERC20 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
+// solhint-disable-next-line max-line-length
+import { SafeERC20Upgradeable as SafeERC20 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+import { LiquidityStrategy } from "./LiquidityStrategy.sol";
+import { ILiquidityStrategy } from "../interfaces/ILiquidityStrategy.sol";
+import { IOpenLiquidityStrategy } from "../interfaces/IOpenLiquidityStrategy.sol";
+import { IFPMM } from "../interfaces/IFPMM.sol";
+import { LiquidityStrategyTypes as LQ } from "../libraries/LiquidityStrategyTypes.sol";
+
+/**
+ * @title OpenLiquidityStrategy
+ * @notice Liquidity strategy where the caller of rebalance() acts as the liquidity source.
+ * @dev The rebalancer provides tokens to the pool and receives tokens from the pool
+ *      via standard ERC20 transfers. The rebalancer must approve this contract for
+ *      the tokens owed to the pool before calling rebalance().
+ */
+contract OpenLiquidityStrategy is IOpenLiquidityStrategy, LiquidityStrategy {
+  using LQ for LQ.Context;
+  using SafeERC20 for IERC20;
+
+  /// @dev Transient storage slot for the rebalancer address
+  bytes32 private constant REBALANCER_TSLOT = keccak256("OpenLiquidityStrategy.rebalancer");
+
+  /* ============================================================ */
+  /* ======================= Constructor ======================== */
+  /* ============================================================ */
+
+  /**
+   * @notice Disables initializers on implementation contracts.
+   * @param disable Set to true to disable initializers (for proxy pattern).
+   */
+  constructor(bool disable) LiquidityStrategy(disable) {}
+
+  /// @inheritdoc IOpenLiquidityStrategy
+  function initialize(address _initialOwner) public initializer {
+    __LiquidityStrategy_init(_initialOwner);
+  }
+
+  /* ============================================================ */
+  /* ==================== External Functions ==================== */
+  /* ============================================================ */
+
+  /// @inheritdoc IOpenLiquidityStrategy
+  function addPool(AddPoolParams calldata params) external onlyOwner {
+    LiquidityStrategy._addPool(params);
+  }
+
+  /// @inheritdoc IOpenLiquidityStrategy
+  function removePool(address pool) external onlyOwner {
+    LiquidityStrategy._removePool(pool);
+  }
+
+  function rebalance(address pool) external override(ILiquidityStrategy, LiquidityStrategy) nonReentrant {
+    _setRebalancer(_msgSender());
+
+    _ensurePool(pool);
+    if (_isHookCalled(pool)) {
+      revert LS_CAN_ONLY_REBALANCE_ONCE(pool);
+    }
+
+    PoolConfig memory config = poolConfigs[pool];
+    // Skip cooldown check for first rebalance (lastRebalance == 0)
+    if (config.lastRebalance > 0 && block.timestamp < config.lastRebalance + config.rebalanceCooldown) {
+      revert LS_COOLDOWN_ACTIVE();
+    }
+
+    LQ.Context memory ctx = LQ.newRebalanceContext(pool, config);
+    LQ.Action memory action = _determineAction(ctx);
+
+    (address debtToken, address collToken) = ctx.tokens();
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: action.amountOwedToPool,
+        dir: action.dir,
+        isToken0Debt: ctx.isToken0Debt,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    poolConfigs[pool].lastRebalance = uint32(block.timestamp);
+    IFPMM(pool).rebalance(action.amount0Out, action.amount1Out, hookData);
+    if (!_isHookCalled(pool)) {
+      revert LS_HOOK_NOT_CALLED();
+    }
+
+    // slither-disable-start incorrect-equality
+    emit LiquidityMoved({
+      pool: pool,
+      direction: action.dir,
+      tokenGivenToPool: action.dir == LQ.Direction.Expand ? debtToken : collToken,
+      amountGivenToPool: action.amountOwedToPool,
+      tokenTakenFromPool: action.dir == LQ.Direction.Expand ? collToken : debtToken,
+      amountTakenFromPool: action.amount0Out + action.amount1Out // only one is positive
+    });
+    // slither-disable-end incorrect-equality
+  }
+
+  /* =========================================================== */
+  /* ==================== Virtual Functions ==================== */
+  /* =========================================================== */
+
+  /**
+   * @notice Clamps expansion amounts based on the rebalancer's debt token balance
+   * @dev For expansions, checks the rebalancer's debt token balance and adjusts if insufficient
+   * @param ctx The liquidity context containing pool state and configuration
+   * @param idealDebtToExpand The calculated ideal amount of debt tokens to add to pool
+   * @param idealCollateralToPay The calculated ideal amount of collateral to receive from pool
+   * @return debtToExpand The actual debt amount to expand (may be less than ideal)
+   * @return collateralToPay The actual collateral amount to receive (adjusted if balance insufficient)
+   */
+  function _clampExpansion(
+    LQ.Context memory ctx,
+    uint256 idealDebtToExpand,
+    uint256 idealCollateralToPay
+  ) internal view override returns (uint256 debtToExpand, uint256 collateralToPay) {
+    address debtToken = ctx.debtToken();
+    uint256 debtBalance = IERC20(debtToken).balanceOf(_getRebalancer());
+
+    // slither-disable-next-line incorrect-equality
+    if (debtBalance == 0) revert OLS_OUT_OF_DEBT();
+
+    if (debtBalance < idealDebtToExpand) {
+      uint256 combinedFeeMultiplier = LQ.combineFees(
+        ctx.incentives.protocolIncentiveExpansion,
+        ctx.incentives.liquiditySourceIncentiveExpansion
+      );
+      debtToExpand = debtBalance;
+      collateralToPay = ctx.convertToCollateralWithFee(debtBalance, LQ.FEE_DENOMINATOR, combinedFeeMultiplier);
+    } else {
+      debtToExpand = idealDebtToExpand;
+      collateralToPay = idealCollateralToPay;
+    }
+
+    return (debtToExpand, collateralToPay);
+  }
+
+  /**
+   * @notice Clamps contraction amounts based on the rebalancer's collateral balance
+   * @dev For contractions, checks the rebalancer's collateral balance and adjusts if insufficient
+   * @param ctx The liquidity context containing pool state and configuration
+   * @param idealDebtToContract The calculated ideal amount of debt tokens to receive from pool
+   * @param idealCollateralToReceive The calculated ideal amount of collateral to add to pool
+   * @return debtToContract The actual debt amount to contract (may be less than ideal)
+   * @return collateralToReceive The actual collateral amount to send (adjusted if balance insufficient)
+   */
+  function _clampContraction(
+    LQ.Context memory ctx,
+    uint256 idealDebtToContract,
+    uint256 idealCollateralToReceive
+  ) internal view override returns (uint256 debtToContract, uint256 collateralToReceive) {
+    address collateralToken = ctx.collateralToken();
+    uint256 collateralBalance = IERC20(collateralToken).balanceOf(_getRebalancer());
+
+    // slither-disable-next-line incorrect-equality
+    if (collateralBalance == 0) revert OLS_OUT_OF_COLLATERAL();
+
+    if (collateralBalance < idealCollateralToReceive) {
+      uint256 combinedFeeMultiplier = LQ.combineFees(
+        ctx.incentives.protocolIncentiveContraction,
+        ctx.incentives.liquiditySourceIncentiveContraction
+      );
+      collateralToReceive = collateralBalance;
+      debtToContract = ctx.convertToDebtWithFee(collateralBalance, LQ.FEE_DENOMINATOR, combinedFeeMultiplier);
+    } else {
+      collateralToReceive = idealCollateralToReceive;
+      debtToContract = idealDebtToContract;
+    }
+
+    return (debtToContract, collateralToReceive);
+  }
+
+  /* ============================================================ */
+  /* ================= Callback Implementation ================== */
+  /* ============================================================ */
+
+  /**
+   * @notice Handles the rebalance callback by transferring tokens to/from the rebalancer
+   * @dev Tokens received from the pool (minus protocol incentive) go to the rebalancer.
+   *      Tokens owed to the pool are pulled from the rebalancer via transferFrom.
+   * @param pool The address of the FPMM pool
+   * @param amount0Out The amount of token0 sent by the pool
+   * @param amount1Out The amount of token1 sent by the pool
+   * @param cb The callback data containing rebalance parameters
+   */
+  function _handleCallback(
+    address pool,
+    uint256 amount0Out,
+    uint256 amount1Out,
+    LQ.CallbackData memory cb
+  ) internal override {
+    PoolConfig memory config = poolConfigs[pool];
+    address rebalancer = _getRebalancer();
+
+    (address tokenFromPool, address tokenToPool, uint256 protocolIncentive) = cb.dir == LQ.Direction.Expand
+      ? (cb.collToken, cb.debtToken, uint256(config.protocolIncentiveExpansion))
+      : (cb.debtToken, cb.collToken, uint256(config.protocolIncentiveContraction));
+
+    uint256 amountFromPool = amount0Out > 0 ? amount0Out : amount1Out;
+    uint256 protocolIncentiveAmount = (amountFromPool * protocolIncentive) / LQ.FEE_DENOMINATOR;
+
+    // Transfer protocol incentive to protocol fee recipient
+    _transferRebalanceIncentive(tokenFromPool, protocolIncentiveAmount, config.protocolFeeRecipient);
+    // Transfer remaining tokens to rebalancer (includes liquidity source incentive)
+    IERC20(tokenFromPool).safeTransfer(rebalancer, amountFromPool - protocolIncentiveAmount);
+    // Pull tokens from rebalancer and send to pool
+    IERC20(tokenToPool).safeTransferFrom(rebalancer, pool, cb.amountOwedToPool);
+  }
+
+  /* ============================================================ */
+  /* ==================== Private Functions ===================== */
+  /* ============================================================ */
+
+  /**
+   * @notice Stores the rebalancer address in transient storage
+   * @param rebalancer The address of the rebalancer (msg.sender of rebalance())
+   */
+  function _setRebalancer(address rebalancer) private {
+    bytes32 slot = REBALANCER_TSLOT;
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      tstore(slot, rebalancer)
+    }
+  }
+
+  /**
+   * @notice Reads the rebalancer address from transient storage
+   * @return rebalancer The stored rebalancer address
+   */
+  function _getRebalancer() private view returns (address rebalancer) {
+    bytes32 slot = REBALANCER_TSLOT;
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      rebalancer := tload(slot)
+    }
+  }
+
+  /**
+   * @notice Checks if the hook was called for a pool in the current transaction
+   * @dev Mirrors LiquidityStrategy._getHookCalled (which is private) using the same key derivation
+   * @param pool The address of the pool being checked
+   * @return called True if the hook was called for this pool
+   */
+  function _isHookCalled(address pool) private view returns (bool called) {
+    bytes32 key = bytes32(uint256(uint160(pool)));
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      called := tload(key)
+    }
+  }
+}

--- a/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Admin.t.sol
+++ b/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Admin.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+// solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
+pragma solidity ^0.8;
+
+import { OpenLiquidityStrategy_BaseTest } from "./OpenLiquidityStrategy_BaseTest.sol";
+import { OpenLiquidityStrategy } from "contracts/liquidityStrategies/OpenLiquidityStrategy.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
+
+contract OpenLiquidityStrategy_AdminTest is OpenLiquidityStrategy_BaseTest {
+  /* ============================================================ */
+  /* =================== Initialization Tests ================== */
+  /* ============================================================ */
+
+  function test_initialize_whenValidParameters_shouldSetCorrectly() public {
+    address newOwner = makeAddr("NewOwner");
+
+    OpenLiquidityStrategy newStrategy = new OpenLiquidityStrategy(false);
+    newStrategy.initialize(newOwner);
+
+    assertEq(newStrategy.owner(), newOwner, "Should set owner correctly");
+  }
+
+  function test_initialize_whenZeroOwner_shouldRevert() public {
+    OpenLiquidityStrategy newStrategy = new OpenLiquidityStrategy(false);
+    vm.expectRevert("LS_INVALID_OWNER()");
+    newStrategy.initialize(address(0));
+  }
+
+  function test_initialize_whenCalledTwice_shouldRevert() public {
+    OpenLiquidityStrategy newStrategy = new OpenLiquidityStrategy(false);
+    newStrategy.initialize(owner);
+    vm.expectRevert("Initializable: contract is already initialized");
+    newStrategy.initialize(owner);
+  }
+
+  /* ============================================================ */
+  /* =================== Pool Management ======================== */
+  /* ============================================================ */
+
+  function test_addPool_whenValidParams_shouldAddPool() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      protocolFeeRecipient,
+      25,
+      25,
+      25,
+      25
+    );
+    vm.expectEmit(true, true, true, true);
+    emit PoolAdded(address(fpmm), params);
+
+    vm.prank(owner);
+    strategy.addPool(params);
+
+    assertTrue(strategy.isPoolRegistered(address(fpmm)));
+  }
+
+  function test_addPool_whenPoolIsZero_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(0),
+      debtToken,
+      3600,
+      protocolFeeRecipient,
+      25,
+      25,
+      25,
+      25
+    );
+    vm.prank(owner);
+    vm.expectRevert(ILiquidityStrategy.LS_POOL_MUST_BE_SET.selector);
+    strategy.addPool(params);
+  }
+
+  function test_addPool_whenPoolAlreadyExists_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      protocolFeeRecipient,
+      25,
+      25,
+      25,
+      25
+    );
+    vm.prank(owner);
+    strategy.addPool(params);
+
+    vm.prank(owner);
+    vm.expectRevert(ILiquidityStrategy.LS_POOL_ALREADY_EXISTS.selector);
+    strategy.addPool(params);
+  }
+
+  function test_addPool_whenCalledByNonOwner_shouldRevert() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      protocolFeeRecipient,
+      25,
+      25,
+      25,
+      25
+    );
+    vm.prank(notOwner);
+    vm.expectRevert();
+    strategy.addPool(params);
+  }
+
+  function test_removePool_whenPoolExists_shouldRemovePool() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      protocolFeeRecipient,
+      25,
+      25,
+      25,
+      25
+    );
+    vm.prank(owner);
+    strategy.addPool(params);
+
+    vm.expectEmit(true, false, false, false);
+    emit PoolRemoved(address(fpmm));
+
+    vm.prank(owner);
+    strategy.removePool(address(fpmm));
+
+    assertFalse(strategy.isPoolRegistered(address(fpmm)));
+  }
+
+  function test_removePool_whenPoolDoesNotExist_shouldRevert() public fpmmToken0Debt(18, 18) {
+    vm.prank(owner);
+    vm.expectRevert(ILiquidityStrategy.LS_POOL_NOT_FOUND.selector);
+    strategy.removePool(address(fpmm));
+  }
+
+  function test_setRebalanceCooldown_whenPoolExists_shouldUpdateCooldown() public fpmmToken0Debt(18, 18) {
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      3600,
+      protocolFeeRecipient,
+      25,
+      25,
+      25,
+      25
+    );
+    vm.prank(owner);
+    strategy.addPool(params);
+
+    vm.expectEmit(true, false, false, true);
+    emit RebalanceCooldownSet(address(fpmm), 7200);
+
+    vm.prank(owner);
+    strategy.setRebalanceCooldown(address(fpmm), 7200);
+  }
+}

--- a/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_BaseTest.sol
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+// solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
+pragma solidity ^0.8;
+
+import { LiquidityStrategy_BaseTest } from "../LiquidityStrategy/LiquidityStrategy_BaseTest.sol";
+import { OpenLiquidityStrategyHarness } from "test/utils/harnesses/OpenLiquidityStrategyHarness.sol";
+import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
+import { MockERC20 } from "test/utils/mocks/MockERC20.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
+
+contract OpenLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
+  OpenLiquidityStrategyHarness public strategy;
+
+  address public rebalancer = makeAddr("Rebalancer");
+
+  function setUp() public virtual override {
+    LiquidityStrategy_BaseTest.setUp();
+
+    strategy = new OpenLiquidityStrategyHarness(owner);
+    strategyAddr = address(strategy);
+  }
+
+  modifier addFpmm(
+    uint32 cooldown,
+    uint64 liquiditySourceIncentiveExpansion,
+    uint64 protocolIncentiveExpansion,
+    uint64 liquiditySourceIncentiveContraction,
+    uint64 protocolIncentiveContraction
+  ) {
+    // Set FPMM rebalance incentive cap to match or exceed strategy incentive
+    uint64 fpmmIncentive = liquiditySourceIncentiveExpansion + protocolIncentiveExpansion >=
+      liquiditySourceIncentiveContraction + protocolIncentiveContraction
+      ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
+      : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
+
+    // Convert from basis points to bps
+    fpmmIncentive = fpmmIncentive / 1e14;
+
+    fpmm.setRebalanceIncentive(fpmmIncentive);
+
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      cooldown,
+      protocolFeeRecipient,
+      liquiditySourceIncentiveExpansion,
+      protocolIncentiveExpansion,
+      liquiditySourceIncentiveContraction,
+      protocolIncentiveContraction
+    );
+
+    vm.prank(owner);
+    strategy.addPool(params);
+
+    // Fund rebalancer with both tokens and approve strategy
+    MockERC20(debtToken).mint(rebalancer, 1_000_000e18);
+    MockERC20(collToken).mint(rebalancer, 1_000_000e18);
+    vm.startPrank(rebalancer);
+    MockERC20(debtToken).approve(strategyAddr, type(uint256).max);
+    MockERC20(collToken).approve(strategyAddr, type(uint256).max);
+    vm.stopPrank();
+    _;
+  }
+
+  modifier addFpmmWithIncentive(
+    uint32 cooldown,
+    uint16 rebalanceIncentive,
+    uint64 liquiditySourceIncentiveExpansion,
+    uint64 protocolIncentiveExpansion,
+    uint64 liquiditySourceIncentiveContraction,
+    uint64 protocolIncentiveContraction
+  ) {
+    fpmm.setRebalanceIncentive(rebalanceIncentive);
+
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      cooldown,
+      protocolFeeRecipient,
+      liquiditySourceIncentiveExpansion,
+      protocolIncentiveExpansion,
+      liquiditySourceIncentiveContraction,
+      protocolIncentiveContraction
+    );
+
+    vm.prank(owner);
+    strategy.addPool(params);
+
+    // Fund rebalancer with both tokens and approve strategy
+    MockERC20(debtToken).mint(rebalancer, 1_000_000e18);
+    MockERC20(collToken).mint(rebalancer, 1_000_000e18);
+    vm.startPrank(rebalancer);
+    MockERC20(debtToken).approve(strategyAddr, type(uint256).max);
+    MockERC20(collToken).approve(strategyAddr, type(uint256).max);
+    vm.stopPrank();
+    _;
+  }
+
+  /* ============================================================ */
+  /* ================= Helper Functions ========================= */
+  /* ============================================================ */
+
+  /**
+   * @notice Create a liquidity context for testing
+   */
+  function _createContext(
+    uint256 reserveDen,
+    uint256 reserveNum,
+    uint256 oracleNum,
+    uint256 oracleDen,
+    bool poolPriceAbove,
+    LQ.RebalanceIncentives memory incentives
+  ) internal view returns (LQ.Context memory) {
+    return
+      _createContextWithDecimals(reserveDen, reserveNum, oracleNum, oracleDen, poolPriceAbove, 1e18, 1e18, incentives);
+  }
+
+  /**
+   * @notice Create a liquidity context with custom decimals
+   */
+  function _createContextWithDecimals(
+    uint256 reserveDen,
+    uint256 reserveNum,
+    uint256 oracleNum,
+    uint256 oracleDen,
+    bool poolPriceAbove,
+    uint256 token0Dec,
+    uint256 token1Dec,
+    LQ.RebalanceIncentives memory incentives
+  ) internal view returns (LQ.Context memory) {
+    return
+      LQ.Context({
+        pool: address(fpmm),
+        reserves: LQ.Reserves({ reserveNum: reserveNum, reserveDen: reserveDen }),
+        prices: LQ.Prices({
+          oracleNum: oracleNum,
+          oracleDen: oracleDen,
+          poolPriceAbove: poolPriceAbove,
+          rebalanceThreshold: 500
+        }),
+        token0Dec: uint64(token0Dec),
+        token1Dec: uint64(token1Dec),
+        token0: debtToken,
+        token1: collToken,
+        isToken0Debt: true,
+        incentives: incentives
+      });
+  }
+
+  /**
+   * @notice Create a liquidity context with custom token order
+   */
+  function _createContextWithTokenOrder(
+    uint256 reserveDen,
+    uint256 reserveNum,
+    uint256 oracleNum,
+    uint256 oracleDen,
+    bool poolPriceAbove,
+    bool isToken0Debt,
+    LQ.RebalanceIncentives memory incentives
+  ) internal view returns (LQ.Context memory) {
+    return
+      LQ.Context({
+        pool: address(fpmm),
+        reserves: LQ.Reserves({ reserveNum: reserveNum, reserveDen: reserveDen }),
+        prices: LQ.Prices({
+          oracleNum: oracleNum,
+          oracleDen: oracleDen,
+          poolPriceAbove: poolPriceAbove,
+          rebalanceThreshold: 500
+        }),
+        token0Dec: 1e18,
+        token1Dec: 1e18,
+        token0: isToken0Debt ? debtToken : collToken,
+        token1: isToken0Debt ? collToken : debtToken,
+        isToken0Debt: isToken0Debt,
+        incentives: incentives
+      });
+  }
+
+  function _expectLiquidityMovedEvent(
+    address _pool,
+    LQ.Direction _direction,
+    address _tokenGivenToPool,
+    uint256 _amountGivenToPool,
+    address _tokenTakenFromPool,
+    uint256 _amountTakenFromPool
+  ) internal {
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(
+      _pool,
+      _direction,
+      _tokenGivenToPool,
+      _amountGivenToPool,
+      _tokenTakenFromPool,
+      _amountTakenFromPool
+    );
+  }
+
+  /**
+   * @notice Expect an ERC20 transfer event from the strategy
+   */
+  function expectERC20Transfer(address token, address from, address to, uint256 amount) internal {
+    vm.expectEmit(true, true, false, true, token);
+    emit Transfer(from, to, amount);
+  }
+
+  /* ============================================================ */
+  /* ======================= Events ============================= */
+  /* ============================================================ */
+
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_BaseTest.sol
+++ b/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_BaseTest.sol
@@ -34,7 +34,7 @@ contract OpenLiquidityStrategy_BaseTest is LiquidityStrategy_BaseTest {
       ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
       : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
 
-    // Convert from basis points to bps
+    // Convert from 1e18-denominated to bps
     fpmmIncentive = fpmmIncentive / 1e14;
 
     fpmm.setRebalanceIncentive(fpmmIncentive);

--- a/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Hook.t.sol
+++ b/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Hook.t.sol
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+// solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
+// solhint-disable max-line-length
+pragma solidity ^0.8;
+
+import { OpenLiquidityStrategy_BaseTest } from "./OpenLiquidityStrategy_BaseTest.sol";
+import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import { MockERC20 } from "test/utils/mocks/MockERC20.sol";
+
+contract OpenLiquidityStrategy_HookTest is OpenLiquidityStrategy_BaseTest {
+  function setUp() public override {
+    super.setUp();
+  }
+
+  /* ============================================================ */
+  /* ====================== Hook Function ======================= */
+  /* ============================================================ */
+
+  function test_hook_whenValidExpansionCallback_shouldTransferToAndFromRebalancer()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    uint256 amountOwedToPool = 100e18;
+    uint256 amount0Out = 0;
+    uint256 amount1Out = 100e18; // collateral out from pool
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Expand,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    uint256 protocolIncentive = (amount1Out * 0.005e18) / 1e18;
+    uint256 toRebalancer = amount1Out - protocolIncentive;
+
+    // Fund strategy (simulating pool sending tokens during callback)
+    MockERC20(collToken).mint(address(strategy), amount1Out);
+
+    uint256 feeRecipientCollBefore = IERC20(collToken).balanceOf(protocolFeeRecipient);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 fpmmDebtBefore = IERC20(debtToken).balanceOf(address(fpmm));
+
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+
+    // Protocol fee recipient gets collateral incentive
+    assertEq(IERC20(collToken).balanceOf(protocolFeeRecipient) - feeRecipientCollBefore, protocolIncentive);
+    // Rebalancer gets remaining collateral
+    assertEq(IERC20(collToken).balanceOf(rebalancer) - rebalancerCollBefore, toRebalancer);
+    // Rebalancer's debt decreases (pulled to pool)
+    assertEq(rebalancerDebtBefore - IERC20(debtToken).balanceOf(rebalancer), amountOwedToPool);
+    // Pool receives debt
+    assertEq(IERC20(debtToken).balanceOf(address(fpmm)) - fpmmDebtBefore, amountOwedToPool);
+  }
+
+  function test_hook_whenValidContractionCallback_shouldTransferToAndFromRebalancer()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    uint256 amountOwedToPool = 100e18; // collateral going into pool
+    uint256 amount0Out = 100e18; // debt coming out of pool
+    uint256 amount1Out = 0;
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Contract,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    uint256 protocolIncentive = (amount0Out * 0.005e18) / 1e18;
+    uint256 toRebalancer = amount0Out - protocolIncentive;
+
+    // Fund strategy (simulating pool sending tokens during callback)
+    MockERC20(debtToken).mint(address(strategy), amount0Out);
+
+    uint256 feeRecipientDebtBefore = IERC20(debtToken).balanceOf(protocolFeeRecipient);
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    uint256 fpmmCollBefore = IERC20(collToken).balanceOf(address(fpmm));
+
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+
+    // Protocol fee recipient gets debt incentive
+    assertEq(IERC20(debtToken).balanceOf(protocolFeeRecipient) - feeRecipientDebtBefore, protocolIncentive);
+    // Rebalancer gets remaining debt
+    assertEq(IERC20(debtToken).balanceOf(rebalancer) - rebalancerDebtBefore, toRebalancer);
+    // Rebalancer's collateral decreases (pulled to pool)
+    assertEq(rebalancerCollBefore - IERC20(collToken).balanceOf(rebalancer), amountOwedToPool);
+    // Pool receives collateral
+    assertEq(IERC20(collToken).balanceOf(address(fpmm)) - fpmmCollBefore, amountOwedToPool);
+  }
+
+  function test_hook_whenUntrustedPool_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: 100e18,
+        dir: LQ.Direction.Expand,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    address untrustedPool = makeAddr("untrustedPool");
+    vm.prank(untrustedPool);
+    vm.expectRevert("LS_POOL_NOT_FOUND()");
+    strategy.onRebalance(address(strategy), 0, 100e18, hookData);
+  }
+
+  function test_hook_whenInvalidSender_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: 100e18,
+        dir: LQ.Direction.Expand,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    vm.prank(address(fpmm));
+    vm.expectRevert("LS_INVALID_SENDER()");
+    strategy.onRebalance(owner, 0, 100e18, hookData); // Wrong sender
+  }
+
+  /* ============================================================ */
+  /* ================= Expansion Callback Tests ================ */
+  /* ============================================================ */
+
+  function test_hook_expansionCallback_whenToken0IsDebt_shouldTransferCorrectly()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    uint256 amountOwedToPool = 200e18;
+    uint256 amount0Out = 0;
+    uint256 amount1Out = 200e18; // collateral out
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Expand,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    uint256 protocolIncentive = (amount1Out * 0.005e18) / 1e18;
+    uint256 toRebalancer = amount1Out - protocolIncentive;
+
+    MockERC20(collToken).mint(address(strategy), amount1Out);
+
+    uint256 feeRecipientCollBefore = IERC20(collToken).balanceOf(protocolFeeRecipient);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 fpmmDebtBefore = IERC20(debtToken).balanceOf(address(fpmm));
+
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+
+    assertEq(IERC20(collToken).balanceOf(protocolFeeRecipient) - feeRecipientCollBefore, protocolIncentive);
+    assertEq(IERC20(collToken).balanceOf(rebalancer) - rebalancerCollBefore, toRebalancer);
+    assertEq(rebalancerDebtBefore - IERC20(debtToken).balanceOf(rebalancer), amountOwedToPool);
+    assertEq(IERC20(debtToken).balanceOf(address(fpmm)) - fpmmDebtBefore, amountOwedToPool);
+  }
+
+  function test_hook_expansionCallback_whenToken1IsDebt_shouldTransferCorrectly()
+    public
+    fpmmToken1Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    uint256 amountOwedToPool = 150e18;
+    uint256 amount0Out = 150e18; // collateral out (token0 is collateral)
+    uint256 amount1Out = 0;
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Expand,
+        isToken0Debt: false,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    uint256 protocolIncentive = (amount0Out * 0.005e18) / 1e18;
+    uint256 toRebalancer = amount0Out - protocolIncentive;
+
+    MockERC20(collToken).mint(address(strategy), amount0Out);
+
+    uint256 feeRecipientCollBefore = IERC20(collToken).balanceOf(protocolFeeRecipient);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 fpmmDebtBefore = IERC20(debtToken).balanceOf(address(fpmm));
+
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+
+    assertEq(IERC20(collToken).balanceOf(protocolFeeRecipient) - feeRecipientCollBefore, protocolIncentive);
+    assertEq(IERC20(collToken).balanceOf(rebalancer) - rebalancerCollBefore, toRebalancer);
+    assertEq(rebalancerDebtBefore - IERC20(debtToken).balanceOf(rebalancer), amountOwedToPool);
+    assertEq(IERC20(debtToken).balanceOf(address(fpmm)) - fpmmDebtBefore, amountOwedToPool);
+  }
+
+  /* ============================================================ */
+  /* ================ Contraction Callback Tests =============== */
+  /* ============================================================ */
+
+  function test_hook_contractionCallback_whenToken0IsDebt_shouldTransferCorrectly()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    uint256 amountOwedToPool = 90e18; // collateral going into pool
+    uint256 amount0Out = 90e18; // debt out
+    uint256 amount1Out = 0;
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Contract,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    uint256 protocolIncentive = (amount0Out * 0.005e18) / 1e18;
+    uint256 toRebalancer = amount0Out - protocolIncentive;
+
+    MockERC20(debtToken).mint(address(strategy), amount0Out);
+
+    uint256 feeRecipientDebtBefore = IERC20(debtToken).balanceOf(protocolFeeRecipient);
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    uint256 fpmmCollBefore = IERC20(collToken).balanceOf(address(fpmm));
+
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+
+    assertEq(IERC20(debtToken).balanceOf(protocolFeeRecipient) - feeRecipientDebtBefore, protocolIncentive);
+    assertEq(IERC20(debtToken).balanceOf(rebalancer) - rebalancerDebtBefore, toRebalancer);
+    assertEq(rebalancerCollBefore - IERC20(collToken).balanceOf(rebalancer), amountOwedToPool);
+    assertEq(IERC20(collToken).balanceOf(address(fpmm)) - fpmmCollBefore, amountOwedToPool);
+  }
+
+  function test_hook_contractionCallback_whenToken1IsDebt_shouldTransferCorrectly()
+    public
+    fpmmToken1Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    uint256 amountOwedToPool = 75e18; // collateral going into pool
+    uint256 amount0Out = 0;
+    uint256 amount1Out = 75e18; // debt out (token1 is debt)
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Contract,
+        isToken0Debt: false,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    uint256 protocolIncentive = (amount1Out * 0.005e18) / 1e18;
+    uint256 toRebalancer = amount1Out - protocolIncentive;
+
+    MockERC20(debtToken).mint(address(strategy), amount1Out);
+
+    uint256 feeRecipientDebtBefore = IERC20(debtToken).balanceOf(protocolFeeRecipient);
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    uint256 fpmmCollBefore = IERC20(collToken).balanceOf(address(fpmm));
+
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+
+    assertEq(IERC20(debtToken).balanceOf(protocolFeeRecipient) - feeRecipientDebtBefore, protocolIncentive);
+    assertEq(IERC20(debtToken).balanceOf(rebalancer) - rebalancerDebtBefore, toRebalancer);
+    assertEq(rebalancerCollBefore - IERC20(collToken).balanceOf(rebalancer), amountOwedToPool);
+    assertEq(IERC20(collToken).balanceOf(address(fpmm)) - fpmmCollBefore, amountOwedToPool);
+  }
+
+  /* ============================================================ */
+  /* ==================== Edge Case Tests ====================== */
+  /* ============================================================ */
+
+  function test_hook_withZeroIncentive_shouldTransferAllToRebalancer()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0, 0, 0, 0)
+  {
+    uint256 amountOwedToPool = 100e18;
+    uint256 amount0Out = 0;
+    uint256 amount1Out = 100e18; // collateral out
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Expand,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    MockERC20(collToken).mint(address(strategy), amount1Out);
+
+    uint256 feeRecipientCollBefore = IERC20(collToken).balanceOf(protocolFeeRecipient);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 fpmmDebtBefore = IERC20(debtToken).balanceOf(address(fpmm));
+
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+
+    // No protocol incentive
+    assertEq(IERC20(collToken).balanceOf(protocolFeeRecipient), feeRecipientCollBefore);
+    // Full amount to rebalancer
+    assertEq(IERC20(collToken).balanceOf(rebalancer) - rebalancerCollBefore, amount1Out);
+    // Debt pulled from rebalancer to pool
+    assertEq(rebalancerDebtBefore - IERC20(debtToken).balanceOf(rebalancer), amountOwedToPool);
+    assertEq(IERC20(debtToken).balanceOf(address(fpmm)) - fpmmDebtBefore, amountOwedToPool);
+  }
+
+  function test_hook_whenRebalancerInsufficientApproval_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
+  {
+    uint256 amountOwedToPool = 100e18;
+    uint256 amount0Out = 0;
+    uint256 amount1Out = 100e18;
+
+    bytes memory hookData = abi.encode(
+      LQ.CallbackData({
+        amountOwedToPool: amountOwedToPool,
+        dir: LQ.Direction.Expand,
+        isToken0Debt: true,
+        debtToken: debtToken,
+        collToken: collToken
+      })
+    );
+
+    // Revoke rebalancer's debt token approval
+    vm.prank(rebalancer);
+    MockERC20(debtToken).approve(address(strategy), 0);
+
+    MockERC20(collToken).mint(address(strategy), amount1Out);
+    strategy.setRebalancerForTesting(rebalancer);
+    vm.prank(address(fpmm));
+    vm.expectRevert(); // SafeERC20: transferFrom will fail
+    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
+  }
+}

--- a/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Hook.t.sol
+++ b/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Hook.t.sol
@@ -151,45 +151,6 @@ contract OpenLiquidityStrategy_HookTest is OpenLiquidityStrategy_BaseTest {
   /* ================= Expansion Callback Tests ================ */
   /* ============================================================ */
 
-  function test_hook_expansionCallback_whenToken0IsDebt_shouldTransferCorrectly()
-    public
-    fpmmToken0Debt(18, 18)
-    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
-  {
-    uint256 amountOwedToPool = 200e18;
-    uint256 amount0Out = 0;
-    uint256 amount1Out = 200e18; // collateral out
-
-    bytes memory hookData = abi.encode(
-      LQ.CallbackData({
-        amountOwedToPool: amountOwedToPool,
-        dir: LQ.Direction.Expand,
-        isToken0Debt: true,
-        debtToken: debtToken,
-        collToken: collToken
-      })
-    );
-
-    uint256 protocolIncentive = (amount1Out * 0.005e18) / 1e18;
-    uint256 toRebalancer = amount1Out - protocolIncentive;
-
-    MockERC20(collToken).mint(address(strategy), amount1Out);
-
-    uint256 feeRecipientCollBefore = IERC20(collToken).balanceOf(protocolFeeRecipient);
-    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
-    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
-    uint256 fpmmDebtBefore = IERC20(debtToken).balanceOf(address(fpmm));
-
-    strategy.setRebalancerForTesting(rebalancer);
-    vm.prank(address(fpmm));
-    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
-
-    assertEq(IERC20(collToken).balanceOf(protocolFeeRecipient) - feeRecipientCollBefore, protocolIncentive);
-    assertEq(IERC20(collToken).balanceOf(rebalancer) - rebalancerCollBefore, toRebalancer);
-    assertEq(rebalancerDebtBefore - IERC20(debtToken).balanceOf(rebalancer), amountOwedToPool);
-    assertEq(IERC20(debtToken).balanceOf(address(fpmm)) - fpmmDebtBefore, amountOwedToPool);
-  }
-
   function test_hook_expansionCallback_whenToken1IsDebt_shouldTransferCorrectly()
     public
     fpmmToken1Debt(18, 18)
@@ -232,45 +193,6 @@ contract OpenLiquidityStrategy_HookTest is OpenLiquidityStrategy_BaseTest {
   /* ============================================================ */
   /* ================ Contraction Callback Tests =============== */
   /* ============================================================ */
-
-  function test_hook_contractionCallback_whenToken0IsDebt_shouldTransferCorrectly()
-    public
-    fpmmToken0Debt(18, 18)
-    addFpmm(0, 0.005e18, 0.005e18, 0.005e18, 0.005e18)
-  {
-    uint256 amountOwedToPool = 90e18; // collateral going into pool
-    uint256 amount0Out = 90e18; // debt out
-    uint256 amount1Out = 0;
-
-    bytes memory hookData = abi.encode(
-      LQ.CallbackData({
-        amountOwedToPool: amountOwedToPool,
-        dir: LQ.Direction.Contract,
-        isToken0Debt: true,
-        debtToken: debtToken,
-        collToken: collToken
-      })
-    );
-
-    uint256 protocolIncentive = (amount0Out * 0.005e18) / 1e18;
-    uint256 toRebalancer = amount0Out - protocolIncentive;
-
-    MockERC20(debtToken).mint(address(strategy), amount0Out);
-
-    uint256 feeRecipientDebtBefore = IERC20(debtToken).balanceOf(protocolFeeRecipient);
-    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
-    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
-    uint256 fpmmCollBefore = IERC20(collToken).balanceOf(address(fpmm));
-
-    strategy.setRebalancerForTesting(rebalancer);
-    vm.prank(address(fpmm));
-    strategy.onRebalance(address(strategy), amount0Out, amount1Out, hookData);
-
-    assertEq(IERC20(debtToken).balanceOf(protocolFeeRecipient) - feeRecipientDebtBefore, protocolIncentive);
-    assertEq(IERC20(debtToken).balanceOf(rebalancer) - rebalancerDebtBefore, toRebalancer);
-    assertEq(rebalancerCollBefore - IERC20(collToken).balanceOf(rebalancer), amountOwedToPool);
-    assertEq(IERC20(collToken).balanceOf(address(fpmm)) - fpmmCollBefore, amountOwedToPool);
-  }
 
   function test_hook_contractionCallback_whenToken1IsDebt_shouldTransferCorrectly()
     public

--- a/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Rebalance.t.sol
+++ b/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Rebalance.t.sol
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+// solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
+pragma solidity ^0.8;
+
+import { OpenLiquidityStrategy_BaseTest } from "./OpenLiquidityStrategy_BaseTest.sol";
+import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import { MockERC20 } from "test/utils/mocks/MockERC20.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
+import { IOpenLiquidityStrategy } from "contracts/interfaces/IOpenLiquidityStrategy.sol";
+
+contract OpenLiquidityStrategy_RebalanceTest is OpenLiquidityStrategy_BaseTest {
+  function setUp() public override {
+    super.setUp();
+  }
+
+  /* ============================================================ */
+  /* ================= Rebalance Function Tests ================= */
+  /* ============================================================ */
+
+  function test_rebalance_whenPoolPriceAboveOracle_shouldExpandSuccessfully()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 50, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 100 debt and 200 collateral (excess collateral)
+    provideFPMMReserves(100e18, 200e18, true);
+    // Oracle price is 1:1, pool price is 2:1 (pool price above oracle)
+    setOracleRate(1e18, 1e18);
+
+    // Expansion: debt flows IN from rebalancer, collateral flows OUT to rebalancer
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Expand, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenPoolPriceBelowOracle_shouldContractSuccessfully()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 200 debt and 100 collateral (excess debt)
+    provideFPMMReserves(200e18, 100e18, true);
+    // Oracle price is 1:1, pool price is 0.5:1 (pool price below oracle)
+    setOracleRate(1e18, 1e18);
+
+    // Contraction: collateral flows IN from rebalancer, debt flows OUT to rebalancer
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Contract, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenPoolNotAdded_shouldRevert() public fpmmToken0Debt(18, 18) {
+    provideFPMMReserves(100e18, 200e18, true);
+    setOracleRate(1e18, 1e18);
+
+    vm.expectRevert("LS_POOL_NOT_FOUND()");
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenPoolPriceEqualsOracle_shouldNotRebalance()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has balanced reserves at 1:1
+    provideFPMMReserves(100e18, 100e18, true);
+    // Oracle price is also 1:1 (pool price equals oracle)
+    setOracleRate(1e18, 1e18);
+
+    vm.expectRevert(ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE.selector);
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_withZeroIncentive_shouldSucceed() public fpmmToken0Debt(18, 18) addFpmm(0, 0, 0, 0, 0) {
+    // Setup: Pool has excess collateral
+    provideFPMMReserves(100e18, 200e18, true);
+    setOracleRate(1e18, 1e18);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Expand, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_withMaxIncentive_shouldSucceed()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has excess debt
+    provideFPMMReserves(200e18, 100e18, true);
+    setOracleRate(1e18, 1e18);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Contract, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  /* ============================================================ */
+  /* =================== Token Flow Tests ====================== */
+  /* ============================================================ */
+
+  function test_rebalance_expansion_shouldTransferDebtFromRebalancerAndCollateralToRebalancer()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 100 debt and 200 collateral (excess collateral)
+    provideFPMMReserves(100e18, 200e18, true);
+    setOracleRate(1e18, 1e18);
+
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+
+    uint256 rebalancerDebtAfter = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 rebalancerCollAfter = IERC20(collToken).balanceOf(rebalancer);
+
+    // Expansion: rebalancer provides debt to pool, receives collateral from pool
+    assertLt(rebalancerDebtAfter, rebalancerDebtBefore, "Rebalancer should send debt tokens");
+    assertGt(rebalancerCollAfter, rebalancerCollBefore, "Rebalancer should receive collateral tokens");
+  }
+
+  function test_rebalance_contraction_shouldTransferCollateralFromRebalancerAndDebtToRebalancer()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 200 debt and 100 collateral (excess debt)
+    provideFPMMReserves(200e18, 100e18, true);
+    setOracleRate(1e18, 1e18);
+
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+
+    uint256 rebalancerDebtAfter = IERC20(debtToken).balanceOf(rebalancer);
+    uint256 rebalancerCollAfter = IERC20(collToken).balanceOf(rebalancer);
+
+    // Contraction: rebalancer provides collateral to pool, receives debt from pool
+    assertGt(rebalancerDebtAfter, rebalancerDebtBefore, "Rebalancer should receive debt tokens");
+    assertLt(rebalancerCollAfter, rebalancerCollBefore, "Rebalancer should send collateral tokens");
+  }
+
+  /* ============================================================ */
+  /* =============== Reversed Token Order Tests ================ */
+  /* ============================================================ */
+
+  function test_rebalance_whenToken1IsDebt_shouldExpandCorrectly()
+    public
+    fpmmToken1Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 200 collateral (token0) and 100 debt (token1) - excess collateral
+    provideFPMMReserves(200e18, 100e18, false);
+    setOracleRate(1e18, 1e18);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Expand, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenToken1IsDebt_shouldContractCorrectly()
+    public
+    fpmmToken1Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 100 collateral (token0) and 200 debt (token1) - excess debt
+    provideFPMMReserves(100e18, 200e18, false);
+    setOracleRate(1e18, 1e18);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Contract, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  /* ============================================================ */
+  /* =============== Different Oracle Prices =================== */
+  /* ============================================================ */
+
+  function test_rebalance_withHighOraclePrice_shouldContractCorrectly()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 100 debt and 100 collateral
+    provideFPMMReserves(100e18, 100e18, true);
+    // Oracle price is 2:1, pool needs more collateral
+    setOracleRate(2e18, 1e18);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Contract, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_withLowOraclePrice_shouldExpandCorrectly()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: Pool has 100 debt and 100 collateral
+    provideFPMMReserves(100e18, 100e18, true);
+    // Oracle price is 1:2, pool has excess collateral
+    setOracleRate(1e18, 2e18);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Expand, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  /* ============================================================ */
+  /* ================ Clamping Tests =========================== */
+  /* ============================================================ */
+
+  function test_rebalance_contraction_whenRebalancerHasNoCollateral_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    provideFPMMReserves(200e18, 100e18, true);
+    setOracleRate(1e18, 1e18);
+
+    // Burn all rebalancer's collateral
+    vm.startPrank(rebalancer);
+    MockERC20(collToken).transfer(address(1), MockERC20(collToken).balanceOf(rebalancer));
+    vm.stopPrank();
+
+    vm.expectRevert(IOpenLiquidityStrategy.OLS_OUT_OF_COLLATERAL.selector);
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_expansion_whenRebalancerHasNoDebt_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    provideFPMMReserves(100e18, 200e18, true);
+    setOracleRate(1e18, 1e18);
+
+    // Burn all rebalancer's debt tokens
+    vm.startPrank(rebalancer);
+    MockERC20(debtToken).transfer(address(1), MockERC20(debtToken).balanceOf(rebalancer));
+    vm.stopPrank();
+
+    vm.expectRevert(IOpenLiquidityStrategy.OLS_OUT_OF_DEBT.selector);
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_contraction_whenRebalancerHasLimitedCollateral_shouldClamp()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: large imbalance requiring lots of collateral
+    provideFPMMReserves(1000e18, 100e18, true);
+    setOracleRate(1e18, 1e18);
+
+    // Give rebalancer only a small amount of collateral
+    vm.startPrank(rebalancer);
+    MockERC20(collToken).transfer(address(1), MockERC20(collToken).balanceOf(rebalancer) - 1e18);
+    vm.stopPrank();
+
+    uint256 rebalancerCollBefore = IERC20(collToken).balanceOf(rebalancer);
+    assertEq(rebalancerCollBefore, 1e18, "Rebalancer should have 1e18 collateral");
+
+    // Should succeed with clamped amounts
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+
+    // Rebalancer should have spent their collateral (minus what they received as incentive)
+    uint256 rebalancerCollAfter = IERC20(collToken).balanceOf(rebalancer);
+    assertLt(rebalancerCollAfter, rebalancerCollBefore, "Rebalancer should have spent collateral");
+  }
+
+  function test_rebalance_expansion_whenRebalancerHasLimitedDebt_shouldClamp()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Setup: large imbalance requiring lots of debt
+    provideFPMMReserves(100e18, 1000e18, true);
+    setOracleRate(1e18, 1e18);
+
+    // Give rebalancer only a small amount of debt tokens
+    vm.startPrank(rebalancer);
+    MockERC20(debtToken).transfer(address(1), MockERC20(debtToken).balanceOf(rebalancer) - 1e18);
+    vm.stopPrank();
+
+    uint256 rebalancerDebtBefore = IERC20(debtToken).balanceOf(rebalancer);
+    assertEq(rebalancerDebtBefore, 1e18, "Rebalancer should have 1e18 debt tokens");
+
+    // Should succeed with clamped amounts
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+
+    uint256 rebalancerDebtAfter = IERC20(debtToken).balanceOf(rebalancer);
+    assertLt(rebalancerDebtAfter, rebalancerDebtBefore, "Rebalancer should have spent debt tokens");
+  }
+
+  /* ============================================================ */
+  /* =================== Edge Cases =========================== */
+  /* ============================================================ */
+
+  function test_rebalance_withVerySmallImbalance_shouldRevertDueToThreshold()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Very small imbalance (100 vs 101) - below FPMM threshold
+    provideFPMMReserves(100e18, 101e18, true);
+    setOracleRate(1e18, 1e18);
+
+    vm.expectRevert(ILiquidityStrategy.LS_POOL_NOT_REBALANCEABLE.selector);
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_withLargeImbalance_shouldHandleCorrectly()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    // Large imbalance (100 vs 1000)
+    provideFPMMReserves(100e18, 1000e18, true);
+    setOracleRate(1e18, 1e18);
+
+    vm.expectEmit(true, true, false, false);
+    emit LiquidityMoved(address(fpmm), LQ.Direction.Expand, address(0), 0, address(0), 0);
+
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenRebalancedTwiceInSameTx_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    provideFPMMReserves(100e18, 200e18, true);
+    setOracleRate(1e18, 1e18);
+
+    // First rebalance succeeds
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+
+    // Skew pool again
+    provideFPMMReserves(100e18, 200e18, true);
+
+    // Second rebalance in same tx should fail (transient storage hook flag still set)
+    vm.expectRevert(abi.encodeWithSelector(ILiquidityStrategy.LS_CAN_ONLY_REBALANCE_ONCE.selector, address(fpmm)));
+    vm.prank(rebalancer);
+    strategy.rebalance(address(fpmm));
+  }
+
+  function test_rebalance_whenRebalancerHasNoApproval_shouldRevert()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    provideFPMMReserves(100e18, 200e18, true);
+    setOracleRate(1e18, 1e18);
+
+    address unapprovedRebalancer = makeAddr("UnapprovedRebalancer");
+    MockERC20(debtToken).mint(unapprovedRebalancer, 1_000_000e18);
+    MockERC20(collToken).mint(unapprovedRebalancer, 1_000_000e18);
+    // Note: no approval given
+
+    vm.prank(unapprovedRebalancer);
+    vm.expectRevert(); // SafeERC20: transferFrom will fail
+    strategy.rebalance(address(fpmm));
+  }
+}

--- a/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Rebalance.t.sol
+++ b/test/unit/liquidityStrategies/OpenLiquidityStrategy/OpenLiquidityStrategy_Rebalance.t.sol
@@ -22,7 +22,7 @@ contract OpenLiquidityStrategy_RebalanceTest is OpenLiquidityStrategy_BaseTest {
   function test_rebalance_whenPoolPriceAboveOracle_shouldExpandSuccessfully()
     public
     fpmmToken0Debt(18, 18)
-    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 50, 0.005025125628140703e18)
+    addFpmmWithIncentive(0, 100, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
   {
     // Setup: Pool has 100 debt and 200 collateral (excess collateral)
     provideFPMMReserves(100e18, 200e18, true);

--- a/test/utils/harnesses/OpenLiquidityStrategyHarness.sol
+++ b/test/utils/harnesses/OpenLiquidityStrategyHarness.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.24;
+
+import { OpenLiquidityStrategy } from "contracts/liquidityStrategies/OpenLiquidityStrategy.sol";
+import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
+
+/**
+ * @title OpenLiquidityStrategyHarness
+ * @notice Test harness that exposes internal methods for testing
+ */
+contract OpenLiquidityStrategyHarness is OpenLiquidityStrategy {
+  constructor(address _initialOwner) OpenLiquidityStrategy(false) {
+    initialize(_initialOwner);
+  }
+
+  /**
+   * @notice Exposes the internal _determineAction method for testing
+   * @param ctx The liquidity context
+   * @return action The determined rebalance action
+   */
+  function determineAction(LQ.Context memory ctx) external view returns (LQ.Action memory action) {
+    return _determineAction(ctx);
+  }
+
+  /**
+   * @notice Sets the rebalancer address in transient storage for testing
+   * @dev Mirrors the private _setRebalancer using the same storage slot
+   * @param rebalancer The address to set as rebalancer
+   */
+  function setRebalancerForTesting(address rebalancer) external {
+    bytes32 slot = keccak256("OpenLiquidityStrategy.rebalancer");
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      tstore(slot, rebalancer)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `OpenLiquidityStrategy`, a new liquidity strategy where the caller of `rebalance()` acts as the liquidity source via ERC20 transfers (no reserve minting/burning)
- Uses EIP-1153 transient storage (`tstore`/`tload`) to track the rebalancer address within a transaction
- Includes `_clampExpansion` and `_clampContraction` overrides that check the rebalancer's token balance and adjust amounts accordingly
- Protocol incentive goes to `protocolFeeRecipient`, remaining tokens go to the rebalancer

## Files
- `contracts/interfaces/IOpenLiquidityStrategy.sol` — interface with `OLS_OUT_OF_DEBT` / `OLS_OUT_OF_COLLATERAL` errors
- `contracts/liquidityStrategies/OpenLiquidityStrategy.sol` — full implementation
- `test/utils/harnesses/OpenLiquidityStrategyHarness.sol` — test harness
- `test/unit/liquidityStrategies/OpenLiquidityStrategy/` — 40 tests (admin, rebalance, hook)

## Test plan
- [x] All 40 tests passing (10 admin + 20 rebalance + 10 hook)
- [ ] Review token flow correctness in `_handleCallback`
- [ ] Verify transient storage slot isolation between rebalancer and hook-called flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)