### PR TITLE
test: add Foundry invariant tests for TradingLimits and BancorExchangeProvider (MEN-47)

### DIFF
--- a/test/invariant/BancorExchangeProvider.invariant.t.sol
+++ b/test/invariant/BancorExchangeProvider.invariant.t.sol
@@ -67,8 +67,8 @@ contract BancorExchangeProviderInvariantTest is Test {
       tokenAddress: address(token),
       tokenSupply: 300_000 * 1e18,
       reserveBalance: 60_000 * 1e18,
-      reserveRatio: uint32(MAX_WEIGHT * 20 / 100), // 20%
-      exitContribution: uint32(MAX_WEIGHT * 1 / 100) // 1%
+      reserveRatio: uint32((MAX_WEIGHT * 20) / 100), // 20%
+      exitContribution: uint32((MAX_WEIGHT * 1) / 100) // 1%
     });
 
     vm.prank(provider.owner());

--- a/test/invariant/BancorExchangeProvider.invariant.t.sol
+++ b/test/invariant/BancorExchangeProvider.invariant.t.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+pragma solidity 0.8.19;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20 } from "openzeppelin-contracts-next/contracts/token/ERC20/ERC20.sol";
+
+import { BancorExchangeProvider } from "contracts/goodDollar/BancorExchangeProvider.sol";
+import { IBancorExchangeProvider } from "contracts/interfaces/IBancorExchangeProvider.sol";
+import { IReserve } from "contracts/interfaces/IReserve.sol";
+
+import { BancorHandler } from "./handlers/BancorHandler.sol";
+
+/**
+ * @title BancorExchangeProviderInvariantTest
+ * @notice Foundry invariant tests for BancorExchangeProvider.
+ *
+ * Run with:
+ *   forge test --match-contract BancorExchangeProviderInvariant --no-match-contract ForkTest -v
+ *
+ * Invariants verified:
+ *   1. reserveBalance is always > 0 (pool never fully drained)
+ *   2. tokenSupply is always > 0 (token supply never fully drained)
+ *   3. reserveRatio stays within (0, MAX_WEIGHT] after any sequence of swaps
+ *   4. currentPrice() never reverts after valid swaps
+ *   5. getAmountOut() >= 1 for non-trivial amountIn (price is always positive)
+ */
+contract BancorExchangeProviderInvariantTest is Test {
+  uint32 constant MAX_WEIGHT = 1e8;
+
+  BancorExchangeProvider provider;
+  BancorHandler handler;
+  bytes32 exchangeId;
+
+  ERC20 reserveToken;
+  ERC20 token;
+
+  address brokerAddress;
+  address reserveAddress;
+
+  function setUp() public {
+    reserveToken = new ERC20("cUSD", "cUSD");
+    token = new ERC20("Good$", "G$");
+
+    brokerAddress = makeAddr("Broker");
+    reserveAddress = makeAddr("Reserve");
+
+    // Mock reserve interface calls
+    vm.mockCall(
+      reserveAddress,
+      abi.encodeWithSelector(IReserve(reserveAddress).isStableAsset.selector, address(token)),
+      abi.encode(true)
+    );
+    vm.mockCall(
+      reserveAddress,
+      abi.encodeWithSelector(IReserve(reserveAddress).isCollateralAsset.selector, address(reserveToken)),
+      abi.encode(true)
+    );
+
+    // Deploy provider without proxy (disable=false for testing)
+    provider = new BancorExchangeProvider(false);
+    provider.initialize(brokerAddress, reserveAddress);
+
+    // Create exchange
+    IBancorExchangeProvider.PoolExchange memory poolExchange = IBancorExchangeProvider.PoolExchange({
+      reserveAsset: address(reserveToken),
+      tokenAddress: address(token),
+      tokenSupply: 300_000 * 1e18,
+      reserveBalance: 60_000 * 1e18,
+      reserveRatio: uint32(MAX_WEIGHT * 20 / 100), // 20%
+      exitContribution: uint32(MAX_WEIGHT * 1 / 100) // 1%
+    });
+
+    vm.prank(provider.owner());
+    exchangeId = provider.createExchange(poolExchange);
+
+    // Deploy handler — acts as the broker
+    handler = new BancorHandler(provider, exchangeId);
+
+    // Re-point provider's broker to the handler so swapIn/swapOut succeed
+    vm.prank(provider.owner());
+    provider.setBroker(address(handler));
+
+    targetContract(address(handler));
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 1: reserveBalance always positive
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_reserveBalance_positive() public view {
+    IBancorExchangeProvider.PoolExchange memory ex = provider.getPoolExchange(exchangeId);
+    assertGt(ex.reserveBalance, 0, "reserveBalance must be > 0");
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 2: tokenSupply always positive
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_tokenSupply_positive() public view {
+    IBancorExchangeProvider.PoolExchange memory ex = provider.getPoolExchange(exchangeId);
+    assertGt(ex.tokenSupply, 0, "tokenSupply must be > 0");
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 3: reserveRatio within (0, MAX_WEIGHT]
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_reserveRatio_in_bounds() public view {
+    IBancorExchangeProvider.PoolExchange memory ex = provider.getPoolExchange(exchangeId);
+    assertGt(ex.reserveRatio, 0, "reserveRatio must be > 0");
+    assertLe(ex.reserveRatio, MAX_WEIGHT, "reserveRatio must be <= MAX_WEIGHT");
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 4: currentPrice() does not revert
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_currentPrice_does_not_revert() public view {
+    uint256 price = provider.currentPrice(exchangeId);
+    assertGt(price, 0, "currentPrice must be > 0");
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 5: getAmountOut for a small amountIn returns > 0
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_getAmountOut_positive_for_small_in() public view {
+    // Probe with 1 unit of reserve (1e18 scaled)
+    uint256 amountOut = provider.getAmountOut(exchangeId, address(reserveToken), address(token), 1e18);
+    assertGt(amountOut, 0, "getAmountOut must return > 0 for non-trivial amountIn");
+  }
+}

--- a/test/invariant/TradingLimits.invariant.t.sol
+++ b/test/invariant/TradingLimits.invariant.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+pragma solidity 0.8.19;
+pragma experimental ABIEncoderV2;
+
+import { Test } from "forge-std/Test.sol";
+
+import { ITradingLimits } from "contracts/interfaces/ITradingLimits.sol";
+import { TradingLimitsHarness } from "test/utils/harnesses/TradingLimitsHarness.sol";
+import { TradingLimitsHandler } from "./handlers/TradingLimitsHandler.sol";
+
+/**
+ * @title TradingLimitsInvariantTest
+ * @notice Foundry invariant tests for the TradingLimits library.
+ *
+ * Run with:
+ *   forge test --match-contract TradingLimitsInvariant --no-match-contract ForkTest -v
+ *
+ * Invariants verified:
+ *   1. netflow0 never exceeds ±limit0 when L0 is enabled
+ *   2. netflow1 never exceeds ±limit1 when L1 is enabled
+ *   3. netflowGlobal never exceeds ±limitGlobal when LG is enabled
+ *   4. verify() does not revert after any sequence of accepted updates
+ *   5. callCount is monotonically non-decreasing (sanity)
+ */
+contract TradingLimitsInvariantTest is Test {
+  uint8 constant L0 = 1;
+  uint8 constant L1 = 2;
+  uint8 constant LG = 4;
+
+  TradingLimitsHarness harness;
+
+  TradingLimitsHandler handlerL0LG;
+  TradingLimitsHandler handlerL0L1LG;
+  TradingLimitsHandler handlerLG;
+
+  function setUp() public {
+    harness = new TradingLimitsHarness();
+
+    // Config: L0 | LG
+    ITradingLimits.Config memory configL0LG = ITradingLimits.Config({
+      timestep0: 1 hours,
+      timestep1: 0,
+      limit0: 1_000,
+      limit1: 0,
+      limitGlobal: 10_000,
+      flags: L0 | LG
+    });
+    handlerL0LG = new TradingLimitsHandler(harness, configL0LG);
+
+    // Config: L0 | L1 | LG
+    ITradingLimits.Config memory configFull = ITradingLimits.Config({
+      timestep0: 1 hours,
+      timestep1: 1 days,
+      limit0: 500,
+      limit1: 2_000,
+      limitGlobal: 20_000,
+      flags: L0 | L1 | LG
+    });
+    handlerL0L1LG = new TradingLimitsHandler(harness, configFull);
+
+    // Config: LG only
+    ITradingLimits.Config memory configLGOnly = ITradingLimits.Config({
+      timestep0: 0,
+      timestep1: 0,
+      limit0: 0,
+      limit1: 0,
+      limitGlobal: 5_000,
+      flags: LG
+    });
+    handlerLG = new TradingLimitsHandler(harness, configLGOnly);
+
+    targetContract(address(handlerL0LG));
+    targetContract(address(handlerL0L1LG));
+    targetContract(address(handlerLG));
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 1: netflow0 within ±limit0 whenever L0 is enabled
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_netflow0_within_limit_L0LG() public {
+    ITradingLimits.State memory s = handlerL0LG.getState();
+    ITradingLimits.Config memory c = handlerL0LG.getConfig();
+    if (c.flags & L0 > 0) {
+      assertGe(int256(s.netflow0), -int256(c.limit0), "netflow0 below -limit0 (L0LG)");
+      assertLe(int256(s.netflow0), int256(c.limit0), "netflow0 above limit0 (L0LG)");
+    }
+  }
+
+  function invariant_netflow0_within_limit_full() public {
+    ITradingLimits.State memory s = handlerL0L1LG.getState();
+    ITradingLimits.Config memory c = handlerL0L1LG.getConfig();
+    if (c.flags & L0 > 0) {
+      assertGe(int256(s.netflow0), -int256(c.limit0), "netflow0 below -limit0 (full)");
+      assertLe(int256(s.netflow0), int256(c.limit0), "netflow0 above limit0 (full)");
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 2: netflow1 within ±limit1 whenever L1 is enabled
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_netflow1_within_limit_full() public {
+    ITradingLimits.State memory s = handlerL0L1LG.getState();
+    ITradingLimits.Config memory c = handlerL0L1LG.getConfig();
+    if (c.flags & L1 > 0) {
+      assertGe(int256(s.netflow1), -int256(c.limit1), "netflow1 below -limit1");
+      assertLe(int256(s.netflow1), int256(c.limit1), "netflow1 above limit1");
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 3: netflowGlobal within ±limitGlobal whenever LG is enabled
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_netflowGlobal_within_limit_L0LG() public {
+    ITradingLimits.State memory s = handlerL0LG.getState();
+    ITradingLimits.Config memory c = handlerL0LG.getConfig();
+    if (c.flags & LG > 0) {
+      assertGe(int256(s.netflowGlobal), -int256(c.limitGlobal), "netflowGlobal below -limitGlobal (L0LG)");
+      assertLe(int256(s.netflowGlobal), int256(c.limitGlobal), "netflowGlobal above limitGlobal (L0LG)");
+    }
+  }
+
+  function invariant_netflowGlobal_within_limit_LG_only() public {
+    ITradingLimits.State memory s = handlerLG.getState();
+    ITradingLimits.Config memory c = handlerLG.getConfig();
+    if (c.flags & LG > 0) {
+      assertGe(int256(s.netflowGlobal), -int256(c.limitGlobal), "netflowGlobal below -limitGlobal (LG-only)");
+      assertLe(int256(s.netflowGlobal), int256(c.limitGlobal), "netflowGlobal above limitGlobal (LG-only)");
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 4: verify() does not revert on accepted state
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_verify_does_not_revert_L0LG() public {
+    ITradingLimits.State memory s = handlerL0LG.getState();
+    ITradingLimits.Config memory c = handlerL0LG.getConfig();
+    harness.verify(s, c);
+  }
+
+  function invariant_verify_does_not_revert_full() public {
+    ITradingLimits.State memory s = handlerL0L1LG.getState();
+    ITradingLimits.Config memory c = handlerL0L1LG.getConfig();
+    harness.verify(s, c);
+  }
+
+  function invariant_verify_does_not_revert_LG() public {
+    ITradingLimits.State memory s = handlerLG.getState();
+    ITradingLimits.Config memory c = handlerLG.getConfig();
+    harness.verify(s, c);
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Invariant 5: callCount sanity
+  // ──────────────────────────────────────────────────────────────────────────
+
+  function invariant_callCount_non_negative() public view {
+    assertGe(handlerL0LG.callCount(), 0, "callCount underflowed");
+    assertGe(handlerL0L1LG.callCount(), 0, "callCount underflowed");
+    assertGe(handlerLG.callCount(), 0, "callCount underflowed");
+  }
+}

--- a/test/invariant/handlers/BancorHandler.sol
+++ b/test/invariant/handlers/BancorHandler.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase
+pragma solidity 0.8.19;
+
+import { CommonBase } from "forge-std/Base.sol";
+import { StdCheats } from "forge-std/StdCheats.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
+
+import { BancorExchangeProvider } from "contracts/goodDollar/BancorExchangeProvider.sol";
+import { IBancorExchangeProvider } from "contracts/interfaces/IBancorExchangeProvider.sol";
+
+/**
+ * @title BancorHandler
+ * @notice Handler for BancorExchangeProvider invariant tests.
+ * Acts as the broker — calls swapIn/swapOut with bounded random inputs.
+ * Ghost variables track total reserve in and token out for ratio assertions.
+ */
+contract BancorHandler is CommonBase, StdCheats, StdUtils {
+  BancorExchangeProvider public provider;
+  bytes32 public exchangeId;
+  address public reserveAsset;
+  address public tokenAddress;
+
+  uint256 public totalSwapsIn; // reserve → token swaps
+  uint256 public totalSwapsOut; // token → reserve swaps
+
+  constructor(BancorExchangeProvider _provider, bytes32 _exchangeId) {
+    provider = _provider;
+    exchangeId = _exchangeId;
+    IBancorExchangeProvider.PoolExchange memory ex = _provider.getPoolExchange(_exchangeId);
+    reserveAsset = ex.reserveAsset;
+    tokenAddress = ex.tokenAddress;
+  }
+
+  /**
+   * @notice Swap reserve asset in for token (buy).
+   * Bounded to avoid exhausting reserves.
+   */
+  function swapIn_reserveForToken(uint256 amountIn) external {
+    IBancorExchangeProvider.PoolExchange memory ex = provider.getPoolExchange(exchangeId);
+    // Bound to at most 1% of current reserve balance to keep pool alive
+    uint256 maxIn = ex.reserveBalance / 100 + 1;
+    amountIn = bound(amountIn, 1, maxIn);
+
+    vm.prank(address(this)); // this contract IS the broker
+    try provider.swapIn(exchangeId, reserveAsset, tokenAddress, amountIn) {
+      totalSwapsIn++;
+    } catch {
+      // Revert is acceptable (e.g. amountOut == 0)
+    }
+  }
+
+  /**
+   * @notice Swap token in for reserve asset (sell).
+   * Bounded to avoid draining the token supply entirely.
+   */
+  function swapIn_tokenForReserve(uint256 amountIn) external {
+    IBancorExchangeProvider.PoolExchange memory ex = provider.getPoolExchange(exchangeId);
+    // Bound to at most 0.5% of token supply to keep the pool alive
+    uint256 maxIn = ex.tokenSupply / 200 + 1;
+    amountIn = bound(amountIn, 1, maxIn);
+
+    vm.prank(address(this));
+    try provider.swapIn(exchangeId, tokenAddress, reserveAsset, amountIn) {
+      totalSwapsOut++;
+    } catch {
+      // Acceptable (e.g. insufficient reserve)
+    }
+  }
+}

--- a/test/invariant/handlers/TradingLimitsHandler.sol
+++ b/test/invariant/handlers/TradingLimitsHandler.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase
+pragma solidity 0.8.19;
+pragma experimental ABIEncoderV2;
+
+import { CommonBase } from "forge-std/Base.sol";
+import { StdCheats } from "forge-std/StdCheats.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
+
+import { ITradingLimits } from "contracts/interfaces/ITradingLimits.sol";
+import { TradingLimitsHarness } from "test/utils/harnesses/TradingLimitsHarness.sol";
+
+/**
+ * @title TradingLimitsHandler
+ * @notice Handler for TradingLimits invariant tests.
+ *
+ * Models realistic usage: update() is always followed by verify().
+ * The state is only committed if BOTH succeed — mirroring how the Broker
+ * uses the library in production (update then verify in a single tx).
+ *
+ * The key invariants we're testing:
+ *   - If update+verify succeed, state netflows stay within configured limits
+ *   - verify() never silently allows an out-of-bounds state
+ */
+contract TradingLimitsHandler is CommonBase, StdCheats, StdUtils {
+  TradingLimitsHarness public harness;
+
+  ITradingLimits.State internal currentState;
+  ITradingLimits.Config internal currentConfig;
+
+  uint8 public constant DECIMALS = 18;
+
+  // Accepted swaps (update+verify both passed)
+  uint256 public callCount;
+  // Rejected swaps (update passed but verify reverted — expected behaviour)
+  uint256 public rejectedCount;
+
+  constructor(TradingLimitsHarness _harness, ITradingLimits.Config memory initConfig) {
+    harness = _harness;
+    currentConfig = initConfig;
+    currentState = ITradingLimits.State({
+      lastUpdated0: 0,
+      lastUpdated1: 0,
+      netflow0: 0,
+      netflow1: 0,
+      netflowGlobal: 0
+    });
+  }
+
+  /// @notice Returns a copy of the current trading limits state.
+  function getState() external view returns (ITradingLimits.State memory) {
+    return currentState;
+  }
+
+  /// @notice Returns the current config.
+  function getConfig() external view returns (ITradingLimits.Config memory) {
+    return currentConfig;
+  }
+
+  /**
+   * @notice Simulate a swap: call update() then verify().
+   * State is committed only if both succeed — matching Broker behaviour.
+   */
+  function update(int64 rawDelta, uint32 timeWarp) external {
+    // Advance time to exercise window resets (bounded to reasonable range)
+    timeWarp = uint32(bound(uint256(timeWarp), 0, 7 days));
+    vm.warp(block.timestamp + timeWarp);
+
+    // Use a narrower delta range to get a mix of accepted and rejected swaps
+    int256 delta = bound(int256(rawDelta), -1e10, 1e10);
+    int256 scaledDelta = delta * int256(10 ** uint256(DECIMALS));
+
+    ITradingLimits.State memory nextState;
+    bool updateSucceeded;
+
+    try harness.update(currentState, currentConfig, scaledDelta, DECIMALS) returns (
+      ITradingLimits.State memory newState
+    ) {
+      nextState = newState;
+      updateSucceeded = true;
+    } catch {
+      // Arithmetic overflow — skip
+      return;
+    }
+
+    if (!updateSucceeded) return;
+
+    // Only commit state if verify() also passes
+    try harness.verify(nextState, currentConfig) {
+      currentState = nextState;
+      callCount++;
+    } catch {
+      // verify() reverted — limit exceeded, this is expected and correct
+      rejectedCount++;
+    }
+  }
+
+  /**
+   * @notice Warp past a time window to trigger netflow resets on next update.
+   */
+  function warpPastWindow(uint8 which) external {
+    if (which % 3 == 0 && currentConfig.timestep0 > 0) {
+      vm.warp(block.timestamp + uint256(currentConfig.timestep0) + 1);
+    } else if (which % 3 == 1 && currentConfig.timestep1 > 0) {
+      vm.warp(block.timestamp + uint256(currentConfig.timestep1) + 1);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Addresses MEN-47 from the mento-core QA audit (P2-6). Adds Foundry-native invariant tests for two critical protocol contracts.

## Changes

### TradingLimits invariant tests (`test/invariant/TradingLimits.invariant.t.sol`)

Handler: `test/invariant/handlers/TradingLimitsHandler.sol`

Models realistic Broker usage — `update()` is always followed by `verify()`, and state is only committed when both succeed. Three handler instances covering different flag combinations:
- L0 | LG
- L0 | L1 | LG (full config)
- LG only

Invariants tested (9 total):
- `netflow0` never exceeds ±`limit0` when L0 is enabled
- `netflow1` never exceeds ±`limit1` when L1 is enabled  
- `netflowGlobal` never exceeds ±`limitGlobal` when LG is enabled
- `verify()` never reverts on an accepted state
- Time window resets exercised via `warpPastWindow()`

### BancorExchangeProvider invariant tests (`test/invariant/BancorExchangeProvider.invariant.t.sol`)

Handler: `test/invariant/handlers/BancorHandler.sol`

Handler acts as broker, calls `swapIn()` in both directions (reserve→token, token→reserve) with bounded random inputs.

Invariants tested (5 total):
- `reserveBalance` always > 0 (pool never fully drained)
- `tokenSupply` always > 0 (token supply never exhausted)
- `reserveRatio` always within `(0, MAX_WEIGHT]`
- `currentPrice()` never reverts and is always > 0
- `getAmountOut()` returns > 0 for non-trivial input

## Test Results

```
Ran 14 tests: 14 passed, 0 failed
- TradingLimitsInvariantTest: 9 passed
- BancorExchangeProviderInvariantTest: 5 passed
```

Run with:
```bash
forge test --match-contract "TradingLimitsInvariant|BancorExchangeProviderInvariant" --no-match-contract ForkTest -v
```

## Acceptance Criteria
- [x] At minimum 2 invariant test files with handler contracts
- [x] Tests pass with `forge test --match-contract "invariant" --no-match-contract ForkTest`
- [x] PR opened on `mento-protocol/mento-core`

Closes MEN-47