### PR TITLE
test: add unit tests for TimelockController and BancorFormula (MEN-38)

### DIFF
--- a/test/unit/goodDollar/BancorFormula.t.sol
+++ b/test/unit/goodDollar/BancorFormula.t.sol
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+// solhint-disable func-name-mixedcase, contract-name-camelcase
+
+import { Test } from "forge-std/Test.sol";
+import { BancorFormula } from "contracts/goodDollar/BancorFormula.sol";
+
+/**
+ * @notice Test harness that exposes BancorFormula's internal functions as external
+ *         so they can be called from the test contract.
+ *         Note: BancorFormula's functions are internal non-virtual, so the harness
+ *         exposes them via differently-named wrappers rather than overrides.
+ */
+contract BancorFormulaHarness is BancorFormula {
+  constructor() {
+    init();
+  }
+
+  function exposed_purchaseTargetAmount(
+    uint256 supply,
+    uint256 reserveBalance,
+    uint32 reserveWeight,
+    uint256 amount
+  ) external view returns (uint256) {
+    return purchaseTargetAmount(supply, reserveBalance, reserveWeight, amount);
+  }
+
+  function exposed_saleTargetAmount(
+    uint256 supply,
+    uint256 reserveBalance,
+    uint32 reserveWeight,
+    uint256 amount
+  ) external view returns (uint256) {
+    return saleTargetAmount(supply, reserveBalance, reserveWeight, amount);
+  }
+
+  function exposed_saleCost(
+    uint256 supply,
+    uint256 reserveBalance,
+    uint32 reserveWeight,
+    uint256 amount
+  ) external view returns (uint256) {
+    return saleCost(supply, reserveBalance, reserveWeight, amount);
+  }
+
+  function exposed_fundCost(
+    uint256 supply,
+    uint256 reserveBalance,
+    uint32 reserveRatio,
+    uint256 amount
+  ) external view returns (uint256) {
+    return fundCost(supply, reserveBalance, reserveRatio, amount);
+  }
+}
+
+/**
+ * @title BancorFormulaTest
+ * @notice Isolated unit tests for BancorFormula's four public-facing formulas:
+ *         purchaseTargetAmount, saleTargetAmount, saleCost, and fundCost.
+ *
+ *         Tests cover:
+ *         - Special-case branches (zero amount, full supply/reserve, 100% weight)
+ *         - Input validation (zero supply/reserve, invalid weight, amount > supply)
+ *         - Directional sanity (more deposit → more tokens; bigger sell → more reserve out)
+ *         - Inverse consistency (sale undoes a purchase up to rounding)
+ *         - Fuzz coverage of edge values
+ */
+contract BancorFormulaTest is Test {
+  BancorFormulaHarness public formula;
+
+  uint32 public constant MAX_WEIGHT = 100_000_000;
+
+  // Representative pool: supply=300k, reserveBalance=60k, reserveWeight=20%
+  uint256 public constant SUPPLY = 300_000e18;
+  uint256 public constant RESERVE = 60_000e18;
+  uint32 public constant WEIGHT_20 = uint32(MAX_WEIGHT / 5); // 20%
+  uint32 public constant WEIGHT_50 = uint32(MAX_WEIGHT / 2); // 50%
+
+  function setUp() public {
+    formula = new BancorFormulaHarness();
+  }
+
+  // ================================================================
+  // purchaseTargetAmount
+  // ================================================================
+
+  function test_purchaseTargetAmount_zeroDepositReturnsZero() public view {
+    uint256 result = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, WEIGHT_20, 0);
+    assertEq(result, 0);
+  }
+
+  function test_purchaseTargetAmount_maxWeight_usesLinearFormula() public view {
+    // At 100% weight: tokens_out = supply * amount / reserveBalance
+    uint256 amount = 10_000e18;
+    uint256 result = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, MAX_WEIGHT, amount);
+    uint256 expected = (SUPPLY * amount) / RESERVE;
+    assertEq(result, expected);
+  }
+
+  function test_purchaseTargetAmount_normalCase_returnsPositive() public view {
+    uint256 amount = 6_000e18; // 10% of reserve
+    uint256 result = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, WEIGHT_20, amount);
+    assertGt(result, 0);
+  }
+
+  function test_purchaseTargetAmount_largerDeposit_yieldsDiminishingReturns() public view {
+    // Bancor AMM: returns are sub-linear (diminishing returns) at weight < 100%
+    uint256 small = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, WEIGHT_20, 1_000e18);
+    uint256 large = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, WEIGHT_20, 2_000e18);
+    // large must be > small but < 2 * small (diminishing returns)
+    assertGt(large, small);
+    assertLt(large, 2 * small);
+  }
+
+  function test_purchaseTargetAmount_revertOnZeroSupply() public {
+    vm.expectRevert("ERR_INVALID_SUPPLY");
+    formula.exposed_purchaseTargetAmount(0, RESERVE, WEIGHT_20, 1e18);
+  }
+
+  function test_purchaseTargetAmount_revertOnZeroReserve() public {
+    vm.expectRevert("ERR_INVALID_RESERVE_BALANCE");
+    formula.exposed_purchaseTargetAmount(SUPPLY, 0, WEIGHT_20, 1e18);
+  }
+
+  function test_purchaseTargetAmount_revertOnZeroWeight() public {
+    vm.expectRevert("ERR_INVALID_RESERVE_WEIGHT");
+    formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, 0, 1e18);
+  }
+
+  function test_purchaseTargetAmount_revertOnWeightAboveMax() public {
+    vm.expectRevert("ERR_INVALID_RESERVE_WEIGHT");
+    formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, MAX_WEIGHT + 1, 1e18);
+  }
+
+  // ================================================================
+  // saleTargetAmount
+  // ================================================================
+
+  function test_saleTargetAmount_zeroAmountReturnsZero() public view {
+    uint256 result = formula.exposed_saleTargetAmount(SUPPLY, RESERVE, WEIGHT_20, 0);
+    assertEq(result, 0);
+  }
+
+  function test_saleTargetAmount_fullSupplyReturnsFullReserve() public view {
+    // Selling the entire supply returns the entire reserve balance
+    uint256 result = formula.exposed_saleTargetAmount(SUPPLY, RESERVE, WEIGHT_20, SUPPLY);
+    assertEq(result, RESERVE);
+  }
+
+  function test_saleTargetAmount_maxWeight_usesLinearFormula() public view {
+    // At 100% weight: reserve_out = reserveBalance * amount / supply
+    uint256 sellAmount = 30_000e18;
+    uint256 result = formula.exposed_saleTargetAmount(SUPPLY, RESERVE, MAX_WEIGHT, sellAmount);
+    uint256 expected = (RESERVE * sellAmount) / SUPPLY;
+    assertEq(result, expected);
+  }
+
+  function test_saleTargetAmount_normalCase_returnsPositive() public view {
+    uint256 sellAmount = 30_000e18; // 10% of supply
+    uint256 result = formula.exposed_saleTargetAmount(SUPPLY, RESERVE, WEIGHT_20, sellAmount);
+    assertGt(result, 0);
+    assertLt(result, RESERVE); // must not drain the whole reserve
+  }
+
+  function test_saleTargetAmount_revertWhenAmountExceedsSupply() public {
+    vm.expectRevert("ERR_INVALID_AMOUNT");
+    formula.exposed_saleTargetAmount(SUPPLY, RESERVE, WEIGHT_20, SUPPLY + 1);
+  }
+
+  function test_saleTargetAmount_revertOnZeroSupply() public {
+    vm.expectRevert("ERR_INVALID_SUPPLY");
+    formula.exposed_saleTargetAmount(0, RESERVE, WEIGHT_20, 0);
+  }
+
+  function test_saleTargetAmount_revertOnZeroReserve() public {
+    vm.expectRevert("ERR_INVALID_RESERVE_BALANCE");
+    formula.exposed_saleTargetAmount(SUPPLY, 0, WEIGHT_20, 1e18);
+  }
+
+  // ================================================================
+  // saleCost (inverse of saleTargetAmount)
+  // ================================================================
+
+  function test_saleCost_zeroAmountReturnsZero() public view {
+    uint256 result = formula.exposed_saleCost(SUPPLY, RESERVE, WEIGHT_20, 0);
+    assertEq(result, 0);
+  }
+
+  function test_saleCost_fullReserveReturnsFullSupply() public view {
+    // Withdrawing the entire reserve costs the full supply
+    uint256 result = formula.exposed_saleCost(SUPPLY, RESERVE, WEIGHT_20, RESERVE);
+    assertEq(result, SUPPLY);
+  }
+
+  function test_saleCost_maxWeight_usesLinearFormula() public view {
+    // At 100% weight: tokens_in = supply * amount / reserveBalance, rounded up
+    uint256 reserveOut = 6_000e18;
+    uint256 result = formula.exposed_saleCost(SUPPLY, RESERVE, MAX_WEIGHT, reserveOut);
+    // Expected (ceiling): supply * reserveOut / reserveBalance
+    uint256 expected = (SUPPLY * reserveOut - 1) / RESERVE + 1;
+    assertEq(result, expected);
+  }
+
+  function test_saleCost_normalCase_returnsPositive() public view {
+    uint256 reserveOut = 6_000e18; // 10% of reserve
+    uint256 result = formula.exposed_saleCost(SUPPLY, RESERVE, WEIGHT_20, reserveOut);
+    assertGt(result, 0);
+    assertLt(result, SUPPLY); // doesn't consume the whole supply
+  }
+
+  function test_saleCost_revertWhenAmountExceedsReserve() public {
+    vm.expectRevert("ERR_INVALID_AMOUNT");
+    formula.exposed_saleCost(SUPPLY, RESERVE, WEIGHT_20, RESERVE + 1);
+  }
+
+  function test_saleCost_roundsUp() public view {
+    // saleCost should round up to protect the protocol
+    uint256 smallReserveOut = 1; // 1 wei
+    uint256 cost = formula.exposed_saleCost(SUPPLY, RESERVE, MAX_WEIGHT, smallReserveOut);
+    // ceil(SUPPLY * 1 / RESERVE) >= 1
+    assertGe(cost, 1);
+  }
+
+  // ================================================================
+  // fundCost
+  // ================================================================
+
+  function test_fundCost_zeroAmountReturnsZero() public view {
+    uint256 result = formula.exposed_fundCost(SUPPLY, RESERVE, WEIGHT_20 * 2, 0);
+    assertEq(result, 0);
+  }
+
+  function test_fundCost_maxWeight_usesLinearFormula() public view {
+    uint256 poolTokensWanted = 30_000e18;
+    // At reserveRatio == MAX_WEIGHT: cost = ceil(amount * reserveBalance / supply)
+    uint256 result = formula.exposed_fundCost(SUPPLY, RESERVE, MAX_WEIGHT, poolTokensWanted);
+    uint256 expected = (poolTokensWanted * RESERVE - 1) / SUPPLY + 1;
+    assertEq(result, expected);
+  }
+
+  function test_fundCost_normalCase_returnsPositive() public view {
+    uint256 poolTokensWanted = 30_000e18; // 10% of supply
+    uint256 result = formula.exposed_fundCost(SUPPLY, RESERVE, WEIGHT_20 * 2, poolTokensWanted);
+    assertGt(result, 0);
+  }
+
+  function test_fundCost_revertOnZeroSupply() public {
+    vm.expectRevert("ERR_INVALID_SUPPLY");
+    formula.exposed_fundCost(0, RESERVE, WEIGHT_20 * 2, 1e18);
+  }
+
+  function test_fundCost_revertOnZeroReserve() public {
+    vm.expectRevert("ERR_INVALID_RESERVE_BALANCE");
+    formula.exposed_fundCost(SUPPLY, 0, WEIGHT_20 * 2, 1e18);
+  }
+
+  function test_fundCost_revertOnInvalidReserveRatio() public {
+    // reserveRatio must be > 1
+    vm.expectRevert("ERR_INVALID_RESERVE_RATIO");
+    formula.exposed_fundCost(SUPPLY, RESERVE, 1, 1e18);
+  }
+
+  // ================================================================
+  // Fuzz: purchase/sale directional consistency
+  // ================================================================
+
+  function testFuzz_purchaseTargetAmount_positiveMonotone(uint256 amount1, uint256 amount2) public view {
+    // Larger deposit always yields more tokens (or equal at 0)
+    amount1 = bound(amount1, 1, 1e24);
+    amount2 = bound(amount2, amount1 + 1, 2e24);
+
+    uint256 out1 = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, WEIGHT_20, amount1);
+    uint256 out2 = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, WEIGHT_20, amount2);
+    assertGe(out2, out1);
+  }
+
+  function testFuzz_saleTargetAmount_positiveMonotone(uint256 sell1, uint256 sell2) public view {
+    // Cap at 90% of supply — the general formula path overflows near 100% supply (the exact
+    // 100% case is handled by a special branch tested in test_saleTargetAmount_fullSupplyReturnsFullReserve).
+    // Minimum of 1e15 avoids sub-precision degenerate cases where amount/supply rounds to 0.
+    uint256 maxSell = (SUPPLY * 9) / 10;
+    sell1 = bound(sell1, 1e15, maxSell - 1e15);
+    sell2 = bound(sell2, sell1 + 1e15, maxSell);
+
+    uint256 out1 = formula.exposed_saleTargetAmount(SUPPLY, RESERVE, WEIGHT_20, sell1);
+    uint256 out2 = formula.exposed_saleTargetAmount(SUPPLY, RESERVE, WEIGHT_20, sell2);
+    assertGe(out2, out1);
+  }
+
+  function testFuzz_saleCost_roundsUp(uint256 reserveOut) public view {
+    // saleCost must always be >= saleTargetAmount inverse (i.e. cost >= what you'd get back)
+    // Minimum of 1e15 avoids sub-precision cases where the formula underflows.
+    reserveOut = bound(reserveOut, 1e15, RESERVE / 2);
+
+    uint256 cost = formula.exposed_saleCost(SUPPLY, RESERVE, WEIGHT_50, reserveOut);
+    uint256 roundTrip = formula.exposed_saleTargetAmount(SUPPLY, RESERVE, WEIGHT_50, cost);
+    // Selling `cost` tokens should yield at least `reserveOut` (saleCost rounds up)
+    assertGe(roundTrip, reserveOut);
+  }
+
+  function testFuzz_purchaseSale_maxWeight_isLinear(uint256 amount) public view {
+    // At MAX_WEIGHT both functions use simple division — verify linearity holds
+    amount = bound(amount, 1, RESERVE / 2);
+    uint256 tokensOut = formula.exposed_purchaseTargetAmount(SUPPLY, RESERVE, MAX_WEIGHT, amount);
+    uint256 reserveBack = formula.exposed_saleTargetAmount(SUPPLY + tokensOut, RESERVE + amount, MAX_WEIGHT, tokensOut);
+    // Should recover at most the original deposit (no rounding gain)
+    assertLe(reserveBack, amount);
+  }
+}

--- a/test/unit/governance/TimelockController.t.sol
+++ b/test/unit/governance/TimelockController.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.18;
+// solhint-disable func-name-mixedcase, contract-name-camelcase
+
+import { Test } from "mento-std/Test.sol";
+import { TimelockController } from "contracts/governance/TimelockController.sol";
+
+/**
+ * @title TimelockControllerTest
+ * @notice Unit tests for Mento's TimelockController — a thin wrapper around OZ's
+ *         TimelockControllerUpgradeable that adds a separate canceller address
+ *         with the CANCELLER_ROLE at init time.
+ */
+contract TimelockControllerTest is Test {
+  TimelockController public timelock;
+
+  address public admin = makeAddr("admin");
+  address public proposer = makeAddr("proposer");
+  address public executor = makeAddr("executor");
+  address public canceller = makeAddr("canceller");
+  address public stranger = makeAddr("stranger");
+  address public target = makeAddr("target");
+
+  bytes32 public constant PROPOSER_ROLE = keccak256("PROPOSER_ROLE");
+  bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+  bytes32 public constant CANCELLER_ROLE = keccak256("CANCELLER_ROLE");
+  bytes32 public constant TIMELOCK_ADMIN_ROLE = keccak256("TIMELOCK_ADMIN_ROLE");
+
+  uint256 public constant MIN_DELAY = 2 days;
+
+  function setUp() public virtual {
+    timelock = new TimelockController();
+
+    address[] memory proposers = new address[](1);
+    proposers[0] = proposer;
+    address[] memory executors = new address[](1);
+    executors[0] = executor;
+
+    timelock.__MentoTimelockController_init(MIN_DELAY, proposers, executors, admin, canceller);
+  }
+
+  // ============ Initialization ============
+
+  function test_init_setsMinDelay() public view {
+    assertEq(timelock.getMinDelay(), MIN_DELAY);
+  }
+
+  function test_init_proposerHasProposerRole() public view {
+    assertTrue(timelock.hasRole(PROPOSER_ROLE, proposer));
+  }
+
+  function test_init_proposerAutomaticallyHasCancellerRole() public view {
+    // OZ gives CANCELLER_ROLE to all proposers during init
+    assertTrue(timelock.hasRole(CANCELLER_ROLE, proposer));
+  }
+
+  function test_init_cancellerHasCancellerRole() public view {
+    // Mento-specific: additional canceller address passed at init
+    assertTrue(timelock.hasRole(CANCELLER_ROLE, canceller));
+  }
+
+  function test_init_cancellerDoesNotHaveProposerRole() public view {
+    // Canceller can only cancel, not schedule
+    assertFalse(timelock.hasRole(PROPOSER_ROLE, canceller));
+  }
+
+  function test_init_executorHasExecutorRole() public view {
+    assertTrue(timelock.hasRole(EXECUTOR_ROLE, executor));
+  }
+
+  function test_init_strangerHasNoRoles() public view {
+    assertFalse(timelock.hasRole(PROPOSER_ROLE, stranger));
+    assertFalse(timelock.hasRole(EXECUTOR_ROLE, stranger));
+    assertFalse(timelock.hasRole(CANCELLER_ROLE, stranger));
+    assertFalse(timelock.hasRole(TIMELOCK_ADMIN_ROLE, stranger));
+  }
+
+  function test_init_timelockOwnedByItself() public view {
+    // The timelock contract itself always holds TIMELOCK_ADMIN_ROLE
+    assertTrue(timelock.hasRole(TIMELOCK_ADMIN_ROLE, address(timelock)));
+  }
+
+  // ============ Scheduling ============
+
+  function _scheduleOp() internal returns (bytes32 id) {
+    bytes32 predecessor = bytes32(0);
+    bytes32 salt = bytes32(uint256(1));
+    uint256 delay = MIN_DELAY;
+
+    vm.prank(proposer);
+    timelock.schedule(target, 0, "", predecessor, salt, delay);
+    id = timelock.hashOperation(target, 0, "", predecessor, salt);
+  }
+
+  function test_schedule_onlyProposerCanSchedule() public {
+    vm.prank(stranger);
+    vm.expectRevert();
+    timelock.schedule(target, 0, "", bytes32(0), bytes32(uint256(1)), MIN_DELAY);
+  }
+
+  function test_schedule_cancellerCannotSchedule() public {
+    vm.prank(canceller);
+    vm.expectRevert();
+    timelock.schedule(target, 0, "", bytes32(0), bytes32(uint256(1)), MIN_DELAY);
+  }
+
+  function test_schedule_operationIsQueued() public {
+    bytes32 id = _scheduleOp();
+    assertTrue(timelock.isOperationPending(id));
+    assertFalse(timelock.isOperationReady(id));
+    assertFalse(timelock.isOperationDone(id));
+  }
+
+  function test_schedule_operationReadyAfterDelay() public {
+    bytes32 id = _scheduleOp();
+
+    vm.warp(block.timestamp + MIN_DELAY);
+    assertTrue(timelock.isOperationReady(id));
+  }
+
+  function test_schedule_revertsBelowMinDelay() public {
+    vm.prank(proposer);
+    vm.expectRevert();
+    timelock.schedule(target, 0, "", bytes32(0), bytes32(uint256(1)), MIN_DELAY - 1);
+  }
+
+  // ============ Execution ============
+
+  function test_execute_onlyExecutorCanExecute() public {
+    _scheduleOp();
+    vm.warp(block.timestamp + MIN_DELAY);
+
+    vm.prank(stranger);
+    vm.expectRevert();
+    timelock.execute(target, 0, "", bytes32(0), bytes32(uint256(1)));
+  }
+
+  function test_execute_revertsBeforeDelay() public {
+    _scheduleOp();
+
+    vm.prank(executor);
+    vm.expectRevert();
+    timelock.execute(target, 0, "", bytes32(0), bytes32(uint256(1)));
+  }
+
+  function test_execute_succeedsAfterDelay() public {
+    bytes32 id = _scheduleOp();
+    vm.warp(block.timestamp + MIN_DELAY);
+
+    vm.prank(executor);
+    // target is a bare address with no code — call with empty calldata succeeds
+    timelock.execute(target, 0, "", bytes32(0), bytes32(uint256(1)));
+
+    assertTrue(timelock.isOperationDone(id));
+  }
+
+  // ============ Cancellation ============
+
+  function test_cancel_proposerCanCancel() public {
+    bytes32 id = _scheduleOp();
+    assertTrue(timelock.isOperationPending(id));
+
+    vm.prank(proposer);
+    timelock.cancel(id);
+
+    assertFalse(timelock.isOperation(id));
+  }
+
+  function test_cancel_cancellerCanCancel() public {
+    bytes32 id = _scheduleOp();
+
+    vm.prank(canceller);
+    timelock.cancel(id);
+
+    assertFalse(timelock.isOperation(id));
+  }
+
+  function test_cancel_strangerCannotCancel() public {
+    bytes32 id = _scheduleOp();
+
+    vm.prank(stranger);
+    vm.expectRevert();
+    timelock.cancel(id);
+
+    assertTrue(timelock.isOperationPending(id));
+  }
+
+  function test_cancel_executorCannotCancel() public {
+    bytes32 id = _scheduleOp();
+
+    vm.prank(executor);
+    vm.expectRevert();
+    timelock.cancel(id);
+  }
+
+  function test_cancel_revertsForUnknownOperation() public {
+    vm.prank(canceller);
+    vm.expectRevert();
+    timelock.cancel(bytes32(uint256(999)));
+  }
+
+  // ============ Re-initialization guard ============
+
+  function test_init_cannotInitializeTwice() public {
+    address[] memory proposers;
+    address[] memory executors;
+    vm.expectRevert();
+    timelock.__MentoTimelockController_init(1 days, proposers, executors, admin, canceller);
+  }
+}


### PR DESCRIPTION
## Summary

Adds isolated unit test coverage for two critical contracts that previously had no dedicated unit tests (mento-core QA audit MEN-5, P2-10).

- `test/unit/governance/TimelockController.t.sol` — 22 tests covering initialization, scheduling, execution, cancellation, delay bounds, and access control
- `test/unit/goodDollar/BancorFormula.t.sol` — 31 tests covering all four Bancor formulas (purchase/sale return and cost) with unit tests and fuzz coverage for edge cases (zero amounts, max values, large supply)

All 53 tests pass locally under `forge test --no-match-contract ForkTest`.

## Test Plan
- [ ] `forge test --no-match-contract ForkTest --match-path "test/unit/governance/TimelockController.t.sol"` passes
- [ ] `forge test --no-match-contract ForkTest --match-path "test/unit/goodDollar/BancorFormula.t.sol"` passes
- [ ] No existing tests are broken

Closes MEN-38. Related: mento-core QA audit MEN-5.