### PR TITLE
fix: validate all Chainlink feed timestamps against expiry in ChainlinkRelayerV1

### DIFF
--- a/contracts/oracles/ChainlinkRelayerV1.sol
+++ b/contracts/oracles/ChainlinkRelayerV1.sol
@@ -225,7 +225,7 @@ contract ChainlinkRelayerV1 is IChainlinkRelayer {
       revert TimestampNotNew();
     }
 
-    if (isTimestampExpired(newestChainlinkTs)) {
+    if (isTimestampExpired(oldestChainlinkTs)) {
       revert ExpiredTimestamp();
     }
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -11,3 +11,5 @@ prb/math/=lib/prb-math/src/
 celo/=node_modules/@celo/
 contracts/=contracts/
 BokkyPooBahsDateTimeLibrary/=lib/BokkyPooBahsDateTimeLibrary/
+
+foundry-chainlink-toolkit/=lib/foundry-chainlink-toolkit/

--- a/test/unit/oracles/ChainlinkRelayerV1.t.sol
+++ b/test/unit/oracles/ChainlinkRelayerV1.t.sol
@@ -590,6 +590,8 @@ contract ChainlinkRelayerV1Test_relay_double is ChainlinkRelayerV1Test_relay_sin
     // Spread: 300s (== maxTimestampSpread=300, within limit)
     // Without the fix, only newestChainlinkTs is checked and this would
     // silently relay stale price data from feed 0.
+    // Advance time so subtracting 700 from block.timestamp does not underflow.
+    vm.warp(block.timestamp + 1000);
     uint256 oldTs = block.timestamp - 700;
     uint256 newTs = block.timestamp - 400;
     mockAggregator0.setRoundData(aggregatorPrice0, oldTs);

--- a/test/unit/oracles/ChainlinkRelayerV1.t.sol
+++ b/test/unit/oracles/ChainlinkRelayerV1.t.sol
@@ -584,6 +584,20 @@ contract ChainlinkRelayerV1Test_relay_double is ChainlinkRelayerV1Test_relay_sin
     relayer.relay();
   }
 
+  function test_revertsWhenOldestFeedIsExpiredButNewestIsNot() public {
+    // Feed 0: 700s old (expired, > expirySeconds=600)
+    // Feed 1: 400s old (not expired, < expirySeconds=600)
+    // Spread: 300s (== maxTimestampSpread=300, within limit)
+    // Without the fix, only newestChainlinkTs is checked and this would
+    // silently relay stale price data from feed 0.
+    uint256 oldTs = block.timestamp - 700;
+    uint256 newTs = block.timestamp - 400;
+    mockAggregator0.setRoundData(aggregatorPrice0, oldTs);
+    mockAggregator1.setRoundData(aggregatorPrice1, newTs);
+    vm.expectRevert(EXPIRED_TIMESTAMP_ERROR);
+    relayer.relay();
+  }
+
   function test_revertsWhenTimestampSpreadTooLarge() public virtual {
     mockAggregator0.setRoundData(aggregatorPrice0, block.timestamp);
     vm.warp(block.timestamp + 301);

--- a/test/unit/oracles/ChainlinkRelayerV1.t.sol
+++ b/test/unit/oracles/ChainlinkRelayerV1.t.sol
@@ -584,7 +584,7 @@ contract ChainlinkRelayerV1Test_relay_double is ChainlinkRelayerV1Test_relay_sin
     relayer.relay();
   }
 
-  function test_revertsWhenOldestFeedIsExpiredButNewestIsNot() public {
+  function test_revertsWhenOldestFeedIsExpiredButNewestIsNot() public virtual {
     // Feed 0: 700s old (expired, > expirySeconds=600)
     // Feed 1: 400s old (not expired, < expirySeconds=600)
     // Spread: 300s (== maxTimestampSpread=300, within limit)
@@ -671,6 +671,19 @@ contract ChainlinkRelayerV1Test_relay_triple is ChainlinkRelayerV1Test_relay_dou
     relayer.relay();
   }
 
+  function test_revertsWhenOldestFeedIsExpiredButNewestIsNot() public virtual override {
+    // Same scenario as relay_double but also sets aggregator2 to avoid
+    // spurious TimestampSpreadTooHigh from aggregator2's stale setUp timestamp.
+    vm.warp(block.timestamp + 1000);
+    uint256 oldTs = block.timestamp - 700;
+    uint256 newTs = block.timestamp - 400;
+    mockAggregator0.setRoundData(aggregatorPrice0, oldTs);
+    mockAggregator1.setRoundData(aggregatorPrice1, newTs);
+    mockAggregator2.setRoundData(aggregatorPrice2, newTs);
+    vm.expectRevert(EXPIRED_TIMESTAMP_ERROR);
+    relayer.relay();
+  }
+
   function test_revertsWhenTimestampSpreadTooLarge() public virtual override {
     mockAggregator0.setRoundData(aggregatorPrice0, block.timestamp);
     vm.warp(block.timestamp + 301);
@@ -743,6 +756,20 @@ contract ChainlinkRelayerV1Test_relay_full is ChainlinkRelayerV1Test_relay_tripl
     mockAggregator2.setRoundData(aggregatorPrice3, block.timestamp + 1);
 
     vm.warp(block.timestamp + expirySeconds + 1);
+    vm.expectRevert(EXPIRED_TIMESTAMP_ERROR);
+    relayer.relay();
+  }
+
+  function test_revertsWhenOldestFeedIsExpiredButNewestIsNot() public override {
+    // Same scenario as relay_double but also sets aggregators 2 and 3 to avoid
+    // spurious TimestampSpreadTooHigh from their stale setUp timestamps.
+    vm.warp(block.timestamp + 1000);
+    uint256 oldTs = block.timestamp - 700;
+    uint256 newTs = block.timestamp - 400;
+    mockAggregator0.setRoundData(aggregatorPrice0, oldTs);
+    mockAggregator1.setRoundData(aggregatorPrice1, newTs);
+    mockAggregator2.setRoundData(aggregatorPrice2, newTs);
+    mockAggregator3.setRoundData(aggregatorPrice3, newTs);
     vm.expectRevert(EXPIRED_TIMESTAMP_ERROR);
     relayer.relay();
   }


### PR DESCRIPTION
## Summary

Fixes a security bug (mento-core S-2 from QA audit MEN-5) where only the **newest** Chainlink aggregator timestamp was checked against the staleness expiry window.

## Problem

In `ChainlinkRelayerV1.relay()`, when multiple aggregators are used:

```solidity
// Before: only checks the newest timestamp
if (isTimestampExpired(newestChainlinkTs)) {
    revert ExpiredTimestamp();
}
```

With two aggregators where feed 0 is stale but feed 1 is fresh, the relay succeeds with stale data influencing the aggregated rate. Example:

| Feed | Age | Expired? |
|---|---|---|
| Feed 0 (oldest) | 700s | Yes (expirySeconds=600) |
| Feed 1 (newest) | 400s | No |
| Spread | 300s | Within maxTimestampSpread |

Current code: relay succeeds, stale price from Feed 0 contaminates the result.

## Fix

```solidity
// After: checks the oldest timestamp — if oldest is valid, all are valid
if (isTimestampExpired(oldestChainlinkTs)) {
    revert ExpiredTimestamp();
}
```

If the oldest timestamp is within the expiry window, all feeds are fresh. If the oldest is expired, at least one feed carries stale data and the relay reverts.

## Tests

Adds `test_revertsWhenOldestFeedIsExpiredButNewestIsNot` to `ChainlinkRelayerV1Test_relay_double` demonstrating the exact vulnerability scenario.

This PR was initially closed due to CI failures in `relay_triple` and `relay_full` test suites. The root cause was that the test function was defined for `relay_double` (2 aggregators) and inherited by `relay_triple` (3) and `relay_full` (4). The inherited setUp timestamps caused a timestamp spread > `maxTimestampSpread`, firing `TimestampSpreadTooHigh` before `ExpiredTimestamp`.

**CI fixes (commits `4634545`, `8d814f0`):**
- Warped `block.timestamp` to prevent underflow in the staleness test
- Marked the base test function `virtual` and overrode it in `relay_triple` and `relay_full` to set all aggregator timestamps, keeping spread ≤300 and ensuring `ExpiredTimestamp` fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)