### PR TITLE
fix: update IStableTokenSpoke sol version to 0.8

### DIFF
--- a/contracts/interfaces/IStableTokenSpoke.sol
+++ b/contracts/interfaces/IStableTokenSpoke.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.24;
+pragma solidity ^0.8.0;
 import {
   IERC20PermitUpgradeable
 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";


### PR DESCRIPTION
### Description

Update the version to 0.8.0 to be consistent with the rest of V3 contracts
