### PR TITLE
docs: point agents to master context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Mento Core Instructions
+
+For any protocol-level question that crosses beyond this contracts repo, first
+read the private `mento-master-context` router when the checkout is available:
+
+```text
+../mento-master-context/.agents/mento-context/README.md
+```
+
+This applies before broad repo searches for deployments, addresses, ABIs, live
+on-chain state, stable supply, reserve data, monitoring/data semantics, docs,
+the whitepaper, business model, or legal/risk framing. Load only the relevant
+master-context card(s), then return to this repo for contract implementation
+details.
+
+This repo is source of truth for Mento core contract behavior, not for published
+deployment addresses or current chain state. Resolve deployed addresses and
+generated ABIs through `deployments-v2`; verify current values with live RPC at
+an explicit block. When answering, mention which master-context card you used or
+state that the checkout was unavailable.


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md pointer to the private mento-master-context router.
- Keep this repo as source of truth for local implementation details while routing cross-protocol questions to the compact context index first.

## Validation
- git diff --check
- local autoreview helper: no deterministic findings
- commit/push hooks ran where configured

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, contract, or deployment impact.
> 
> **Overview**
> Adds a root **`AGENTS.md`** so automated agents know how to handle Mento questions that span more than this contracts repo.
> 
> Agents are told to consult the private **`mento-master-context`** router first (when that checkout exists) for deployments, addresses, ABIs, live chain state, reserves, monitoring semantics, docs, whitepaper, and legal/risk framing—before doing wide searches here. They should load only the relevant context cards, then come back to this repo for **contract implementation** detail.
> 
> The doc also clarifies boundaries: this repo is authoritative for **core contract behavior**, while deployed addresses and ABIs come from **`deployments-v2`**, and current on-chain values require **live RPC** at an explicit block. Answers should cite which master-context card was used or note that the checkout was unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a084048c8a6eae87a96be526f2ba2a66c60280bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->