### PR TITLE
chore: remove Alfajores from fork tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,2 @@
 CELOSCAN_API_KEY=
 CELO_MAINNET_RPC_URL=https://forno.celo.org
-ALFAJORES_RPC_URL=https://alfajores-forno.celo-testnet.org

--- a/.github/workflows/fork-tests.yaml
+++ b/.github/workflows/fork-tests.yaml
@@ -2,7 +2,6 @@ name: "ForkTests"
 
 env:
   FOUNDRY_PROFILE: "fork-tests"
-  ALFAJORES_RPC_URL: ${{secrets.ALFAJORES_RPC_URL}}
   CELO_MAINNET_RPC_URL: ${{secrets.CELO_MAINNET_RPC_URL}}
 
 on: 

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -2,7 +2,6 @@ name: CI
 
 env:
   FOUNDRY_PROFILE: ci
-  ALFAJORES_RPC_URL: ${{secrets.ALFAJORES_RPC_URL}}
   CELO_MAINNET_RPC_URL: ${{secrets.CELO_MAINNET_RPC_URL}}
 
 on:

--- a/foundry.toml
+++ b/foundry.toml
@@ -32,4 +32,3 @@ match_contract = "ForkTest"
 
 [rpc_endpoints]
 celo = "${CELO_MAINNET_RPC_URL}"
-alfajores = "${ALFAJORES_RPC_URL}"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "solhint:tests": "solhint --config \"./test/.solhint.json\" \"test/**/*.sol\" -w 0",
     "test": "forge test",
     "fork-test": "env FOUNDRY_PROFILE=fork-tests forge test",
-    "fork-test:alfajores": "env FOUNDRY_PROFILE=fork-tests forge test --match-contract Alfajores",
     "fork-test:celo-mainnet": "env FOUNDRY_PROFILE=fork-tests forge test --match-contract Celo",
     "check-no-ir": "./bin/check-contracts.sh",
     "check-contract-sizes": "env FOUNDRY_PROFILE=optimized forge build --sizes --skip \"test/**/*\"",

--- a/test/fork/ForkTests.t.sol
+++ b/test/fork/ForkTests.t.sol
@@ -9,7 +9,7 @@ Thare are two types of test contracts:
   assets, contract initialization state, etc.
 - ExchangeForkTests: Tests that are specific to the exchange, such as trading limits, swaps, circuit breakers, etc.
 
-To make it easier to debug and develop, we have one ChainForkTest for each chain (Alfajores, Celo) and 
+To make it easier to debug and develop, we have one ChainForkTest for each chain (Celo) and
 one ExchangeForkTest for each exchange provider and exchange pair.
 
 The ChainForkTests are instantiated with:
@@ -26,17 +26,17 @@ The ExchangeForkTests are instantiated with:
 
 And the naming convention for them is:
 - ${ChainName}_P${ExchangeProviderIndex}E${ExchangeIndex}_ExchangeForkTest
-- e.g. "Alfajores_P0E00_ExchangeForkTest (Alfajores, Exchange Provider 0, Exchange 0)"
+- e.g. "Celo_P0E00_ExchangeForkTest (Celo, Exchange Provider 0, Exchange 0)"
 The Exchange Index is 0 padded to make them align nicely in the file.
 Exchange provider counts shouldn't exceed 10. If they do, then we need to update the naming convention.
 
 This makes it easy to drill into which exchange is failing and debug it like:
 - `$ env FOUNDRY_PROFILE=fork-tests forge test --match-contract CELO_P0E12`
 or run all tests for a chain:
-- `$ env FOUNDRY_PROFILE=fork-tests forge test --match-contract Alfajores`
+- `$ env FOUNDRY_PROFILE=fork-tests forge test --match-contract Celo`
 */
 
-import { CELO_ID, ALFAJORES_ID } from "mento-std/Constants.sol";
+import { CELO_ID } from "mento-std/Constants.sol";
 import { uints } from "mento-std/Array.sol";
 import { ChainForkTest } from "./ChainForkTest.sol";
 import { ExchangeForkTest } from "./ExchangeForkTest.sol";
@@ -44,46 +44,6 @@ import { BancorExchangeProviderForkTest } from "./BancorExchangeProviderForkTest
 import { GoodDollarTradingLimitsForkTest } from "./GoodDollar/TradingLimitsForkTest.sol";
 import { GoodDollarSwapForkTest } from "./GoodDollar/SwapForkTest.sol";
 import { GoodDollarExpansionForkTest } from "./GoodDollar/ExpansionForkTest.sol";
-
-contract Alfajores_ChainForkTest is ChainForkTest(ALFAJORES_ID, 1, uints(19)) {}
-
-contract Alfajores_P0E00_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 0) {}
-
-contract Alfajores_P0E01_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 1) {}
-
-contract Alfajores_P0E02_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 2) {}
-
-contract Alfajores_P0E03_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 3) {}
-
-contract Alfajores_P0E04_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 4) {}
-
-contract Alfajores_P0E05_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 5) {}
-
-contract Alfajores_P0E06_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 6) {}
-
-contract Alfajores_P0E07_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 7) {}
-
-contract Alfajores_P0E08_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 8) {}
-
-contract Alfajores_P0E09_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 9) {}
-
-contract Alfajores_P0E10_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 10) {}
-
-contract Alfajores_P0E11_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 11) {}
-
-contract Alfajores_P0E12_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 12) {}
-
-contract Alfajores_P0E13_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 13) {}
-
-contract Alfajores_P0E14_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 14) {}
-
-contract Alfajores_P0E15_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 15) {}
-
-contract Alfajores_P0E16_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 16) {}
-
-contract Alfajores_P0E17_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 17) {}
-
-contract Alfajores_P0E18_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 18) {}
 
 contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(19)) {}
 

--- a/test/fork/README.md
+++ b/test/fork/README.md
@@ -18,14 +18,11 @@
          +-----------------+   +--------------------+
                  ^                       ^
                  |                       |
-    +-------------------------+  +-------------------------+
-    | Alfajores_ChainForkTest |  | Alfajores_P0E00_...     |
-    +-------------------------+  +-------------------------+
     +--------------------+       +-------------------------+
-    | Celo_ChainForkTest |       | Alfajores_P0E01_...     |
+    | Celo_ChainForkTest |       | Celo_P0E00_...          |
     +--------------------+       +-------------------------+
                                  +-------------------------+
-                                 | Celo_P0E00_...          |
+                                 | Celo_P0E01_...          |
                                  +-------------------------+
 ```
 
@@ -41,17 +38,17 @@ These contracts are abstract and need to be extended by instance specific contra
 This happens in `ForkTests.t.sol`. For example:
 
 ```solidity
-contract Alfajores_ChainForkTest is ChainForkTest(ALFAJORES_ID, 1, uints(14)) {}
+contract Celo_ChainForkTest is ChainForkTest(CELO_ID, 1, uints(19)) {}
 ```
 
-This represents a ChainForkTest for Alfajores, with the expectation that there's a single exchange provider,
-and it has 14 exchanges. If the expectations change this will fail and need to be updated.
+This represents a ChainForkTest for Celo, with the expectation that there's a single exchange provider,
+and it has 19 exchanges. If the expectations change this will fail and need to be updated.
 
 ```solidity
-contract Alfajores_P0E00_ExchangeForkTest is ExchangeForkTest(ALFAJORES_ID, 0, 0) {}
+contract Celo_P0E00_ExchangeForkTest is ExchangeForkTest(CELO_ID, 0, 0) {}
 ```
 
-This represents an ExchangeForkTest for the 0th exchange of the 0th exchange provider on Alfajores.
+This represents an ExchangeForkTest for the 0th exchange of the 0th exchange provider on Celo.
 These tests contracts need to be added manually when we add more pairs or exchange providers, but the
 assertions at chain level gives us the heads up when this changes.
 


### PR DESCRIPTION
## Summary
- Remove all Alfajores fork test contracts (ChainForkTest + 19 ExchangeForkTests) from `ForkTests.t.sol`
- Remove `ALFAJORES_RPC_URL` from CI workflows, `foundry.toml`, and `.env.example`
- Remove `fork-test:alfajores` npm script from `package.json`
- Update fork test README to use Celo-only examples

## Motivation
Alfajores testnet is dead — no reason to keep fork-testing against it.

## Test plan
- [x] Lint passes (verified via pre-push hook)
- [ ] CI fork tests pass against Celo mainnet only

🤖 Generated with [Claude Code](https://claude.com/claude-code)