### PR TITLE
feat: align RLS contraction clamp with stable-first transfer semantics

### DIFF
--- a/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
@@ -1,203 +1,219 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.24;
 
-import { IERC20Upgradeable as IERC20 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
+import {
+    IERC20Upgradeable as IERC20
+} from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
 // solhint-disable-next-line max-line-length
-import { SafeERC20Upgradeable as SafeERC20 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import { IERC20MintableBurnable } from "../common/IERC20MintableBurnable.sol";
+import {
+    SafeERC20Upgradeable as SafeERC20
+} from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import {IERC20MintableBurnable} from "../common/IERC20MintableBurnable.sol";
 
-import { LiquidityStrategy } from "./LiquidityStrategy.sol";
-import { IReserveV2 } from "../interfaces/IReserveV2.sol";
-import { IReserveLiquidityStrategy } from "../interfaces/IReserveLiquidityStrategy.sol";
-import { LiquidityStrategyTypes as LQ } from "../libraries/LiquidityStrategyTypes.sol";
+import {LiquidityStrategy} from "./LiquidityStrategy.sol";
+import {IReserveV2} from "../interfaces/IReserveV2.sol";
+import {IReserveLiquidityStrategy} from "../interfaces/IReserveLiquidityStrategy.sol";
+import {LiquidityStrategyTypes as LQ} from "../libraries/LiquidityStrategyTypes.sol";
 
 contract ReserveLiquidityStrategy is IReserveLiquidityStrategy, LiquidityStrategy {
-  using LQ for LQ.Context;
-  using SafeERC20 for IERC20;
+    using LQ for LQ.Context;
+    using SafeERC20 for IERC20;
 
-  /* ============================================================ */
-  /* ==================== State Variables ======================= */
-  /* ============================================================ */
+    /* ============================================================ */
+    /* ==================== State Variables ======================= */
+    /* ============================================================ */
 
-  /// @notice The reserve contract that holds collateral
-  IReserveV2 public reserve;
+    /// @notice The reserve contract that holds collateral
+    IReserveV2 public reserve;
 
-  /* ============================================================ */
-  /* ======================= Constructor ======================== */
-  /* ============================================================ */
+    /* ============================================================ */
+    /* ======================= Constructor ======================== */
+    /* ============================================================ */
 
-  /**
-   * @notice Disables initializers on implementation contracts.
-   * @param disable Set to true to disable initializers (for proxy pattern).
-   */
-  constructor(bool disable) LiquidityStrategy(disable) {}
+    /**
+     * @notice Disables initializers on implementation contracts.
+     * @param disable Set to true to disable initializers (for proxy pattern).
+     */
+    constructor(bool disable) LiquidityStrategy(disable) {}
 
-  /// @inheritdoc IReserveLiquidityStrategy
-  function initialize(address _initialOwner, address _reserve) public initializer {
-    __LiquidityStrategy_init(_initialOwner);
-    if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
-    reserve = IReserveV2(_reserve);
-    emit ReserveSet(address(0), _reserve);
-  }
-
-  /* ============================================================ */
-  /* ==================== External Functions ==================== */
-  /* ============================================================ */
-
-  /// @inheritdoc IReserveLiquidityStrategy
-  function addPool(AddPoolParams calldata params) external onlyOwner {
-    LiquidityStrategy._addPool(params);
-  }
-
-  /// @inheritdoc IReserveLiquidityStrategy
-  function removePool(address pool) external onlyOwner {
-    LiquidityStrategy._removePool(pool);
-  }
-
-  /// @inheritdoc IReserveLiquidityStrategy
-  function setReserve(address _reserve) external onlyOwner {
-    if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
-
-    address oldReserve = address(reserve);
-    reserve = IReserveV2(_reserve);
-
-    emit ReserveSet(oldReserve, _reserve);
-  }
-
-  /* =========================================================== */
-  /* ==================== Virtual Functions ==================== */
-  /* =========================================================== */
-
-  /**
-   * @notice Clamps contraction amounts based on Reserve's collateral balance
-   * @dev Reserve has unlimited minting capacity for expansions so no clamping needed
-   *      For contractions, checks Reserve collateral balance and adjusts if insufficient
-   * @param ctx The liquidity context containing pool state and configuration
-   * @param idealDebtToContract The calculated ideal amount of debt tokens to receive from pool
-   * @param idealCollateralToReceive The calculated ideal amount of collateral to add to pool
-   * @return debtToContract The actual debt amount to contract (may be less than ideal)
-   * @return collateralToReceive The actual collateral amount to send (adjusted if balance insufficient)
-   */
-  function _clampContraction(
-    LQ.Context memory ctx,
-    uint256 idealDebtToContract,
-    uint256 idealCollateralToReceive
-  ) internal view override returns (uint256 debtToContract, uint256 collateralToReceive) {
-    address collateralToken = ctx.collateralToken();
-    uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(reserve));
-
-    // slither-disable-next-line incorrect-equality
-    if (collateralBalance == 0) revert RLS_RESERVE_OUT_OF_COLLATERAL();
-
-    if (collateralBalance < idealCollateralToReceive) {
-      uint256 combinedFeeMultiplier = LQ.combineFees(
-        ctx.incentives.protocolIncentiveContraction,
-        ctx.incentives.liquiditySourceIncentiveContraction
-      );
-      collateralToReceive = collateralBalance;
-      debtToContract = ctx.convertToDebtWithFee(collateralBalance, LQ.FEE_DENOMINATOR, combinedFeeMultiplier);
-    } else {
-      collateralToReceive = idealCollateralToReceive;
-      debtToContract = idealDebtToContract;
+    /// @inheritdoc IReserveLiquidityStrategy
+    function initialize(address _initialOwner, address _reserve) public initializer {
+        __LiquidityStrategy_init(_initialOwner);
+        if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
+        reserve = IReserveV2(_reserve);
+        emit ReserveSet(address(0), _reserve);
     }
 
-    return (debtToContract, collateralToReceive);
-  }
+    /* ============================================================ */
+    /* ==================== External Functions ==================== */
+    /* ============================================================ */
 
-  /* ============================================================ */
-  /* ================= Callback Implementation ================== */
-  /* ============================================================ */
-
-  /**
-   * @notice Handles the rebalance callback by managing token flows with the Reserve
-   * @dev Determines token flow direction and calls appropriate transfer functions
-   * @param pool The address of the FPMM pool
-   * @param amount0Out The amount of token0 sent by the pool
-   * @param amount1Out The amount of token1 sent by the pool
-   * @param cb The callback data containing rebalance parameters
-   */
-  function _handleCallback(
-    address pool,
-    uint256 amount0Out,
-    uint256 amount1Out,
-    LQ.CallbackData memory cb
-  ) internal override {
-    PoolConfig memory config = poolConfigs[pool];
-
-    (
-      address tokenToTransferToReserve,
-      address tokenToTransferToPool,
-      uint256 protocolIncentive,
-      uint256 liquiditySourceIncentive
-    ) = cb.dir == LQ.Direction.Expand
-        ? (cb.collToken, cb.debtToken, config.protocolIncentiveExpansion, config.liquiditySourceIncentiveExpansion)
-        : (cb.debtToken, cb.collToken, config.protocolIncentiveContraction, config.liquiditySourceIncentiveContraction);
-    uint256 amountToTransferToReserve = amount0Out > 0 ? amount0Out : amount1Out;
-    uint256 protocolIncentiveAmount = (amountToTransferToReserve * protocolIncentive) / LQ.FEE_DENOMINATOR;
-    uint256 liquiditySourceIncentiveAmount = ((amountToTransferToReserve - protocolIncentiveAmount) *
-      liquiditySourceIncentive) / LQ.FEE_DENOMINATOR;
-    if (cb.dir == LQ.Direction.Expand) {
-      // Expansion: Pool price > oracle price
-      // Reserve provides debt to pool, receives collateral from pool
-
-      // Transfer protocol incentive to protocol fee recipient
-      _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
-      // Transfer collateral to reserve this includes the liquidity source incentive since reserve is the liquidity source
-      _transferToReserve(tokenToTransferToReserve, amountToTransferToReserve - protocolIncentiveAmount);
-      // mint stable asset to pool
-      _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
-    } else {
-      // Contraction: Pool price < oracle price
-      // Reserve provides collateral to pool, receives debt from pool
-
-      // Transfer protocol incentive to protocol fee recipient
-      _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
-      // Transfer liquidity source incentive in stable asset to reserve
-      _transferRebalanceIncentive(tokenToTransferToReserve, liquiditySourceIncentiveAmount, address(reserve));
-      // burn stable assets from pool
-      _transferToReserve(
-        tokenToTransferToReserve,
-        amountToTransferToReserve - (protocolIncentiveAmount + liquiditySourceIncentiveAmount)
-      );
-      // transfer collateral from reserve to pool
-      _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
+    /// @inheritdoc IReserveLiquidityStrategy
+    function addPool(AddPoolParams calldata params) external onlyOwner {
+        LiquidityStrategy._addPool(params);
     }
-  }
 
-  /**
-   * @notice Transfer tokens into the pool and pay incentive
-   * @param token The token to transfer in
-   * @param pool The pool to transfer to
-   * @param amount Amount to send to the pool
-   */
-  function _transferToPool(address token, address pool, uint256 amount) internal {
-    if (reserve.isStableAsset(token)) {
-      // Mint stable assets directly
-      IERC20MintableBurnable(token).mint(pool, amount);
-    } else if (reserve.isCollateralAsset(token)) {
-      // Transfer collateral from reserve
-      if (!reserve.transferCollateralAsset(token, pool, amount)) revert RLS_COLLATERAL_TO_POOL_FAILED();
-    } else {
-      revert RLS_TOKEN_IN_NOT_SUPPORTED();
+    /// @inheritdoc IReserveLiquidityStrategy
+    function removePool(address pool) external onlyOwner {
+        LiquidityStrategy._removePool(pool);
     }
-  }
 
-  /**
-   * @notice Transfer tokens out from the pool back to reserve
-   * @param token The token to transfer out
-   * @param amount The amount to transfer
-   */
-  function _transferToReserve(address token, uint256 amount) internal {
-    if (amount == 0) return;
+    /// @inheritdoc IReserveLiquidityStrategy
+    function setReserve(address _reserve) external onlyOwner {
+        if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
 
-    if (reserve.isStableAsset(token)) {
-      // Burn stable assets received from pool
-      IERC20MintableBurnable(token).burn(amount);
-    } else if (reserve.isCollateralAsset(token)) {
-      // Transfer collateral back to reserve
-      IERC20(token).safeTransfer(address(reserve), amount);
-    } else {
-      revert RLS_TOKEN_OUT_NOT_SUPPORTED();
+        address oldReserve = address(reserve);
+        reserve = IReserveV2(_reserve);
+
+        emit ReserveSet(oldReserve, _reserve);
     }
-  }
+
+    /* =========================================================== */
+    /* ==================== Virtual Functions ==================== */
+    /* =========================================================== */
+
+    /**
+     * @notice Clamps contraction amounts based on how the collateral side is sourced
+     * @dev If the collateral token is registered as a stable asset, it is minted during contraction
+     *      so the ideal amounts can be used without clamping.
+     *      If it is registered as a collateral asset, the amount is clamped to the Reserve's balance.
+     * @param ctx The liquidity context containing pool state and configuration
+     * @param idealDebtToContract The calculated ideal amount of debt tokens to receive from pool
+     * @param idealCollateralToReceive The calculated ideal amount of collateral to add to pool
+     * @return debtToContract The actual debt amount to contract (may be less than ideal)
+     * @return collateralToReceive The actual collateral amount to send (adjusted if Reserve balance is insufficient)
+     */
+    function _clampContraction(LQ.Context memory ctx, uint256 idealDebtToContract, uint256 idealCollateralToReceive)
+        internal
+        view
+        override
+        returns (uint256 debtToContract, uint256 collateralToReceive)
+    {
+        address collateralToken = ctx.collateralToken();
+
+        if (reserve.isStableAsset(collateralToken)) {
+            // Stable assets are minted, so no reserve balance constraint
+            return (idealDebtToContract, idealCollateralToReceive);
+        } else if (reserve.isCollateralAsset(collateralToken)) {
+            uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(reserve));
+
+            // slither-disable-next-line incorrect-equality
+            if (collateralBalance == 0) revert RLS_RESERVE_OUT_OF_COLLATERAL();
+
+            if (collateralBalance < idealCollateralToReceive) {
+                uint256 combinedFeeMultiplier = LQ.combineFees(
+                    ctx.incentives.protocolIncentiveContraction, ctx.incentives.liquiditySourceIncentiveContraction
+                );
+                collateralToReceive = collateralBalance;
+                debtToContract = ctx.convertToDebtWithFee(collateralBalance, LQ.FEE_DENOMINATOR, combinedFeeMultiplier);
+            } else {
+                collateralToReceive = idealCollateralToReceive;
+                debtToContract = idealDebtToContract;
+            }
+
+            return (debtToContract, collateralToReceive);
+        } else {
+            revert RLS_TOKEN_IN_NOT_SUPPORTED();
+        }
+    }
+
+    /* ============================================================ */
+    /* ================= Callback Implementation ================== */
+    /* ============================================================ */
+
+    /**
+     * @notice Handles the rebalance callback by managing token flows with the Reserve
+     * @dev Determines token flow direction and calls appropriate transfer functions
+     * @param pool The address of the FPMM pool
+     * @param amount0Out The amount of token0 sent by the pool
+     * @param amount1Out The amount of token1 sent by the pool
+     * @param cb The callback data containing rebalance parameters
+     */
+    function _handleCallback(address pool, uint256 amount0Out, uint256 amount1Out, LQ.CallbackData memory cb)
+        internal
+        override
+    {
+        PoolConfig memory config = poolConfigs[pool];
+
+        (
+            address tokenToTransferToReserve,
+            address tokenToTransferToPool,
+            uint256 protocolIncentive,
+            uint256 liquiditySourceIncentive
+        ) = cb.dir == LQ.Direction.Expand
+            ? (cb.collToken, cb.debtToken, config.protocolIncentiveExpansion, config.liquiditySourceIncentiveExpansion)
+            : (
+                cb.debtToken,
+                cb.collToken,
+                config.protocolIncentiveContraction,
+                config.liquiditySourceIncentiveContraction
+            );
+        uint256 amountToTransferToReserve = amount0Out > 0 ? amount0Out : amount1Out;
+        uint256 protocolIncentiveAmount = (amountToTransferToReserve * protocolIncentive) / LQ.FEE_DENOMINATOR;
+        uint256 liquiditySourceIncentiveAmount =
+            ((amountToTransferToReserve - protocolIncentiveAmount) * liquiditySourceIncentive) / LQ.FEE_DENOMINATOR;
+        if (cb.dir == LQ.Direction.Expand) {
+            // Expansion: Pool price > oracle price
+            // Reserve provides debt to pool, receives collateral from pool
+
+            // Transfer protocol incentive to protocol fee recipient
+            _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
+            // Transfer collateral to reserve this includes the liquidity source incentive since reserve is the liquidity source
+            _transferToReserve(tokenToTransferToReserve, amountToTransferToReserve - protocolIncentiveAmount);
+            // mint stable asset to pool
+            _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
+        } else {
+            // Contraction: Pool price < oracle price
+            // Reserve provides collateral to pool, receives debt from pool
+
+            // Transfer protocol incentive to protocol fee recipient
+            _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
+            // Transfer liquidity source incentive in stable asset to reserve
+            _transferRebalanceIncentive(tokenToTransferToReserve, liquiditySourceIncentiveAmount, address(reserve));
+            // burn stable assets from pool
+            _transferToReserve(
+                tokenToTransferToReserve,
+                amountToTransferToReserve - (protocolIncentiveAmount + liquiditySourceIncentiveAmount)
+            );
+            // transfer collateral from reserve to pool
+            _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
+        }
+    }
+
+    /**
+     * @notice Transfer tokens into the pool and pay incentive
+     * @param token The token to transfer in
+     * @param pool The pool to transfer to
+     * @param amount Amount to send to the pool
+     */
+    function _transferToPool(address token, address pool, uint256 amount) internal {
+        if (reserve.isStableAsset(token)) {
+            // Mint stable assets directly
+            IERC20MintableBurnable(token).mint(pool, amount);
+        } else if (reserve.isCollateralAsset(token)) {
+            // Transfer collateral from reserve
+            if (!reserve.transferCollateralAsset(token, pool, amount)) revert RLS_COLLATERAL_TO_POOL_FAILED();
+        } else {
+            revert RLS_TOKEN_IN_NOT_SUPPORTED();
+        }
+    }
+
+    /**
+     * @notice Transfer tokens out from the pool back to reserve
+     * @param token The token to transfer out
+     * @param amount The amount to transfer
+     */
+    function _transferToReserve(address token, uint256 amount) internal {
+        if (amount == 0) return;
+
+        if (reserve.isStableAsset(token)) {
+            // Burn stable assets received from pool
+            IERC20MintableBurnable(token).burn(amount);
+        } else if (reserve.isCollateralAsset(token)) {
+            // Transfer collateral back to reserve
+            IERC20(token).safeTransfer(address(reserve), amount);
+        } else {
+            revert RLS_TOKEN_OUT_NOT_SUPPORTED();
+        }
+    }
 }

--- a/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
@@ -86,6 +86,8 @@ contract ReserveLiquidityStrategy is IReserveLiquidityStrategy, LiquidityStrateg
   ) internal view override returns (uint256 debtToContract, uint256 collateralToReceive) {
     address collateralToken = ctx.collateralToken();
 
+    // Invariant: stable-first classification here must mirror _transferToPool so
+    // dual-registered tokens (stable + collateral) follow the mint path, not reserve transfer semantics.
     if (reserve.isStableAsset(collateralToken)) {
       // Stable assets are minted, so no reserve balance constraint
       return (idealDebtToContract, idealCollateralToReceive);

--- a/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
+++ b/contracts/liquidityStrategies/ReserveLiquidityStrategy.sol
@@ -1,219 +1,212 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.24;
 
-import {
-    IERC20Upgradeable as IERC20
-} from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
+import { IERC20Upgradeable as IERC20 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
 // solhint-disable-next-line max-line-length
-import {
-    SafeERC20Upgradeable as SafeERC20
-} from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import {IERC20MintableBurnable} from "../common/IERC20MintableBurnable.sol";
+import { SafeERC20Upgradeable as SafeERC20 } from "openzeppelin-contracts-upgradeable/contracts/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { IERC20MintableBurnable } from "../common/IERC20MintableBurnable.sol";
 
-import {LiquidityStrategy} from "./LiquidityStrategy.sol";
-import {IReserveV2} from "../interfaces/IReserveV2.sol";
-import {IReserveLiquidityStrategy} from "../interfaces/IReserveLiquidityStrategy.sol";
-import {LiquidityStrategyTypes as LQ} from "../libraries/LiquidityStrategyTypes.sol";
+import { LiquidityStrategy } from "./LiquidityStrategy.sol";
+import { IReserveV2 } from "../interfaces/IReserveV2.sol";
+import { IReserveLiquidityStrategy } from "../interfaces/IReserveLiquidityStrategy.sol";
+import { LiquidityStrategyTypes as LQ } from "../libraries/LiquidityStrategyTypes.sol";
 
 contract ReserveLiquidityStrategy is IReserveLiquidityStrategy, LiquidityStrategy {
-    using LQ for LQ.Context;
-    using SafeERC20 for IERC20;
+  using LQ for LQ.Context;
+  using SafeERC20 for IERC20;
 
-    /* ============================================================ */
-    /* ==================== State Variables ======================= */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ==================== State Variables ======================= */
+  /* ============================================================ */
 
-    /// @notice The reserve contract that holds collateral
-    IReserveV2 public reserve;
+  /// @notice The reserve contract that holds collateral
+  IReserveV2 public reserve;
 
-    /* ============================================================ */
-    /* ======================= Constructor ======================== */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ======================= Constructor ======================== */
+  /* ============================================================ */
 
-    /**
-     * @notice Disables initializers on implementation contracts.
-     * @param disable Set to true to disable initializers (for proxy pattern).
-     */
-    constructor(bool disable) LiquidityStrategy(disable) {}
+  /**
+   * @notice Disables initializers on implementation contracts.
+   * @param disable Set to true to disable initializers (for proxy pattern).
+   */
+  constructor(bool disable) LiquidityStrategy(disable) {}
 
-    /// @inheritdoc IReserveLiquidityStrategy
-    function initialize(address _initialOwner, address _reserve) public initializer {
-        __LiquidityStrategy_init(_initialOwner);
-        if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
-        reserve = IReserveV2(_reserve);
-        emit ReserveSet(address(0), _reserve);
+  /// @inheritdoc IReserveLiquidityStrategy
+  function initialize(address _initialOwner, address _reserve) public initializer {
+    __LiquidityStrategy_init(_initialOwner);
+    if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
+    reserve = IReserveV2(_reserve);
+    emit ReserveSet(address(0), _reserve);
+  }
+
+  /* ============================================================ */
+  /* ==================== External Functions ==================== */
+  /* ============================================================ */
+
+  /// @inheritdoc IReserveLiquidityStrategy
+  function addPool(AddPoolParams calldata params) external onlyOwner {
+    LiquidityStrategy._addPool(params);
+  }
+
+  /// @inheritdoc IReserveLiquidityStrategy
+  function removePool(address pool) external onlyOwner {
+    LiquidityStrategy._removePool(pool);
+  }
+
+  /// @inheritdoc IReserveLiquidityStrategy
+  function setReserve(address _reserve) external onlyOwner {
+    if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
+
+    address oldReserve = address(reserve);
+    reserve = IReserveV2(_reserve);
+
+    emit ReserveSet(oldReserve, _reserve);
+  }
+
+  /* =========================================================== */
+  /* ==================== Virtual Functions ==================== */
+  /* =========================================================== */
+
+  /**
+   * @notice Clamps contraction amounts based on how the collateral side is sourced
+   * @dev If the collateral token is registered as a stable asset, it is minted during contraction
+   *      so the ideal amounts can be used without clamping.
+   *      If it is registered as a collateral asset, the amount is clamped to the Reserve's balance.
+   * @param ctx The liquidity context containing pool state and configuration
+   * @param idealDebtToContract The calculated ideal amount of debt tokens to receive from pool
+   * @param idealCollateralToReceive The calculated ideal amount of collateral to add to pool
+   * @return debtToContract The actual debt amount to contract (may be less than ideal)
+   * @return collateralToReceive The actual collateral amount to send (adjusted if Reserve balance is insufficient)
+   */
+  function _clampContraction(
+    LQ.Context memory ctx,
+    uint256 idealDebtToContract,
+    uint256 idealCollateralToReceive
+  ) internal view override returns (uint256 debtToContract, uint256 collateralToReceive) {
+    address collateralToken = ctx.collateralToken();
+
+    if (reserve.isStableAsset(collateralToken)) {
+      // Stable assets are minted, so no reserve balance constraint
+      return (idealDebtToContract, idealCollateralToReceive);
+    } else if (reserve.isCollateralAsset(collateralToken)) {
+      uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(reserve));
+
+      // slither-disable-next-line incorrect-equality
+      if (collateralBalance == 0) revert RLS_RESERVE_OUT_OF_COLLATERAL();
+
+      if (collateralBalance < idealCollateralToReceive) {
+        uint256 combinedFeeMultiplier = LQ.combineFees(
+          ctx.incentives.protocolIncentiveContraction,
+          ctx.incentives.liquiditySourceIncentiveContraction
+        );
+        collateralToReceive = collateralBalance;
+        debtToContract = ctx.convertToDebtWithFee(collateralBalance, LQ.FEE_DENOMINATOR, combinedFeeMultiplier);
+      } else {
+        collateralToReceive = idealCollateralToReceive;
+        debtToContract = idealDebtToContract;
+      }
+
+      return (debtToContract, collateralToReceive);
+    } else {
+      revert RLS_TOKEN_IN_NOT_SUPPORTED();
     }
+  }
 
-    /* ============================================================ */
-    /* ==================== External Functions ==================== */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ================= Callback Implementation ================== */
+  /* ============================================================ */
 
-    /// @inheritdoc IReserveLiquidityStrategy
-    function addPool(AddPoolParams calldata params) external onlyOwner {
-        LiquidityStrategy._addPool(params);
+  /**
+   * @notice Handles the rebalance callback by managing token flows with the Reserve
+   * @dev Determines token flow direction and calls appropriate transfer functions
+   * @param pool The address of the FPMM pool
+   * @param amount0Out The amount of token0 sent by the pool
+   * @param amount1Out The amount of token1 sent by the pool
+   * @param cb The callback data containing rebalance parameters
+   */
+  function _handleCallback(
+    address pool,
+    uint256 amount0Out,
+    uint256 amount1Out,
+    LQ.CallbackData memory cb
+  ) internal override {
+    PoolConfig memory config = poolConfigs[pool];
+
+    (
+      address tokenToTransferToReserve,
+      address tokenToTransferToPool,
+      uint256 protocolIncentive,
+      uint256 liquiditySourceIncentive
+    ) = cb.dir == LQ.Direction.Expand
+        ? (cb.collToken, cb.debtToken, config.protocolIncentiveExpansion, config.liquiditySourceIncentiveExpansion)
+        : (cb.debtToken, cb.collToken, config.protocolIncentiveContraction, config.liquiditySourceIncentiveContraction);
+    uint256 amountToTransferToReserve = amount0Out > 0 ? amount0Out : amount1Out;
+    uint256 protocolIncentiveAmount = (amountToTransferToReserve * protocolIncentive) / LQ.FEE_DENOMINATOR;
+    uint256 liquiditySourceIncentiveAmount = ((amountToTransferToReserve - protocolIncentiveAmount) *
+      liquiditySourceIncentive) / LQ.FEE_DENOMINATOR;
+    if (cb.dir == LQ.Direction.Expand) {
+      // Expansion: Pool price > oracle price
+      // Reserve provides debt to pool, receives collateral from pool
+
+      // Transfer protocol incentive to protocol fee recipient
+      _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
+      // Transfer collateral to reserve this includes the liquidity source incentive since reserve is the liquidity source
+      _transferToReserve(tokenToTransferToReserve, amountToTransferToReserve - protocolIncentiveAmount);
+      // mint stable asset to pool
+      _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
+    } else {
+      // Contraction: Pool price < oracle price
+      // Reserve provides collateral to pool, receives debt from pool
+
+      // Transfer protocol incentive to protocol fee recipient
+      _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
+      // Transfer liquidity source incentive in stable asset to reserve
+      _transferRebalanceIncentive(tokenToTransferToReserve, liquiditySourceIncentiveAmount, address(reserve));
+      // burn stable assets from pool
+      _transferToReserve(
+        tokenToTransferToReserve,
+        amountToTransferToReserve - (protocolIncentiveAmount + liquiditySourceIncentiveAmount)
+      );
+      // transfer collateral from reserve to pool
+      _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
     }
+  }
 
-    /// @inheritdoc IReserveLiquidityStrategy
-    function removePool(address pool) external onlyOwner {
-        LiquidityStrategy._removePool(pool);
+  /**
+   * @notice Transfer tokens into the pool and pay incentive
+   * @param token The token to transfer in
+   * @param pool The pool to transfer to
+   * @param amount Amount to send to the pool
+   */
+  function _transferToPool(address token, address pool, uint256 amount) internal {
+    if (reserve.isStableAsset(token)) {
+      // Mint stable assets directly
+      IERC20MintableBurnable(token).mint(pool, amount);
+    } else if (reserve.isCollateralAsset(token)) {
+      // Transfer collateral from reserve
+      if (!reserve.transferCollateralAsset(token, pool, amount)) revert RLS_COLLATERAL_TO_POOL_FAILED();
+    } else {
+      revert RLS_TOKEN_IN_NOT_SUPPORTED();
     }
+  }
 
-    /// @inheritdoc IReserveLiquidityStrategy
-    function setReserve(address _reserve) external onlyOwner {
-        if (_reserve == address(0)) revert RLS_INVALID_RESERVE();
+  /**
+   * @notice Transfer tokens out from the pool back to reserve
+   * @param token The token to transfer out
+   * @param amount The amount to transfer
+   */
+  function _transferToReserve(address token, uint256 amount) internal {
+    if (amount == 0) return;
 
-        address oldReserve = address(reserve);
-        reserve = IReserveV2(_reserve);
-
-        emit ReserveSet(oldReserve, _reserve);
+    if (reserve.isStableAsset(token)) {
+      // Burn stable assets received from pool
+      IERC20MintableBurnable(token).burn(amount);
+    } else if (reserve.isCollateralAsset(token)) {
+      // Transfer collateral back to reserve
+      IERC20(token).safeTransfer(address(reserve), amount);
+    } else {
+      revert RLS_TOKEN_OUT_NOT_SUPPORTED();
     }
-
-    /* =========================================================== */
-    /* ==================== Virtual Functions ==================== */
-    /* =========================================================== */
-
-    /**
-     * @notice Clamps contraction amounts based on how the collateral side is sourced
-     * @dev If the collateral token is registered as a stable asset, it is minted during contraction
-     *      so the ideal amounts can be used without clamping.
-     *      If it is registered as a collateral asset, the amount is clamped to the Reserve's balance.
-     * @param ctx The liquidity context containing pool state and configuration
-     * @param idealDebtToContract The calculated ideal amount of debt tokens to receive from pool
-     * @param idealCollateralToReceive The calculated ideal amount of collateral to add to pool
-     * @return debtToContract The actual debt amount to contract (may be less than ideal)
-     * @return collateralToReceive The actual collateral amount to send (adjusted if Reserve balance is insufficient)
-     */
-    function _clampContraction(LQ.Context memory ctx, uint256 idealDebtToContract, uint256 idealCollateralToReceive)
-        internal
-        view
-        override
-        returns (uint256 debtToContract, uint256 collateralToReceive)
-    {
-        address collateralToken = ctx.collateralToken();
-
-        if (reserve.isStableAsset(collateralToken)) {
-            // Stable assets are minted, so no reserve balance constraint
-            return (idealDebtToContract, idealCollateralToReceive);
-        } else if (reserve.isCollateralAsset(collateralToken)) {
-            uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(reserve));
-
-            // slither-disable-next-line incorrect-equality
-            if (collateralBalance == 0) revert RLS_RESERVE_OUT_OF_COLLATERAL();
-
-            if (collateralBalance < idealCollateralToReceive) {
-                uint256 combinedFeeMultiplier = LQ.combineFees(
-                    ctx.incentives.protocolIncentiveContraction, ctx.incentives.liquiditySourceIncentiveContraction
-                );
-                collateralToReceive = collateralBalance;
-                debtToContract = ctx.convertToDebtWithFee(collateralBalance, LQ.FEE_DENOMINATOR, combinedFeeMultiplier);
-            } else {
-                collateralToReceive = idealCollateralToReceive;
-                debtToContract = idealDebtToContract;
-            }
-
-            return (debtToContract, collateralToReceive);
-        } else {
-            revert RLS_TOKEN_IN_NOT_SUPPORTED();
-        }
-    }
-
-    /* ============================================================ */
-    /* ================= Callback Implementation ================== */
-    /* ============================================================ */
-
-    /**
-     * @notice Handles the rebalance callback by managing token flows with the Reserve
-     * @dev Determines token flow direction and calls appropriate transfer functions
-     * @param pool The address of the FPMM pool
-     * @param amount0Out The amount of token0 sent by the pool
-     * @param amount1Out The amount of token1 sent by the pool
-     * @param cb The callback data containing rebalance parameters
-     */
-    function _handleCallback(address pool, uint256 amount0Out, uint256 amount1Out, LQ.CallbackData memory cb)
-        internal
-        override
-    {
-        PoolConfig memory config = poolConfigs[pool];
-
-        (
-            address tokenToTransferToReserve,
-            address tokenToTransferToPool,
-            uint256 protocolIncentive,
-            uint256 liquiditySourceIncentive
-        ) = cb.dir == LQ.Direction.Expand
-            ? (cb.collToken, cb.debtToken, config.protocolIncentiveExpansion, config.liquiditySourceIncentiveExpansion)
-            : (
-                cb.debtToken,
-                cb.collToken,
-                config.protocolIncentiveContraction,
-                config.liquiditySourceIncentiveContraction
-            );
-        uint256 amountToTransferToReserve = amount0Out > 0 ? amount0Out : amount1Out;
-        uint256 protocolIncentiveAmount = (amountToTransferToReserve * protocolIncentive) / LQ.FEE_DENOMINATOR;
-        uint256 liquiditySourceIncentiveAmount =
-            ((amountToTransferToReserve - protocolIncentiveAmount) * liquiditySourceIncentive) / LQ.FEE_DENOMINATOR;
-        if (cb.dir == LQ.Direction.Expand) {
-            // Expansion: Pool price > oracle price
-            // Reserve provides debt to pool, receives collateral from pool
-
-            // Transfer protocol incentive to protocol fee recipient
-            _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
-            // Transfer collateral to reserve this includes the liquidity source incentive since reserve is the liquidity source
-            _transferToReserve(tokenToTransferToReserve, amountToTransferToReserve - protocolIncentiveAmount);
-            // mint stable asset to pool
-            _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
-        } else {
-            // Contraction: Pool price < oracle price
-            // Reserve provides collateral to pool, receives debt from pool
-
-            // Transfer protocol incentive to protocol fee recipient
-            _transferRebalanceIncentive(tokenToTransferToReserve, protocolIncentiveAmount, config.protocolFeeRecipient);
-            // Transfer liquidity source incentive in stable asset to reserve
-            _transferRebalanceIncentive(tokenToTransferToReserve, liquiditySourceIncentiveAmount, address(reserve));
-            // burn stable assets from pool
-            _transferToReserve(
-                tokenToTransferToReserve,
-                amountToTransferToReserve - (protocolIncentiveAmount + liquiditySourceIncentiveAmount)
-            );
-            // transfer collateral from reserve to pool
-            _transferToPool(tokenToTransferToPool, pool, cb.amountOwedToPool);
-        }
-    }
-
-    /**
-     * @notice Transfer tokens into the pool and pay incentive
-     * @param token The token to transfer in
-     * @param pool The pool to transfer to
-     * @param amount Amount to send to the pool
-     */
-    function _transferToPool(address token, address pool, uint256 amount) internal {
-        if (reserve.isStableAsset(token)) {
-            // Mint stable assets directly
-            IERC20MintableBurnable(token).mint(pool, amount);
-        } else if (reserve.isCollateralAsset(token)) {
-            // Transfer collateral from reserve
-            if (!reserve.transferCollateralAsset(token, pool, amount)) revert RLS_COLLATERAL_TO_POOL_FAILED();
-        } else {
-            revert RLS_TOKEN_IN_NOT_SUPPORTED();
-        }
-    }
-
-    /**
-     * @notice Transfer tokens out from the pool back to reserve
-     * @param token The token to transfer out
-     * @param amount The amount to transfer
-     */
-    function _transferToReserve(address token, uint256 amount) internal {
-        if (amount == 0) return;
-
-        if (reserve.isStableAsset(token)) {
-            // Burn stable assets received from pool
-            IERC20MintableBurnable(token).burn(amount);
-        } else if (reserve.isCollateralAsset(token)) {
-            // Transfer collateral back to reserve
-            IERC20(token).safeTransfer(address(reserve), amount);
-        } else {
-            revert RLS_TOKEN_OUT_NOT_SUPPORTED();
-        }
-    }
+  }
 }

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_StableStableClamp.t.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_StableStableClamp.t.sol
@@ -3,359 +3,367 @@
 // solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
 pragma solidity ^0.8;
 
-import {ReserveLiquidityStrategy_BaseTest} from "./ReserveLiquidityStrategy_BaseTest.sol";
-import {LiquidityStrategyTypes as LQ} from "contracts/libraries/LiquidityStrategyTypes.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ILiquidityStrategy} from "contracts/interfaces/ILiquidityStrategy.sol";
-import {IReserveLiquidityStrategy} from "contracts/interfaces/IReserveLiquidityStrategy.sol";
-import {MockERC20} from "test/utils/mocks/MockERC20.sol";
+import { ReserveLiquidityStrategy_BaseTest } from "./ReserveLiquidityStrategy_BaseTest.sol";
+import { LiquidityStrategyTypes as LQ } from "contracts/libraries/LiquidityStrategyTypes.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import { ILiquidityStrategy } from "contracts/interfaces/ILiquidityStrategy.sol";
+import { IReserveLiquidityStrategy } from "contracts/interfaces/IReserveLiquidityStrategy.sol";
+import { MockERC20 } from "test/utils/mocks/MockERC20.sol";
 
 contract ReserveLiquidityStrategy_StableStableClampTest is ReserveLiquidityStrategy_BaseTest {
-    function setUp() public override {
-        super.setUp();
-    }
+  function setUp() public override {
+    super.setUp();
+  }
 
-    /* ============================================================ */
-    /* ================ Setup Modifiers ============================ */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ================ Setup Modifiers ============================ */
+  /* ============================================================ */
 
-    /// @notice Register collToken as a stable asset (stable/stable pool)
-    modifier addFpmmStableStable(
-        uint32 cooldown,
-        uint64 liquiditySourceIncentiveExpansion,
-        uint64 protocolIncentiveExpansion,
-        uint64 liquiditySourceIncentiveContraction,
-        uint64 protocolIncentiveContraction
-    ) {
-        uint64 fpmmIncentive = liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
-            >= liquiditySourceIncentiveContraction + protocolIncentiveContraction
-            ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
-            : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
+  /// @notice Register collToken as a stable asset (stable/stable pool)
+  modifier addFpmmStableStable(
+    uint32 cooldown,
+    uint64 liquiditySourceIncentiveExpansion,
+    uint64 protocolIncentiveExpansion,
+    uint64 liquiditySourceIncentiveContraction,
+    uint64 protocolIncentiveContraction
+  ) {
+    uint64 fpmmIncentive = liquiditySourceIncentiveExpansion + protocolIncentiveExpansion >=
+      liquiditySourceIncentiveContraction + protocolIncentiveContraction
+      ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
+      : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
 
-        fpmmIncentive = fpmmIncentive / 1e14;
-        fpmm.setRebalanceIncentive(fpmmIncentive);
+    fpmmIncentive = fpmmIncentive / 1e14;
+    fpmm.setRebalanceIncentive(fpmmIncentive);
 
-        ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
-            address(fpmm),
-            debtToken,
-            cooldown,
-            protocolFeeRecipient,
-            liquiditySourceIncentiveExpansion,
-            protocolIncentiveExpansion,
-            liquiditySourceIncentiveContraction,
-            protocolIncentiveContraction
-        );
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      cooldown,
+      protocolFeeRecipient,
+      liquiditySourceIncentiveExpansion,
+      protocolIncentiveExpansion,
+      liquiditySourceIncentiveContraction,
+      protocolIncentiveContraction
+    );
 
-        vm.startPrank(owner);
-        strategy.addPool(params);
-        // Register both tokens as stable assets
-        reserve.registerStableAsset(debtToken);
-        reserve.registerStableAsset(collToken);
-        vm.stopPrank();
-        _;
-    }
+    vm.startPrank(owner);
+    strategy.addPool(params);
+    // Register both tokens as stable assets
+    reserve.registerStableAsset(debtToken);
+    reserve.registerStableAsset(collToken);
+    vm.stopPrank();
+    _;
+  }
 
-    /// @notice Register collToken as both stable and collateral (dual-registered)
-    modifier addFpmmDualRegistered(
-        uint32 cooldown,
-        uint64 liquiditySourceIncentiveExpansion,
-        uint64 protocolIncentiveExpansion,
-        uint64 liquiditySourceIncentiveContraction,
-        uint64 protocolIncentiveContraction
-    ) {
-        uint64 fpmmIncentive = liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
-            >= liquiditySourceIncentiveContraction + protocolIncentiveContraction
-            ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
-            : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
+  /// @notice Register collToken as both stable and collateral (dual-registered)
+  modifier addFpmmDualRegistered(
+    uint32 cooldown,
+    uint64 liquiditySourceIncentiveExpansion,
+    uint64 protocolIncentiveExpansion,
+    uint64 liquiditySourceIncentiveContraction,
+    uint64 protocolIncentiveContraction
+  ) {
+    uint64 fpmmIncentive = liquiditySourceIncentiveExpansion + protocolIncentiveExpansion >=
+      liquiditySourceIncentiveContraction + protocolIncentiveContraction
+      ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
+      : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
 
-        fpmmIncentive = fpmmIncentive / 1e14;
-        fpmm.setRebalanceIncentive(fpmmIncentive);
+    fpmmIncentive = fpmmIncentive / 1e14;
+    fpmm.setRebalanceIncentive(fpmmIncentive);
 
-        ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
-            address(fpmm),
-            debtToken,
-            cooldown,
-            protocolFeeRecipient,
-            liquiditySourceIncentiveExpansion,
-            protocolIncentiveExpansion,
-            liquiditySourceIncentiveContraction,
-            protocolIncentiveContraction
-        );
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      cooldown,
+      protocolFeeRecipient,
+      liquiditySourceIncentiveExpansion,
+      protocolIncentiveExpansion,
+      liquiditySourceIncentiveContraction,
+      protocolIncentiveContraction
+    );
 
-        vm.startPrank(owner);
-        strategy.addPool(params);
-        reserve.registerStableAsset(debtToken);
-        // Register collToken as BOTH stable and collateral
-        reserve.registerStableAsset(collToken);
-        reserve.registerCollateralAsset(collToken);
-        MockERC20(collToken).mint(address(reserve), 1000000e18);
-        vm.stopPrank();
-        _;
-    }
+    vm.startPrank(owner);
+    strategy.addPool(params);
+    reserve.registerStableAsset(debtToken);
+    // Register collToken as BOTH stable and collateral
+    reserve.registerStableAsset(collToken);
+    reserve.registerCollateralAsset(collToken);
+    MockERC20(collToken).mint(address(reserve), 1000000e18);
+    vm.stopPrank();
+    _;
+  }
 
-    /* ============================================================ */
-    /* ====== Stable/Collateral Contraction (existing behavior) ==== */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ====== Stable/Collateral Contraction (existing behavior) ==== */
+  /* ============================================================ */
 
-    function test_contraction_stableCollateral_shouldClampOnReserveBalance()
-        public
-        fpmmToken0Debt(18, 18)
-        addFpmm(0, 0, 0, 0, 0)
-    {
-        // Existing behavior: collToken is collateral, so contraction clamps on reserve balance
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 300e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0,
-                protocolIncentiveExpansion: 0,
-                liquiditySourceIncentiveContraction: 0,
-                protocolIncentiveContraction: 0
-            })
-        });
+  function test_contraction_stableCollateral_shouldClampOnReserveBalance()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0, 0, 0, 0)
+  {
+    // Existing behavior: collToken is collateral, so contraction clamps on reserve balance
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 300e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
 
-        // Reserve has only 10e18 collateral, much less than the ideal contraction amount
-        vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(10e18));
+    // Reserve has only 10e18 collateral, much less than the ideal contraction amount
+    vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(10e18));
 
-        LQ.Action memory action = strategy.determineAction(ctx);
+    LQ.Action memory action = strategy.determineAction(ctx);
 
-        // Should be clamped to 10e18 collateral
-        assertEq(action.amountOwedToPool, 10e18, "Collateral should be clamped to reserve balance");
-        // Debt out should be recalculated based on clamped collateral
-        assertEq(action.amount0Out, 10e18, "Debt out should match clamped collateral at 1:1 rate");
-    }
+    // Should be clamped to 10e18 collateral
+    assertEq(action.amountOwedToPool, 10e18, "Collateral should be clamped to reserve balance");
+    // Debt out should be recalculated based on clamped collateral
+    assertEq(action.amount0Out, 10e18, "Debt out should match clamped collateral at 1:1 rate");
+  }
 
-    function test_contraction_stableCollateral_shouldRevertWhenZeroBalance()
-        public
-        fpmmToken0Debt(18, 18)
-        addFpmm(0, 0, 0, 0, 0)
-    {
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 300e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0,
-                protocolIncentiveExpansion: 0,
-                liquiditySourceIncentiveContraction: 0,
-                protocolIncentiveContraction: 0
-            })
-        });
+  function test_contraction_stableCollateral_shouldRevertWhenZeroBalance()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmm(0, 0, 0, 0, 0)
+  {
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 300e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
 
-        // Reserve has zero collateral
-        vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(0));
+    // Reserve has zero collateral
+    vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(0));
 
-        vm.expectRevert(IReserveLiquidityStrategy.RLS_RESERVE_OUT_OF_COLLATERAL.selector);
-        strategy.determineAction(ctx);
-    }
+    vm.expectRevert(IReserveLiquidityStrategy.RLS_RESERVE_OUT_OF_COLLATERAL.selector);
+    strategy.determineAction(ctx);
+  }
 
-    /* ============================================================ */
-    /* ====== Stable/Stable Contraction (new behavior) ============ */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ====== Stable/Stable Contraction (new behavior) ============ */
+  /* ============================================================ */
 
-    function test_contraction_stableStable_shouldNotClampOnReserveBalance()
-        public
-        fpmmToken0Debt(18, 18)
-        addFpmmStableStable(0, 0, 0, 0, 0)
-    {
-        // Stable/stable pool: collToken is a stable asset, so minting is unlimited
-        // Even with zero reserve balance, contraction should return ideal amounts
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 300e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0,
-                protocolIncentiveExpansion: 0,
-                liquiditySourceIncentiveContraction: 0,
-                protocolIncentiveContraction: 0
-            })
-        });
+  function test_contraction_stableStable_shouldNotClampOnReserveBalance()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmStableStable(0, 0, 0, 0, 0)
+  {
+    // Stable/stable pool: collToken is a stable asset, so minting is unlimited
+    // Even with zero reserve balance, contraction should return ideal amounts
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 300e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
 
-        // No reserve balance mocking needed - stable tokens are minted, not transferred
+    // No reserve balance mocking needed - stable tokens are minted, not transferred
 
-        LQ.Action memory action = strategy.determineAction(ctx);
+    LQ.Action memory action = strategy.determineAction(ctx);
 
-        // Formula: Y = (TN*RD - TD*RN) / (TN + TD * (1 - i) * ON/OD)
-        // TN = 0.95e18, TD = 1e18, RD = 300e18, RN = 100e18, ON/OD = 1, i = 0
-        // Y = (0.95e18 * 300e18 - 1e18 * 100e18) / (0.95e18 + 1e18 * 1 * 1)
-        // Y = (285e36 - 100e36) / (0.95e18 + 1e18) = 185e36 / 1.95e18 = 94871794871794871794
-        uint256 expectedDebtOut = 94871794871794871794;
-        uint256 expectedCollIn = 94871794871794871794; // same as debt at 1:1 rate with 0 fees
+    // Formula: Y = (TN*RD - TD*RN) / (TN + TD * (1 - i) * ON/OD)
+    // TN = 0.95e18, TD = 1e18, RD = 300e18, RN = 100e18, ON/OD = 1, i = 0
+    // Y = (0.95e18 * 300e18 - 1e18 * 100e18) / (0.95e18 + 1e18 * 1 * 1)
+    // Y = (285e36 - 100e36) / (0.95e18 + 1e18) = 185e36 / 1.95e18 = 94871794871794871794
+    uint256 expectedDebtOut = 94871794871794871794;
+    uint256 expectedCollIn = 94871794871794871794; // same as debt at 1:1 rate with 0 fees
 
-        assertEq(action.amount0Out, expectedDebtOut, "Debt out should be ideal (unclamped)");
-        assertEq(action.amountOwedToPool, expectedCollIn, "Collateral in should be ideal (unclamped)");
-    }
+    assertEq(action.amount0Out, expectedDebtOut, "Debt out should be ideal (unclamped)");
+    assertEq(action.amountOwedToPool, expectedCollIn, "Collateral in should be ideal (unclamped)");
+  }
 
-    function test_contraction_stableStable_withIncentive_shouldNotClamp()
-        public
-        fpmmToken0Debt(18, 18)
-        addFpmmStableStable(0, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
-    {
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 300e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0.005e18,
-                protocolIncentiveExpansion: 0.005025125628140703e18,
-                liquiditySourceIncentiveContraction: 0.005e18,
-                protocolIncentiveContraction: 0.005025125628140703e18
-            })
-        });
+  function test_contraction_stableStable_withIncentive_shouldNotClamp()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmStableStable(0, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+  {
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 300e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0.005e18,
+        protocolIncentiveExpansion: 0.005025125628140703e18,
+        liquiditySourceIncentiveContraction: 0.005e18,
+        protocolIncentiveContraction: 0.005025125628140703e18
+      })
+    });
 
-        LQ.Action memory action = strategy.determineAction(ctx);
+    LQ.Action memory action = strategy.determineAction(ctx);
 
-        // With ~1% total contraction incentive and no clamping, ideal amounts should be returned
-        assertGt(action.amount0Out, 0, "Should have debt out");
-        assertGt(action.amountOwedToPool, 0, "Should have collateral in");
+    // With ~1% total contraction incentive and no clamping, ideal amounts should be returned
+    assertGt(action.amount0Out, 0, "Should have debt out");
+    assertGt(action.amountOwedToPool, 0, "Should have collateral in");
 
-        // Verify that the amounts are NOT clamped - they should be larger than any small reserve balance
-        // would allow. The ideal collateral-in should be close to ~94e18 (unclamped)
-        assertGt(action.amountOwedToPool, 50e18, "Collateral in should not be clamped to a small balance");
-    }
+    // Verify that the amounts are NOT clamped - they should be larger than any small reserve balance
+    // would allow. The ideal collateral-in should be close to ~94e18 (unclamped)
+    assertGt(action.amountOwedToPool, 50e18, "Collateral in should not be clamped to a small balance");
+  }
 
-    function test_contraction_stableStable_shouldReturnSameAsUnclampedFormula()
-        public
-        fpmmToken0Debt(18, 18)
-        addFpmmStableStable(0, 0, 0, 0, 0)
-    {
-        // Compare stable/stable contraction with the ideal formula
-        // Since there's no clamping, the amounts should match what you'd get
-        // from the base LiquidityStrategy (no override)
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 200e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0,
-                protocolIncentiveExpansion: 0,
-                liquiditySourceIncentiveContraction: 0,
-                protocolIncentiveContraction: 0
-            })
-        });
+  function test_contraction_stableStable_shouldReturnSameAsUnclampedFormula()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmStableStable(0, 0, 0, 0, 0)
+  {
+    // Compare stable/stable contraction with the ideal formula
+    // Since there's no clamping, the amounts should match what you'd get
+    // from the base LiquidityStrategy (no override)
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 200e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
 
-        LQ.Action memory action = strategy.determineAction(ctx);
+    LQ.Action memory action = strategy.determineAction(ctx);
 
-        // Formula: Y = (TN*RD - TD*RN) / (TN + TD * (1 - i) * ON/OD)
-        // TN = 0.95e18, TD = 1e18, RD = 200e18, RN = 100e18, ON/OD = 1, i = 0
-        // Y = (0.95e18 * 200e18 - 1e18 * 100e18) / (0.95e18 + 1e18)
-        // Y = (190e36 - 100e36) / 1.95e18 = 90e36 / 1.95e18 = 46153846153846153846
-        assertEq(action.amount0Out, 46153846153846153846, "Debt out should match formula exactly");
-        assertEq(action.amountOwedToPool, 46153846153846153846, "Collateral in should match formula exactly");
-    }
+    // Formula: Y = (TN*RD - TD*RN) / (TN + TD * (1 - i) * ON/OD)
+    // TN = 0.95e18, TD = 1e18, RD = 200e18, RN = 100e18, ON/OD = 1, i = 0
+    // Y = (0.95e18 * 200e18 - 1e18 * 100e18) / (0.95e18 + 1e18)
+    // Y = (190e36 - 100e36) / 1.95e18 = 90e36 / 1.95e18 = 46153846153846153846
+    assertEq(action.amount0Out, 46153846153846153846, "Debt out should match formula exactly");
+    assertEq(action.amountOwedToPool, 46153846153846153846, "Collateral in should match formula exactly");
+  }
 
-    /* ============================================================ */
-    /* ====== Dual-Registered Token (stable + collateral) ========= */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ====== Dual-Registered Token (stable + collateral) ========= */
+  /* ============================================================ */
 
-    function test_contraction_dualRegistered_shouldFollowStableFirstSemantics()
-        public
-        fpmmToken0Debt(18, 18)
-        addFpmmDualRegistered(0, 0, 0, 0, 0)
-    {
-        // collToken is registered as both stable and collateral.
-        // _clampContraction checks isStableAsset first, so it should NOT clamp.
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 300e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0,
-                protocolIncentiveExpansion: 0,
-                liquiditySourceIncentiveContraction: 0,
-                protocolIncentiveContraction: 0
-            })
-        });
+  function test_contraction_dualRegistered_shouldFollowStableFirstSemantics()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmDualRegistered(0, 0, 0, 0, 0)
+  {
+    // collToken is registered as both stable and collateral.
+    // _clampContraction checks isStableAsset first, so it should NOT clamp.
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 300e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
 
-        // collToken is also registered as collateral, but the stable-first check means
-        // we should still get the ideal (unclamped) amounts.
-        LQ.Action memory action = strategy.determineAction(ctx);
+    // collToken is also registered as collateral, but the stable-first check means
+    // we should still get the ideal (unclamped) amounts.
+    LQ.Action memory action = strategy.determineAction(ctx);
 
-        // Same expected values as the stable/stable test above
-        uint256 expectedDebtOut = 94871794871794871794;
-        uint256 expectedCollIn = 94871794871794871794;
+    // Same expected values as the stable/stable test above
+    uint256 expectedDebtOut = 94871794871794871794;
+    uint256 expectedCollIn = 94871794871794871794;
 
-        assertEq(action.amount0Out, expectedDebtOut, "Dual-registered should follow stable-first semantics");
-        assertEq(action.amountOwedToPool, expectedCollIn, "Dual-registered should not clamp on reserve balance");
-    }
+    assertEq(action.amount0Out, expectedDebtOut, "Dual-registered should follow stable-first semantics");
+    assertEq(action.amountOwedToPool, expectedCollIn, "Dual-registered should not clamp on reserve balance");
+  }
 
-    function test_contraction_dualRegistered_withLowReserveBalance_shouldStillNotClamp()
-        public
-        fpmmToken0Debt(18, 18)
-        addFpmmDualRegistered(0, 0, 0, 0, 0)
-    {
-        // Explicitly verify that even with a very low reserve balance,
-        // dual-registered (stable+collateral) uses stable semantics (no clamp)
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 200e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0,
-                protocolIncentiveExpansion: 0,
-                liquiditySourceIncentiveContraction: 0,
-                protocolIncentiveContraction: 0
-            })
-        });
+  function test_contraction_dualRegistered_withLowReserveBalance_shouldStillNotClamp()
+    public
+    fpmmToken0Debt(18, 18)
+    addFpmmDualRegistered(0, 0, 0, 0, 0)
+  {
+    // Explicitly verify that even with a very low reserve balance,
+    // dual-registered (stable+collateral) uses stable semantics (no clamp)
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 200e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
 
-        // Mock a tiny reserve balance - if collateral semantics were used, this would clamp
-        vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(1e18));
+    // Mock a tiny reserve balance - if collateral semantics were used, this would clamp
+    vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(1e18));
 
-        LQ.Action memory action = strategy.determineAction(ctx);
+    LQ.Action memory action = strategy.determineAction(ctx);
 
-        // Should be unclamped (stable-first)
-        assertEq(action.amount0Out, 46153846153846153846, "Should not clamp despite low reserve balance");
-        assertEq(action.amountOwedToPool, 46153846153846153846, "Collateral in should be ideal");
-    }
+    // Should be unclamped (stable-first)
+    assertEq(action.amount0Out, 46153846153846153846, "Should not clamp despite low reserve balance");
+    assertEq(action.amountOwedToPool, 46153846153846153846, "Collateral in should be ideal");
+  }
 
-    /* ============================================================ */
-    /* ====== Unregistered collToken should revert ================= */
-    /* ============================================================ */
+  /* ============================================================ */
+  /* ====== Unregistered collToken should revert ================= */
+  /* ============================================================ */
 
-    function test_contraction_unregisteredCollToken_shouldRevert() public fpmmToken0Debt(18, 18) {
-        // Register pool but do NOT register collToken as either stable or collateral
-        fpmm.setRebalanceIncentive(0);
+  function test_contraction_unregisteredCollToken_shouldRevert() public fpmmToken0Debt(18, 18) {
+    // Register pool but do NOT register collToken as either stable or collateral
+    fpmm.setRebalanceIncentive(0);
 
-        ILiquidityStrategy.AddPoolParams memory params =
-            _buildAddPoolParams(address(fpmm), debtToken, 0, protocolFeeRecipient, 0, 0, 0, 0);
+    ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+      address(fpmm),
+      debtToken,
+      0,
+      protocolFeeRecipient,
+      0,
+      0,
+      0,
+      0
+    );
 
-        vm.startPrank(owner);
-        strategy.addPool(params);
-        reserve.registerStableAsset(debtToken);
-        // collToken is NOT registered
-        vm.stopPrank();
+    vm.startPrank(owner);
+    strategy.addPool(params);
+    reserve.registerStableAsset(debtToken);
+    // collToken is NOT registered
+    vm.stopPrank();
 
-        LQ.Context memory ctx = _createContext({
-            reserveDen: 200e18,
-            reserveNum: 100e18,
-            oracleNum: 1e18,
-            oracleDen: 1e18,
-            poolPriceAbove: false,
-            incentives: LQ.RebalanceIncentives({
-                liquiditySourceIncentiveExpansion: 0,
-                protocolIncentiveExpansion: 0,
-                liquiditySourceIncentiveContraction: 0,
-                protocolIncentiveContraction: 0
-            })
-        });
+    LQ.Context memory ctx = _createContext({
+      reserveDen: 200e18,
+      reserveNum: 100e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
 
-        vm.expectRevert(IReserveLiquidityStrategy.RLS_TOKEN_IN_NOT_SUPPORTED.selector);
-        strategy.determineAction(ctx);
-    }
+    vm.expectRevert(IReserveLiquidityStrategy.RLS_TOKEN_IN_NOT_SUPPORTED.selector);
+    strategy.determineAction(ctx);
+  }
 }

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_StableStableClamp.t.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_StableStableClamp.t.sol
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility, max-line-length
+// solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
+pragma solidity ^0.8;
+
+import {ReserveLiquidityStrategy_BaseTest} from "./ReserveLiquidityStrategy_BaseTest.sol";
+import {LiquidityStrategyTypes as LQ} from "contracts/libraries/LiquidityStrategyTypes.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {ILiquidityStrategy} from "contracts/interfaces/ILiquidityStrategy.sol";
+import {IReserveLiquidityStrategy} from "contracts/interfaces/IReserveLiquidityStrategy.sol";
+import {MockERC20} from "test/utils/mocks/MockERC20.sol";
+
+contract ReserveLiquidityStrategy_StableStableClampTest is ReserveLiquidityStrategy_BaseTest {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /* ============================================================ */
+    /* ================ Setup Modifiers ============================ */
+    /* ============================================================ */
+
+    /// @notice Register collToken as a stable asset (stable/stable pool)
+    modifier addFpmmStableStable(
+        uint32 cooldown,
+        uint64 liquiditySourceIncentiveExpansion,
+        uint64 protocolIncentiveExpansion,
+        uint64 liquiditySourceIncentiveContraction,
+        uint64 protocolIncentiveContraction
+    ) {
+        uint64 fpmmIncentive = liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
+            >= liquiditySourceIncentiveContraction + protocolIncentiveContraction
+            ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
+            : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
+
+        fpmmIncentive = fpmmIncentive / 1e14;
+        fpmm.setRebalanceIncentive(fpmmIncentive);
+
+        ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+            address(fpmm),
+            debtToken,
+            cooldown,
+            protocolFeeRecipient,
+            liquiditySourceIncentiveExpansion,
+            protocolIncentiveExpansion,
+            liquiditySourceIncentiveContraction,
+            protocolIncentiveContraction
+        );
+
+        vm.startPrank(owner);
+        strategy.addPool(params);
+        // Register both tokens as stable assets
+        reserve.registerStableAsset(debtToken);
+        reserve.registerStableAsset(collToken);
+        vm.stopPrank();
+        _;
+    }
+
+    /// @notice Register collToken as both stable and collateral (dual-registered)
+    modifier addFpmmDualRegistered(
+        uint32 cooldown,
+        uint64 liquiditySourceIncentiveExpansion,
+        uint64 protocolIncentiveExpansion,
+        uint64 liquiditySourceIncentiveContraction,
+        uint64 protocolIncentiveContraction
+    ) {
+        uint64 fpmmIncentive = liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
+            >= liquiditySourceIncentiveContraction + protocolIncentiveContraction
+            ? liquiditySourceIncentiveExpansion + protocolIncentiveExpansion
+            : liquiditySourceIncentiveContraction + protocolIncentiveContraction;
+
+        fpmmIncentive = fpmmIncentive / 1e14;
+        fpmm.setRebalanceIncentive(fpmmIncentive);
+
+        ILiquidityStrategy.AddPoolParams memory params = _buildAddPoolParams(
+            address(fpmm),
+            debtToken,
+            cooldown,
+            protocolFeeRecipient,
+            liquiditySourceIncentiveExpansion,
+            protocolIncentiveExpansion,
+            liquiditySourceIncentiveContraction,
+            protocolIncentiveContraction
+        );
+
+        vm.startPrank(owner);
+        strategy.addPool(params);
+        reserve.registerStableAsset(debtToken);
+        // Register collToken as BOTH stable and collateral
+        reserve.registerStableAsset(collToken);
+        reserve.registerCollateralAsset(collToken);
+        MockERC20(collToken).mint(address(reserve), 1000000e18);
+        vm.stopPrank();
+        _;
+    }
+
+    /* ============================================================ */
+    /* ====== Stable/Collateral Contraction (existing behavior) ==== */
+    /* ============================================================ */
+
+    function test_contraction_stableCollateral_shouldClampOnReserveBalance()
+        public
+        fpmmToken0Debt(18, 18)
+        addFpmm(0, 0, 0, 0, 0)
+    {
+        // Existing behavior: collToken is collateral, so contraction clamps on reserve balance
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 300e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0,
+                protocolIncentiveExpansion: 0,
+                liquiditySourceIncentiveContraction: 0,
+                protocolIncentiveContraction: 0
+            })
+        });
+
+        // Reserve has only 10e18 collateral, much less than the ideal contraction amount
+        vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(10e18));
+
+        LQ.Action memory action = strategy.determineAction(ctx);
+
+        // Should be clamped to 10e18 collateral
+        assertEq(action.amountOwedToPool, 10e18, "Collateral should be clamped to reserve balance");
+        // Debt out should be recalculated based on clamped collateral
+        assertEq(action.amount0Out, 10e18, "Debt out should match clamped collateral at 1:1 rate");
+    }
+
+    function test_contraction_stableCollateral_shouldRevertWhenZeroBalance()
+        public
+        fpmmToken0Debt(18, 18)
+        addFpmm(0, 0, 0, 0, 0)
+    {
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 300e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0,
+                protocolIncentiveExpansion: 0,
+                liquiditySourceIncentiveContraction: 0,
+                protocolIncentiveContraction: 0
+            })
+        });
+
+        // Reserve has zero collateral
+        vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(0));
+
+        vm.expectRevert(IReserveLiquidityStrategy.RLS_RESERVE_OUT_OF_COLLATERAL.selector);
+        strategy.determineAction(ctx);
+    }
+
+    /* ============================================================ */
+    /* ====== Stable/Stable Contraction (new behavior) ============ */
+    /* ============================================================ */
+
+    function test_contraction_stableStable_shouldNotClampOnReserveBalance()
+        public
+        fpmmToken0Debt(18, 18)
+        addFpmmStableStable(0, 0, 0, 0, 0)
+    {
+        // Stable/stable pool: collToken is a stable asset, so minting is unlimited
+        // Even with zero reserve balance, contraction should return ideal amounts
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 300e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0,
+                protocolIncentiveExpansion: 0,
+                liquiditySourceIncentiveContraction: 0,
+                protocolIncentiveContraction: 0
+            })
+        });
+
+        // No reserve balance mocking needed - stable tokens are minted, not transferred
+
+        LQ.Action memory action = strategy.determineAction(ctx);
+
+        // Formula: Y = (TN*RD - TD*RN) / (TN + TD * (1 - i) * ON/OD)
+        // TN = 0.95e18, TD = 1e18, RD = 300e18, RN = 100e18, ON/OD = 1, i = 0
+        // Y = (0.95e18 * 300e18 - 1e18 * 100e18) / (0.95e18 + 1e18 * 1 * 1)
+        // Y = (285e36 - 100e36) / (0.95e18 + 1e18) = 185e36 / 1.95e18 = 94871794871794871794
+        uint256 expectedDebtOut = 94871794871794871794;
+        uint256 expectedCollIn = 94871794871794871794; // same as debt at 1:1 rate with 0 fees
+
+        assertEq(action.amount0Out, expectedDebtOut, "Debt out should be ideal (unclamped)");
+        assertEq(action.amountOwedToPool, expectedCollIn, "Collateral in should be ideal (unclamped)");
+    }
+
+    function test_contraction_stableStable_withIncentive_shouldNotClamp()
+        public
+        fpmmToken0Debt(18, 18)
+        addFpmmStableStable(0, 0.005e18, 0.005025125628140703e18, 0.005e18, 0.005025125628140703e18)
+    {
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 300e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0.005e18,
+                protocolIncentiveExpansion: 0.005025125628140703e18,
+                liquiditySourceIncentiveContraction: 0.005e18,
+                protocolIncentiveContraction: 0.005025125628140703e18
+            })
+        });
+
+        LQ.Action memory action = strategy.determineAction(ctx);
+
+        // With ~1% total contraction incentive and no clamping, ideal amounts should be returned
+        assertGt(action.amount0Out, 0, "Should have debt out");
+        assertGt(action.amountOwedToPool, 0, "Should have collateral in");
+
+        // Verify that the amounts are NOT clamped - they should be larger than any small reserve balance
+        // would allow. The ideal collateral-in should be close to ~94e18 (unclamped)
+        assertGt(action.amountOwedToPool, 50e18, "Collateral in should not be clamped to a small balance");
+    }
+
+    function test_contraction_stableStable_shouldReturnSameAsUnclampedFormula()
+        public
+        fpmmToken0Debt(18, 18)
+        addFpmmStableStable(0, 0, 0, 0, 0)
+    {
+        // Compare stable/stable contraction with the ideal formula
+        // Since there's no clamping, the amounts should match what you'd get
+        // from the base LiquidityStrategy (no override)
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 200e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0,
+                protocolIncentiveExpansion: 0,
+                liquiditySourceIncentiveContraction: 0,
+                protocolIncentiveContraction: 0
+            })
+        });
+
+        LQ.Action memory action = strategy.determineAction(ctx);
+
+        // Formula: Y = (TN*RD - TD*RN) / (TN + TD * (1 - i) * ON/OD)
+        // TN = 0.95e18, TD = 1e18, RD = 200e18, RN = 100e18, ON/OD = 1, i = 0
+        // Y = (0.95e18 * 200e18 - 1e18 * 100e18) / (0.95e18 + 1e18)
+        // Y = (190e36 - 100e36) / 1.95e18 = 90e36 / 1.95e18 = 46153846153846153846
+        assertEq(action.amount0Out, 46153846153846153846, "Debt out should match formula exactly");
+        assertEq(action.amountOwedToPool, 46153846153846153846, "Collateral in should match formula exactly");
+    }
+
+    /* ============================================================ */
+    /* ====== Dual-Registered Token (stable + collateral) ========= */
+    /* ============================================================ */
+
+    function test_contraction_dualRegistered_shouldFollowStableFirstSemantics()
+        public
+        fpmmToken0Debt(18, 18)
+        addFpmmDualRegistered(0, 0, 0, 0, 0)
+    {
+        // collToken is registered as both stable and collateral.
+        // _clampContraction checks isStableAsset first, so it should NOT clamp.
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 300e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0,
+                protocolIncentiveExpansion: 0,
+                liquiditySourceIncentiveContraction: 0,
+                protocolIncentiveContraction: 0
+            })
+        });
+
+        // collToken is also registered as collateral, but the stable-first check means
+        // we should still get the ideal (unclamped) amounts.
+        LQ.Action memory action = strategy.determineAction(ctx);
+
+        // Same expected values as the stable/stable test above
+        uint256 expectedDebtOut = 94871794871794871794;
+        uint256 expectedCollIn = 94871794871794871794;
+
+        assertEq(action.amount0Out, expectedDebtOut, "Dual-registered should follow stable-first semantics");
+        assertEq(action.amountOwedToPool, expectedCollIn, "Dual-registered should not clamp on reserve balance");
+    }
+
+    function test_contraction_dualRegistered_withLowReserveBalance_shouldStillNotClamp()
+        public
+        fpmmToken0Debt(18, 18)
+        addFpmmDualRegistered(0, 0, 0, 0, 0)
+    {
+        // Explicitly verify that even with a very low reserve balance,
+        // dual-registered (stable+collateral) uses stable semantics (no clamp)
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 200e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0,
+                protocolIncentiveExpansion: 0,
+                liquiditySourceIncentiveContraction: 0,
+                protocolIncentiveContraction: 0
+            })
+        });
+
+        // Mock a tiny reserve balance - if collateral semantics were used, this would clamp
+        vm.mockCall(collToken, abi.encodeWithSelector(IERC20.balanceOf.selector, address(reserve)), abi.encode(1e18));
+
+        LQ.Action memory action = strategy.determineAction(ctx);
+
+        // Should be unclamped (stable-first)
+        assertEq(action.amount0Out, 46153846153846153846, "Should not clamp despite low reserve balance");
+        assertEq(action.amountOwedToPool, 46153846153846153846, "Collateral in should be ideal");
+    }
+
+    /* ============================================================ */
+    /* ====== Unregistered collToken should revert ================= */
+    /* ============================================================ */
+
+    function test_contraction_unregisteredCollToken_shouldRevert() public fpmmToken0Debt(18, 18) {
+        // Register pool but do NOT register collToken as either stable or collateral
+        fpmm.setRebalanceIncentive(0);
+
+        ILiquidityStrategy.AddPoolParams memory params =
+            _buildAddPoolParams(address(fpmm), debtToken, 0, protocolFeeRecipient, 0, 0, 0, 0);
+
+        vm.startPrank(owner);
+        strategy.addPool(params);
+        reserve.registerStableAsset(debtToken);
+        // collToken is NOT registered
+        vm.stopPrank();
+
+        LQ.Context memory ctx = _createContext({
+            reserveDen: 200e18,
+            reserveNum: 100e18,
+            oracleNum: 1e18,
+            oracleDen: 1e18,
+            poolPriceAbove: false,
+            incentives: LQ.RebalanceIncentives({
+                liquiditySourceIncentiveExpansion: 0,
+                protocolIncentiveExpansion: 0,
+                liquiditySourceIncentiveContraction: 0,
+                protocolIncentiveContraction: 0
+            })
+        });
+
+        vm.expectRevert(IReserveLiquidityStrategy.RLS_TOKEN_IN_NOT_SUPPORTED.selector);
+        strategy.determineAction(ctx);
+    }
+}

--- a/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_StableStableClamp.t.sol
+++ b/test/unit/liquidityStrategies/ReserveLiquidityStrategy/ReserveLiquidityStrategy_StableStableClamp.t.sol
@@ -256,6 +256,41 @@ contract ReserveLiquidityStrategy_StableStableClampTest is ReserveLiquidityStrat
     assertEq(action.amountOwedToPool, 46153846153846153846, "Collateral in should match formula exactly");
   }
 
+  function test_contraction_stableStable_whenToken1IsDebt_shouldNotClamp()
+    public
+    fpmmToken1Debt(18, 18)
+    addFpmmStableStable(0, 0, 0, 0, 0)
+  {
+    // Reversed token order: token1 is debt and token0 is collateral.
+    LQ.Context memory ctx = _createContextWithTokenOrder({
+      reserveDen: 100e18,
+      reserveNum: 300e18,
+      oracleNum: 1e18,
+      oracleDen: 1e18,
+      poolPriceAbove: true,
+      isToken0Debt: false,
+      incentives: LQ.RebalanceIncentives({
+        liquiditySourceIncentiveExpansion: 0,
+        protocolIncentiveExpansion: 0,
+        liquiditySourceIncentiveContraction: 0,
+        protocolIncentiveContraction: 0
+      })
+    });
+
+    LQ.Action memory action = strategy.determineAction(ctx);
+
+    // Formula: Y = (TD*RN - TN*RD) / (TN * (1 - i) * OD/ON + TD)
+    // TN = 1.05e18, TD = 1e18, RN = 300e18, RD = 100e18, OD/ON = 1, i = 0
+    // Y = (1e18 * 300e18 - 1.05e18 * 100e18) / (1.05e18 + 1e18)
+    // Y = (300e36 - 105e36) / 2.05e18 = 195e36 / 2.05e18 = 95121951219512195121
+    uint256 expectedDebtOut = 95121951219512195121;
+
+    assertEq(action.dir, LQ.Direction.Contract, "Should contract when token1 debt is in excess");
+    assertEq(action.amount0Out, 0, "No collateral should flow out during contraction");
+    assertEq(action.amount1Out, expectedDebtOut, "Debt out should be ideal (unclamped)");
+    assertEq(action.amountOwedToPool, expectedDebtOut, "Collateral in should be ideal (unclamped)");
+  }
+
   /* ============================================================ */
   /* ====== Dual-Registered Token (stable + collateral) ========= */
   /* ============================================================ */


### PR DESCRIPTION
Summary:
ReserveLiquidityStrategy currently clamps contraction against ReserveV2 inventory even when the token sent to the pool is configured as a stable asset and will be minted. That makes stable/stable pools behave incorrectly and diverges from the actual transfer path.

This PR makes _clampContraction follow the same stable-first semantics as _transferToPool:
- stable assets return the ideal contraction amounts without reserve-balance clamping
- collateral assets keep the existing reserve-backed clamp
- unsupported assets still revert

Tests:
- stable/collateral still clamps as before
- stable/stable no longer clamps on reserve inventory
- dual stable+collateral registration follows stable-first semantics
