### PR TITLE
fix: add foundry-chainlink-toolkit remapping to remappings.txt

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -11,3 +11,4 @@ prb/math/=lib/prb-math/src/
 celo/=node_modules/@celo/
 contracts/=contracts/
 BokkyPooBahsDateTimeLibrary/=lib/BokkyPooBahsDateTimeLibrary/
+foundry-chainlink-toolkit/=lib/foundry-chainlink-toolkit/


### PR DESCRIPTION
## Summary

Adds an explicit `foundry-chainlink-toolkit/=lib/foundry-chainlink-toolkit/` entry to `remappings.txt`, fixing a fresh-clone build failure (mento-core H-1 from QA audit MEN-5).

## Problem

Without this entry, forge auto-generates an incorrect double-`src/` path:

- **Import:** `foundry-chainlink-toolkit/src/interfaces/feeds/AggregatorV3Interface.sol`
- **Auto-resolved (wrong):** `lib/foundry-chainlink-toolkit/src/src/interfaces/feeds/...`
- **Actual file location:** `lib/foundry-chainlink-toolkit/src/interfaces/feeds/...`

This causes `forge build` to fail on a fresh clone unless a `--remappings` CLI override is supplied.

## Fix

```diff
+ foundry-chainlink-toolkit/=lib/foundry-chainlink-toolkit/
```

## Test plan

- [x] `forge build` compiles successfully with no `--remappings` override
- [x] Affected contracts (`ChainlinkRelayerV1.sol`, `OracleAdapter.sol`, `IOracleAdapter.sol`) all import from this path
- [x] File exists at `lib/foundry-chainlink-toolkit/src/interfaces/feeds/AggregatorV3Interface.sol`

🤖 Generated with [Claude Code](https://claude.com/claude-code)