### PR TITLE
fix: replace assert with require in OracleAdapter._getOracleRate

### DIFF
--- a/contracts/oracles/OracleAdapter.sol
+++ b/contracts/oracles/OracleAdapter.sol
@@ -213,7 +213,8 @@ contract OracleAdapter is IOracleAdapter, OwnableUpgradeable {
     OracleAdapterStorage storage $ = _getStorage();
 
     (numerator, denominator) = $.sortedOracles.medianRate(rateFeedID);
-    require(denominator == 1e24, "OracleAdapter: unexpected denominator"); // denominator from sorted oracles should always be 1e24
+    // denominator from sorted oracles should always be 1e24
+    require(denominator == 1e24, "OracleAdapter: unexpected denominator");
 
     numerator = numerator / 1e6;
     denominator = denominator / 1e6;

--- a/contracts/oracles/OracleAdapter.sol
+++ b/contracts/oracles/OracleAdapter.sol
@@ -213,7 +213,7 @@ contract OracleAdapter is IOracleAdapter, OwnableUpgradeable {
     OracleAdapterStorage storage $ = _getStorage();
 
     (numerator, denominator) = $.sortedOracles.medianRate(rateFeedID);
-    assert(denominator == 1e24); // denominator from sorted oracles should always be 1e24
+    require(denominator == 1e24, "OracleAdapter: unexpected denominator"); // denominator from sorted oracles should always be 1e24
 
     numerator = numerator / 1e6;
     denominator = denominator / 1e6;


### PR DESCRIPTION
## Summary

Replaces `assert(denominator == 1e24)` with `require(denominator == 1e24, "OracleAdapter: unexpected denominator")` in `OracleAdapter.sol:216` (mento-core S-3 from QA audit MEN-5).

## Problem

`assert` is incorrect for input/runtime validation:
- Consumes **all remaining gas** on failure (no refund)
- Intended for internal invariant checks only
- Provides no error message for debugging

`require` is the correct Solidity pattern for validating external/runtime conditions — it refunds unused gas and surfaces a descriptive error.

## Fix

```diff
- assert(denominator == 1e24); // denominator from sorted oracles should always be 1e24
+ require(denominator == 1e24, "OracleAdapter: unexpected denominator"); // denominator from sorted oracles should always be 1e24
```

## Test plan

- [x] 40 existing `OracleAdapter` unit tests pass
- [x] No new logic introduced — pure assert→require replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)