### PR TITLE
fix: add scoped remapping for bold library src imports

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
 lib/bold/:openzeppelin-contracts/=lib/bold/contracts/lib/openzeppelin-contracts/
+lib/bold/:src/=lib/bold/contracts/src/
 openzeppelin/=lib/openzeppelin-contracts/
 openzeppelin-solidity/=lib/openzeppelin-contracts/
 openzeppelin-contracts/=lib/openzeppelin-contracts-next/


### PR DESCRIPTION
## Summary

This fixes the issue of the repo not building on neither the latest foundry stable version nor the nightly:

- The bold submodule uses `src/` relative imports internally (e.g. `import "src/Interfaces/IInterestRouter.sol"`)
- Without a scoped remapping, Foundry resolves these against the top-level project root and the build fails
- Adds `lib/bold/:src/=lib/bold/contracts/src/` to `remappings.txt` so those imports resolve correctly

## Test plan
- [x] `forge build` completes without errors